### PR TITLE
Keep the staging repo when it fails

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -146,6 +146,7 @@
                             <nexusUrl>https://oss.sonatype.org/</nexusUrl>
                             <serverId>ossrh</serverId>
                             <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                            <keepStagingRepositoryOnCloseRuleFailure>true</keepStagingRepositoryOnCloseRuleFailure>
                         </configuration>
                     </plugin>
                     <plugin>


### PR DESCRIPTION
When you end up with a timeout, it's better to keep the staging repo and
finish things manually in the UI.