### PR TITLE
Ignore Dependabot pushes as the pr event already test things

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,6 +1,10 @@
 name: Gizmo CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches-ignore:
+      - 'dependabot/**'
+  pull_request:
 
 jobs:
   build:


### PR DESCRIPTION
Dependabot PRs trigger 2 runs: one for the push to the branch as they
push to the main repo and one for the PR. Trying to get that down to 1
run.