### PR TITLE
Add a constant for the ASM API version we use

### DIFF
--- a/src/main/java/io/quarkus/gizmo/ClassCreator.java
+++ b/src/main/java/io/quarkus/gizmo/ClassCreator.java
@@ -147,7 +147,7 @@ public class ClassCreator implements AutoCloseable, AnnotatedElement, SignatureE
     public void writeTo(ClassOutput classOutput) {
         Objects.requireNonNull(classOutput);
         ClassWriter file = new ClassWriter(ClassWriter.COMPUTE_FRAMES | ClassWriter.COMPUTE_MAXS);
-        final GizmoClassVisitor cv = new GizmoClassVisitor(Opcodes.ASM7, file, classOutput.getSourceWriter(className));
+        final GizmoClassVisitor cv = new GizmoClassVisitor(Gizmo.ASM_API_VERSION, file, classOutput.getSourceWriter(className));
         String[] interfaces = this.interfaces.clone();
         cv.visit(Opcodes.V1_8, ACC_PUBLIC | ACC_SUPER | ACC_SYNTHETIC | extraAccess, className, signature, superClass, interfaces);
         cv.visitSource(null, null);

--- a/src/main/java/io/quarkus/gizmo/Gizmo.java
+++ b/src/main/java/io/quarkus/gizmo/Gizmo.java
@@ -1,0 +1,11 @@
+package io.quarkus.gizmo;
+
+import org.objectweb.asm.Opcodes;
+
+public final class Gizmo {
+
+    public static final int ASM_API_VERSION = Opcodes.ASM7;
+
+    private Gizmo() {
+    }
+}


### PR DESCRIPTION
It is used everywhere in Quarkus and it would be better to only update
it once for Gizmo when we upgrade ASM and have Quarkus align on it.

@stuartwdouglas WDYT of that small addition? I had to check all Quarkus was using ASM7 the other day and it wasn't much fun. We also have to update it in Hibernate ORM but at least having all the Gizmo consumers aligned on this would be great.