### PR TITLE
Add a while-loop-statement-like abstraction

### DIFF
--- a/src/main/java/io/quarkus/gizmo/BytecodeCreator.java
+++ b/src/main/java/io/quarkus/gizmo/BytecodeCreator.java
@@ -17,6 +17,7 @@
 package io.quarkus.gizmo;
 
 import java.util.Objects;
+import java.util.function.Function;
 
 import org.jboss.jandex.FieldInfo;
 import org.jboss.jandex.MethodInfo;
@@ -692,12 +693,21 @@ public interface BytecodeCreator extends AutoCloseable {
     }
 
     /**
-     * Create a nested scope.  Bytecode added to the nested scope will be inserted at this point of the
+     * Create a nested scope. Bytecode added to the nested scope will be inserted at this point of the
      * enclosing scope.
      *
      * @return the nested scope
      */
     BytecodeCreator createScope();
+    
+    /**
+     * Create a new while loop statement.
+     * 
+     * @param conditionFun A function used to create the condition. The true branch continues executing the block and the false
+     *        branch terminates the statement.
+     * @return the while loop statement
+     */
+    WhileLoop whileLoop(Function<BytecodeCreator, BranchResult> conditionFun);
 
     /**
      * Indicate that the scope is no longer in use.  The scope may refuse additional instructions after this method
@@ -705,5 +715,5 @@ public interface BytecodeCreator extends AutoCloseable {
      */
     @Override
     default void close() {}
-
+    
 }

--- a/src/main/java/io/quarkus/gizmo/BytecodeCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo/BytecodeCreatorImpl.java
@@ -30,6 +30,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
 
 import org.objectweb.asm.Label;
 import org.objectweb.asm.MethodVisitor;
@@ -1043,6 +1044,14 @@ class BytecodeCreatorImpl implements BytecodeCreator {
                 return null;
             }
         });
+    }
+    
+    @Override
+    public WhileLoop whileLoop(Function<BytecodeCreator, BranchResult> conditionFun) {
+        Objects.requireNonNull(conditionFun);
+        WhileLoopImpl loop = new WhileLoopImpl(this, conditionFun);
+        operations.add(new BlockOperation(loop));
+        return loop;
     }
 
     private ResultHandle allocateResult(String returnType) {

--- a/src/main/java/io/quarkus/gizmo/WhileLoop.java
+++ b/src/main/java/io/quarkus/gizmo/WhileLoop.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2020 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.quarkus.gizmo;
+
+/**
+ * A while loop statement.
+ */
+public interface WhileLoop {
+
+    /**
+     * The block is executed until the condition evaluates to false.
+     * 
+     * @return the while block
+     */
+    BytecodeCreator block();
+
+    /**
+     * The scope returned from this method should be used to continue/break the while statement.
+     * 
+     * <pre>
+     * WhileLoop loop = method.whileLoop(bc -> bc.ifTrue(condition));
+     * BytecodeCreator block = loop.block();
+     * // If counter > 5 we break the loop even if the condition is still true 
+     * block.ifIntegerGreaterThan(counter, block.load(5)).trueBranch().breakScope(loop.scope());
+     * </pre>
+     * 
+     * @return the scope that could be used to skip the current iteration or terminate the statement
+     * @see BytecodeCreator#continueScope(BytecodeCreator)
+     * @see BytecodeCreator#breakScope(BytecodeCreator)
+     */
+    BytecodeCreator scope();
+}

--- a/src/main/java/io/quarkus/gizmo/WhileLoopImpl.java
+++ b/src/main/java/io/quarkus/gizmo/WhileLoopImpl.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2020 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.quarkus.gizmo;
+
+import java.util.function.Function;
+
+import org.objectweb.asm.MethodVisitor;
+
+class WhileLoopImpl extends BytecodeCreatorImpl implements WhileLoop {
+
+    private final BranchResult result;
+
+    WhileLoopImpl(BytecodeCreatorImpl enclosing, Function<BytecodeCreator, BranchResult> conditionFun) {
+        super(enclosing);
+        BranchResult branchResult = conditionFun.apply(this);
+        if (branchResult == null) {
+            throw new IllegalArgumentException("BranchResult must not be null");
+        }
+        this.result = branchResult;
+    }
+
+    @Override
+    protected void writeOperations(MethodVisitor visitor) {
+        result.trueBranch().continueScope(this);
+        result.falseBranch().breakScope(this);
+        super.writeOperations(visitor);
+    }
+
+    @Override
+    public BytecodeCreator block() {
+        return result.trueBranch();
+    }
+
+    @Override
+    public BytecodeCreator scope() {
+        return this;
+    }
+
+}

--- a/src/test/java/io/quarkus/gizmo/ScopeTestCase.java
+++ b/src/test/java/io/quarkus/gizmo/ScopeTestCase.java
@@ -52,4 +52,92 @@ public class ScopeTestCase {
         Supplier myInterface = (Supplier) cl.loadClass("com.MyTest").newInstance();
         Assert.assertEquals("10-9-8-7-6-5-4-3-2-1-", myInterface.get());
     }
+
+    @Test
+    public void testWhileLoop() throws InstantiationException, IllegalAccessException, ClassNotFoundException {
+        TestClassLoader cl = new TestClassLoader(getClass().getClassLoader());
+        try (ClassCreator creator = ClassCreator.builder().classOutput(cl).className("com.MyTest").interfaces(Supplier.class)
+                .build()) {
+            MethodCreator method = creator.getMethodCreator("get", Object.class);
+            AssignableResultHandle val = method.createVariable(int.class);
+            method.assign(val, method.load(10));
+            ResultHandle sb = method.newInstance(MethodDescriptor.ofConstructor(StringBuilder.class));
+            MethodDescriptor sbAppend = MethodDescriptor.ofMethod(StringBuilder.class, "append", StringBuilder.class,
+                    String.class);
+
+            WhileLoop loop = method.whileLoop(bc -> bc.ifNonZero(val));
+            BytecodeCreator block = loop.block();
+            block.invokeVirtualMethod(sbAppend, sb, block
+                    .invokeStaticMethod(MethodDescriptor.ofMethod(Integer.class, "toString", String.class, int.class), val));
+            block.invokeVirtualMethod(sbAppend, sb, block.load("-"));
+            block.assign(val, block.invokeStaticMethod(
+                    MethodDescriptor.ofMethod(Math.class, "addExact", int.class, int.class, int.class), val, block.load(-1)));
+
+            method.returnValue(
+                    method.invokeVirtualMethod(MethodDescriptor.ofMethod(Object.class, "toString", String.class), sb));
+        }
+        Supplier myInterface = (Supplier) cl.loadClass("com.MyTest").newInstance();
+        Assert.assertEquals("10-9-8-7-6-5-4-3-2-1-", myInterface.get());
+    }
+    
+    @Test
+    public void testWhileLoopContinue() throws InstantiationException, IllegalAccessException, ClassNotFoundException {
+        TestClassLoader cl = new TestClassLoader(getClass().getClassLoader());
+        try (ClassCreator creator = ClassCreator.builder().classOutput(cl).className("com.MyTest").interfaces(Supplier.class)
+                .build()) {
+            MethodCreator method = creator.getMethodCreator("get", Object.class);
+            AssignableResultHandle val = method.createVariable(int.class);
+            method.assign(val, method.load(11));
+            ResultHandle sb = method.newInstance(MethodDescriptor.ofConstructor(StringBuilder.class));
+            MethodDescriptor sbAppend = MethodDescriptor.ofMethod(StringBuilder.class, "append", StringBuilder.class,
+                    String.class);
+
+            WhileLoop loop = method.whileLoop(bc -> bc.ifIntegerGreaterThan(val, bc.load(1)));
+            BytecodeCreator block = loop.block();
+            // decrement the value
+            block.assign(val, block.invokeStaticMethod(
+                    MethodDescriptor.ofMethod(Math.class, "addExact", int.class, int.class, int.class), val, block.load(-1)));
+            // skip number 5
+            block.ifIntegerEqual(val, block.load(5)).trueBranch().continueScope(loop.scope());
+            block.invokeVirtualMethod(sbAppend, sb, block
+                    .invokeStaticMethod(MethodDescriptor.ofMethod(Integer.class, "toString", String.class, int.class), val));
+            block.invokeVirtualMethod(sbAppend, sb, block.load("-"));
+            
+            method.returnValue(
+                    method.invokeVirtualMethod(MethodDescriptor.ofMethod(Object.class, "toString", String.class), sb));
+        }
+        Supplier myInterface = (Supplier) cl.loadClass("com.MyTest").newInstance();
+        Assert.assertEquals("10-9-8-7-6-4-3-2-1-", myInterface.get());
+    }
+    
+    @Test
+    public void testWhileLoopBreak() throws InstantiationException, IllegalAccessException, ClassNotFoundException {
+        TestClassLoader cl = new TestClassLoader(getClass().getClassLoader());
+        try (ClassCreator creator = ClassCreator.builder().classOutput(cl).className("com.MyTest").interfaces(Supplier.class)
+                .build()) {
+            MethodCreator method = creator.getMethodCreator("get", Object.class);
+            AssignableResultHandle val = method.createVariable(int.class);
+            method.assign(val, method.load(11));
+            ResultHandle sb = method.newInstance(MethodDescriptor.ofConstructor(StringBuilder.class));
+            MethodDescriptor sbAppend = MethodDescriptor.ofMethod(StringBuilder.class, "append", StringBuilder.class,
+                    String.class);
+
+            WhileLoop loop = method.whileLoop(bc -> bc.ifIntegerGreaterThan(val, bc.load(1)));
+            BytecodeCreator block = loop.block();
+            // decrement the value
+            block.assign(val, block.invokeStaticMethod(
+                    MethodDescriptor.ofMethod(Math.class, "addExact", int.class, int.class, int.class), val, block.load(-1)));
+            // break if number 5
+            block.ifIntegerEqual(val, block.load(5)).trueBranch().breakScope(loop.scope());
+            block.invokeVirtualMethod(sbAppend, sb, block
+                    .invokeStaticMethod(MethodDescriptor.ofMethod(Integer.class, "toString", String.class, int.class), val));
+            block.invokeVirtualMethod(sbAppend, sb, block.load("-"));
+
+            method.returnValue(
+                    method.invokeVirtualMethod(MethodDescriptor.ofMethod(Object.class, "toString", String.class), sb));
+        }
+        Supplier myInterface = (Supplier) cl.loadClass("com.MyTest").newInstance();
+        Assert.assertEquals("10-9-8-7-6-", myInterface.get());
+    }
+    
 }


### PR DESCRIPTION
I know that it's possible to implement a loop using scopes. However, the API is IMHO not very intuitive and the resulting code is error prone.

I propose to add a simple while loop abstraction.

Compare:
```java
AssignableResultHandle val = method.createVariable(int.class);
method.assign(val, method.load(10));

BytecodeCreator loop = method.createScope();
BranchResult branch = loop.ifNonZero(val);
BytecodeCreator tb = branch.trueBranch();
tb.invokeVirtualMethod(...);
tb.assign(val, tb.invokeStaticMethod(MethodDescriptor.ofMethod(Math.class, "addExact", int.class, int.class, int.class), val, tb.load(-1)));
tb.continueScope(loop);
branch.falseBranch().breakScope(loop);
```
VS
```java
AssignableResultHandle val = method.createVariable(int.class);
method.assign(val, method.load(10));

WhileLoop loop = method.whileLoop(bc -> bc.ifNonZero(val));
BytecodeCreator block = loop.block();
block.invokeVirtualMethod(...);
block.assign(val, block.invokeStaticMethod(MethodDescriptor.ofMethod(Math.class, "addExact", int.class, int.class, int.class), val, block.load(-1)));
```