### PR TITLE
Complete annotation creation

### DIFF
--- a/src/main/java/io/quarkus/gizmo/AnnotatedElement.java
+++ b/src/main/java/io/quarkus/gizmo/AnnotatedElement.java
@@ -38,40 +38,7 @@ public interface AnnotatedElement {
     default void addAnnotation(AnnotationInstance annotation) {
         AnnotationCreator ac = addAnnotation(annotation.name().toString());
         for (AnnotationValue member : annotation.values()) {
-            if (member.kind() == AnnotationValue.Kind.NESTED) {
-                throw new RuntimeException("Not Yet Implemented: Cannot generate annotation " + annotation);
-            } else if (member.kind() == AnnotationValue.Kind.BOOLEAN) {
-                ac.addValue(member.name(), member.asBoolean());
-            } else if (member.kind() == AnnotationValue.Kind.BYTE) {
-                ac.addValue(member.name(), member.asByte());
-            } else if (member.kind() == AnnotationValue.Kind.SHORT) {
-                ac.addValue(member.name(), member.asShort());
-            } else if (member.kind() == AnnotationValue.Kind.INTEGER) {
-                ac.addValue(member.name(), member.asInt());
-            } else if (member.kind() == AnnotationValue.Kind.LONG) {
-                ac.addValue(member.name(), member.asLong());
-            } else if (member.kind() == AnnotationValue.Kind.FLOAT) {
-                ac.addValue(member.name(), member.asFloat());
-            } else if (member.kind() == AnnotationValue.Kind.DOUBLE) {
-                ac.addValue(member.name(), member.asDouble());
-            } else if (member.kind() == AnnotationValue.Kind.STRING) {
-                ac.addValue(member.name(), member.asString());
-            } else if (member.kind() == AnnotationValue.Kind.ARRAY) {
-                ac.addValue(member.name(), member.value());
-            } else if (member.kind() == AnnotationValue.Kind.ENUM) {
-                Class<? extends Enum> enumType = null;
-                try {
-                    enumType = (Class<? extends Enum>)Class.forName(member.asEnumType().toString());
-                } catch (ClassNotFoundException e) {
-                    //handled lower
-                }
-                if (enumType != null) {
-                    Enum enumVal = Enum.valueOf(enumType, member.asEnum());
-                    ac.addValue(member.name(), enumVal);
-                } else {
-                    throw new IllegalArgumentException("typeName must be an enum for: " + member.name());
-                }
-            }
+            ac.addValue(member.name(), member);
         }
     }
 

--- a/src/main/java/io/quarkus/gizmo/AnnotationCreator.java
+++ b/src/main/java/io/quarkus/gizmo/AnnotationCreator.java
@@ -16,7 +16,7 @@
 
 package io.quarkus.gizmo;
 
-//TODO: support for nestled annotations
+//TODO: support for nested annotations (currently only Jandex types can be used)
 public interface AnnotationCreator {
 
     void addValue(String name, Object value);

--- a/src/main/java/io/quarkus/gizmo/AnnotationUtils.java
+++ b/src/main/java/io/quarkus/gizmo/AnnotationUtils.java
@@ -1,5 +1,6 @@
 package io.quarkus.gizmo;
 
+import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.AnnotationValue;
 import org.objectweb.asm.AnnotationVisitor;
 
@@ -13,11 +14,34 @@ final class AnnotationUtils {
                 visitAnnotationValue(arrayVisitor, "value", arrayValue);
             }
             arrayVisitor.visitEnd();
+        } else if (value instanceof AnnotationInstance) {
+            AnnotationInstance annotationInstance = (AnnotationInstance) value;
+            String descriptor = DescriptorUtils.objectToDescriptor(annotationInstance.name().toString());
+            AnnotationVisitor nestedVisitor = visitor.visitAnnotation(key, descriptor);
+            for (AnnotationValue annotationValue : annotationInstance.values()) {
+                visitAnnotationValue(nestedVisitor, annotationValue.name(), annotationValue);
+            }
+            nestedVisitor.visitEnd();
         } else if (value instanceof AnnotationValue) {
             AnnotationValue annotationValue = (AnnotationValue) value;
-            visitor.visit(annotationValue.name(), annotationValue.value());
+            if (annotationValue.kind() == AnnotationValue.Kind.NESTED) {
+                visitAnnotationValue(visitor, annotationValue.name(), annotationValue.asNested());
+            } else if (annotationValue.kind() == AnnotationValue.Kind.CLASS) {
+                String descriptor = DescriptorUtils.typeToString(annotationValue.asClass());
+                visitor.visit(annotationValue.name(), org.objectweb.asm.Type.getType(descriptor));
+            } else if (annotationValue.kind() == AnnotationValue.Kind.ENUM) {
+                String descriptor = DescriptorUtils.objectToDescriptor(annotationValue.asEnumType().toString());
+                visitor.visitEnum(key, descriptor, annotationValue.asEnum());
+            } else if (annotationValue.kind() == AnnotationValue.Kind.ARRAY) {
+                visitAnnotationValue(visitor, annotationValue.name(), annotationValue.value());
+            } else {
+                visitor.visit(annotationValue.name(), annotationValue.value());
+            }
         } else if (value instanceof Enum) {
             visitor.visitEnum(key, DescriptorUtils.objectToDescriptor(value.getClass()), ((Enum) value).name());
+        } else if (value instanceof Class) {
+            String descriptor = DescriptorUtils.objectToDescriptor(value);
+            visitor.visit(key, org.objectweb.asm.Type.getType(descriptor));
         } else {
             visitor.visit(key, value);
         }

--- a/src/test/java/io/quarkus/gizmo/AnnotationTestCase.java
+++ b/src/test/java/io/quarkus/gizmo/AnnotationTestCase.java
@@ -2,7 +2,10 @@ package io.quarkus.gizmo;
 
 import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.AnnotationValue;
+import org.jboss.jandex.ArrayType;
 import org.jboss.jandex.DotName;
+import org.jboss.jandex.PrimitiveType;
+import org.jboss.jandex.Type;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -43,6 +46,18 @@ public class AnnotationTestCase {
         MyArrayAnnotation annotation = cl.loadClass("com.MyTest")
                 .getAnnotation(MyArrayAnnotation.class);
         Assert.assertArrayEquals(new String[] { "test" }, annotation.value());
+    }
+
+    @Test
+    public void testClassFullAnnotation() throws ClassNotFoundException {
+        TestClassLoader cl = new TestClassLoader(getClass().getClassLoader());
+        try (ClassCreator creator = ClassCreator.builder().classOutput(cl).className("com.MyTest").build()) {
+            addFullAnnotationUsingJandex(creator);
+        }
+
+        MyFullAnnotation annotation = cl.loadClass("com.MyTest")
+                .getAnnotation(MyFullAnnotation.class);
+        verifyFullAnnotation(annotation);
     }
 
     @Test
@@ -112,6 +127,22 @@ public class AnnotationTestCase {
     }
 
     @Test
+    public void testMethodFullAnnotation() throws ClassNotFoundException, NoSuchMethodException {
+        TestClassLoader cl = new TestClassLoader(getClass().getClassLoader());
+        try (ClassCreator creator = ClassCreator.builder().classOutput(cl).className("com.MyTest").build()) {
+            try (MethodCreator methodCreator = creator.getMethodCreator("test", void.class)) {
+                addFullAnnotationUsingJandex(methodCreator);
+                methodCreator.returnValue(null);
+            }
+        }
+
+        MyFullAnnotation annotation = cl.loadClass("com.MyTest")
+                .getMethod("test")
+                .getAnnotation(MyFullAnnotation.class);
+        verifyFullAnnotation(annotation);
+    }
+
+    @Test
     public void testMethodParamAnnotationWithString() throws ClassNotFoundException, NoSuchMethodException {
         TestClassLoader cl = new TestClassLoader(getClass().getClassLoader());
         try (ClassCreator creator = ClassCreator.builder().classOutput(cl).className("com.MyTest").build()) {
@@ -164,6 +195,23 @@ public class AnnotationTestCase {
     }
 
     @Test
+    public void testMethodParamFullAnnotation() throws ClassNotFoundException, NoSuchMethodException {
+        TestClassLoader cl = new TestClassLoader(getClass().getClassLoader());
+        try (ClassCreator creator = ClassCreator.builder().classOutput(cl).className("com.MyTest").build()) {
+            try (MethodCreator methodCreator = creator.getMethodCreator("test", void.class, String.class)) {
+                addFullAnnotationUsingJandex(methodCreator.getParameterAnnotations(0));
+                methodCreator.returnValue(null);
+            }
+        }
+
+        MyFullAnnotation annotation = cl.loadClass("com.MyTest")
+                .getMethod("test", String.class)
+                .getParameters()[0]
+                .getAnnotation(MyFullAnnotation.class);
+        verifyFullAnnotation(annotation);
+    }
+
+    @Test
     public void testFieldAnnotationWithString() throws ClassNotFoundException, NoSuchFieldException {
         TestClassLoader cl = new TestClassLoader(getClass().getClassLoader());
         try (ClassCreator creator = ClassCreator.builder().classOutput(cl).className("com.MyTest").build()) {
@@ -206,6 +254,20 @@ public class AnnotationTestCase {
         Assert.assertArrayEquals(new String[] { "test" }, annotation.value());
     }
 
+    @Test
+    public void testFieldFullAnnotation() throws ClassNotFoundException, NoSuchFieldException {
+        TestClassLoader cl = new TestClassLoader(getClass().getClassLoader());
+        try (ClassCreator creator = ClassCreator.builder().classOutput(cl).className("com.MyTest").build()) {
+            FieldCreator fieldCreator = creator.getFieldCreator("test", String.class);
+            addFullAnnotationUsingJandex(fieldCreator);
+        }
+
+        MyFullAnnotation annotation = cl.loadClass("com.MyTest")
+                .getDeclaredField("test")
+                .getAnnotation(MyFullAnnotation.class);
+        verifyFullAnnotation(annotation);
+    }
+
     private void addAnnotationWithString(AnnotatedElement element) {
         AnnotationCreator annotationCreator = element.addAnnotation(MyAnnotation.class);
         annotationCreator.addValue("value", "test");
@@ -227,5 +289,195 @@ public class AnnotationTestCase {
                 }
         );
         element.addAnnotation(annotation);
+    }
+
+    private void addFullAnnotationUsingJandex(AnnotatedElement element) {
+        element.addAnnotation(AnnotationInstance.create(DotName.createSimple(MyFullAnnotation.class.getName()), null,
+                new AnnotationValue[]{
+                        AnnotationValue.createBooleanValue("bool", true),
+                        AnnotationValue.createCharacterValue("ch", 'c'),
+                        AnnotationValue.createByteValue("b", (byte) 42),
+                        AnnotationValue.createShortValue("s", (short) 42),
+                        AnnotationValue.createIntegerValue("i", 42),
+                        AnnotationValue.createLongValue("l", 42L),
+                        AnnotationValue.createFloatValue("f", 42.0F),
+                        AnnotationValue.createDoubleValue("d", 42.0),
+                        AnnotationValue.createStringValue("str", "str"),
+                        AnnotationValue.createEnumValue("enumerated", DotName.createSimple(MyEnum.class.getName()), "YES"),
+                        AnnotationValue.createClassValue("cls", Type.create(DotName.createSimple(MyInterface.class.getName()), Type.Kind.CLASS)),
+                        AnnotationValue.createNestedAnnotationValue("nested", AnnotationInstance.create(DotName.createSimple(MyNestedAnnotation.class.getName()), null,
+                                new AnnotationValue[]{
+                                        AnnotationValue.createClassValue("cls", Type.create(DotName.createSimple(MyInterface.class.getName()), Type.Kind.CLASS)),
+                                        AnnotationValue.createNestedAnnotationValue("innerNested", AnnotationInstance.create(DotName.createSimple(MyAnnotation.class.getName()), null,
+                                                new AnnotationValue[]{
+                                                        AnnotationValue.createStringValue("value", "nested"),
+                                                        AnnotationValue.createEnumValue("enumVal", DotName.createSimple(MyEnum.class.getName()), "YES")
+                                                })),
+                                        AnnotationValue.createArrayValue("clsArray", new AnnotationValue[]{
+                                                AnnotationValue.createClassValue("", Type.create(DotName.createSimple(MyInterface.class.getName()), Type.Kind.CLASS)),
+                                                AnnotationValue.createClassValue("", ArrayType.create(PrimitiveType.BOOLEAN, 1)),
+                                        }),
+                                        AnnotationValue.createArrayValue("innerNestedArray", new AnnotationValue[]{
+                                                AnnotationValue.createNestedAnnotationValue("", AnnotationInstance.create(DotName.createSimple(MyAnnotation.class.getName()), null,
+                                                        new AnnotationValue[]{
+                                                                AnnotationValue.createStringValue("value", "nested1"),
+                                                                AnnotationValue.createEnumValue("enumVal", DotName.createSimple(MyEnum.class.getName()), "YES")
+                                                        })),
+                                                AnnotationValue.createNestedAnnotationValue("", AnnotationInstance.create(DotName.createSimple(MyAnnotation.class.getName()), null,
+                                                        new AnnotationValue[]{
+                                                                AnnotationValue.createStringValue("value", "nested2"),
+                                                                AnnotationValue.createEnumValue("enumVal", DotName.createSimple(MyEnum.class.getName()), "NO")
+                                                        })),
+                                        }),
+                                })),
+
+                        AnnotationValue.createArrayValue("boolArray", new AnnotationValue[]{
+                                AnnotationValue.createBooleanValue("", true),
+                                AnnotationValue.createBooleanValue("", false),
+                        }),
+                        AnnotationValue.createArrayValue("chArray", new AnnotationValue[]{
+                                AnnotationValue.createCharacterValue("", 'c'),
+                                AnnotationValue.createCharacterValue("", 'd'),
+                        }),
+                        AnnotationValue.createArrayValue("bArray", new AnnotationValue[]{
+                                AnnotationValue.createByteValue("", (byte) 42),
+                                AnnotationValue.createByteValue("", (byte) 43),
+                        }),
+                        AnnotationValue.createArrayValue("sArray", new AnnotationValue[]{
+                                AnnotationValue.createShortValue("", (short) 42),
+                                AnnotationValue.createShortValue("", (short) 43),
+                        }),
+                        AnnotationValue.createArrayValue("iArray", new AnnotationValue[]{
+                                AnnotationValue.createIntegerValue("", 42),
+                                AnnotationValue.createIntegerValue("", 43),
+                        }),
+                        AnnotationValue.createArrayValue("lArray", new AnnotationValue[]{
+                                AnnotationValue.createLongValue("", 42L),
+                                AnnotationValue.createLongValue("", 43L),
+                        }),
+                        AnnotationValue.createArrayValue("fArray", new AnnotationValue[]{
+                                AnnotationValue.createFloatValue("", 42.0F),
+                                AnnotationValue.createFloatValue("", 43.0F),
+                        }),
+                        AnnotationValue.createArrayValue("dArray", new AnnotationValue[]{
+                                AnnotationValue.createDoubleValue("", 42.0),
+                                AnnotationValue.createDoubleValue("", 43.0),
+                        }),
+                        AnnotationValue.createArrayValue("strArray", new AnnotationValue[]{
+                                AnnotationValue.createStringValue("", "foo"),
+                                AnnotationValue.createStringValue("", "bar"),
+                        }),
+                        AnnotationValue.createArrayValue("enumeratedArray", new AnnotationValue[]{
+                                AnnotationValue.createEnumValue("", DotName.createSimple(MyEnum.class.getName()), "YES"),
+                                AnnotationValue.createEnumValue("", DotName.createSimple(MyEnum.class.getName()), "NO"),
+                        }),
+                        AnnotationValue.createArrayValue("clsArray", new AnnotationValue[]{
+                                AnnotationValue.createClassValue("", Type.create(DotName.createSimple(MyInterface.class.getName()), Type.Kind.CLASS)),
+                                AnnotationValue.createClassValue("", ArrayType.create(PrimitiveType.CHAR, 2)),
+                        }),
+                        AnnotationValue.createArrayValue("nestedArray", new AnnotationValue[]{
+                                AnnotationValue.createNestedAnnotationValue("", AnnotationInstance.create(DotName.createSimple(MyNestedAnnotation.class.getName()), null,
+                                        new AnnotationValue[]{
+                                                AnnotationValue.createClassValue("cls", Type.create(DotName.createSimple(MyInterface.class.getName()), Type.Kind.CLASS)),
+                                                AnnotationValue.createNestedAnnotationValue("innerNested", AnnotationInstance.create(DotName.createSimple(MyAnnotation.class.getName()), null,
+                                                        new AnnotationValue[]{
+                                                                AnnotationValue.createStringValue("value", "nested1"),
+                                                                AnnotationValue.createEnumValue("enumVal", DotName.createSimple(MyEnum.class.getName()), "YES")
+                                                        })),
+                                                AnnotationValue.createArrayValue("clsArray", new AnnotationValue[]{
+                                                        AnnotationValue.createClassValue("", Type.create(DotName.createSimple(MyInterface.class.getName()), Type.Kind.CLASS)),
+                                                        AnnotationValue.createClassValue("", ArrayType.create(PrimitiveType.BOOLEAN, 1)),
+                                                }),
+                                                AnnotationValue.createArrayValue("innerNestedArray", new AnnotationValue[]{
+                                                        AnnotationValue.createNestedAnnotationValue("", AnnotationInstance.create(DotName.createSimple(MyAnnotation.class.getName()), null,
+                                                                new AnnotationValue[]{
+                                                                        AnnotationValue.createStringValue("value", "nested11"),
+                                                                        AnnotationValue.createEnumValue("enumVal", DotName.createSimple(MyEnum.class.getName()), "YES")
+                                                                })),
+                                                        AnnotationValue.createNestedAnnotationValue("", AnnotationInstance.create(DotName.createSimple(MyAnnotation.class.getName()), null,
+                                                                new AnnotationValue[]{
+                                                                        AnnotationValue.createStringValue("value", "nested12"),
+                                                                        AnnotationValue.createEnumValue("enumVal", DotName.createSimple(MyEnum.class.getName()), "NO")
+                                                                })),
+                                                }),
+                                        })),
+                                AnnotationValue.createNestedAnnotationValue("", AnnotationInstance.create(DotName.createSimple(MyNestedAnnotation.class.getName()), null,
+                                        new AnnotationValue[]{
+                                                AnnotationValue.createClassValue("cls", Type.create(DotName.createSimple(MyInterface.class.getName()), Type.Kind.CLASS)),
+                                                AnnotationValue.createNestedAnnotationValue("innerNested", AnnotationInstance.create(DotName.createSimple(MyAnnotation.class.getName()), null,
+                                                        new AnnotationValue[]{
+                                                                AnnotationValue.createStringValue("value", "nested2"),
+                                                                AnnotationValue.createEnumValue("enumVal", DotName.createSimple(MyEnum.class.getName()), "YES")
+                                                        })),
+                                                AnnotationValue.createArrayValue("clsArray", new AnnotationValue[]{
+                                                        AnnotationValue.createClassValue("", Type.create(DotName.createSimple(MyInterface.class.getName()), Type.Kind.CLASS)),
+                                                        AnnotationValue.createClassValue("", ArrayType.create(PrimitiveType.BOOLEAN, 1)),
+                                                }),
+                                                AnnotationValue.createArrayValue("innerNestedArray", new AnnotationValue[]{
+                                                        AnnotationValue.createNestedAnnotationValue("", AnnotationInstance.create(DotName.createSimple(MyAnnotation.class.getName()), null,
+                                                                new AnnotationValue[]{
+                                                                        AnnotationValue.createStringValue("value", "nested21"),
+                                                                        AnnotationValue.createEnumValue("enumVal", DotName.createSimple(MyEnum.class.getName()), "YES")
+                                                                })),
+                                                        AnnotationValue.createNestedAnnotationValue("", AnnotationInstance.create(DotName.createSimple(MyAnnotation.class.getName()), null,
+                                                                new AnnotationValue[]{
+                                                                        AnnotationValue.createStringValue("value", "nested22"),
+                                                                        AnnotationValue.createEnumValue("enumVal", DotName.createSimple(MyEnum.class.getName()), "NO")
+                                                                })),
+                                                }),
+                                        })),
+                        }),
+                }
+        ));
+    }
+
+    private void verifyFullAnnotation(MyFullAnnotation annotation) {
+        Assert.assertEquals(true, annotation.bool());
+        Assert.assertEquals('c', annotation.ch());
+        Assert.assertEquals((byte) 42, annotation.b());
+        Assert.assertEquals((short) 42, annotation.s());
+        Assert.assertEquals(42, annotation.i());
+        Assert.assertEquals(42L, annotation.l());
+        Assert.assertEquals(42.0F, annotation.f(), 0.1f);
+        Assert.assertEquals(42.0, annotation.d(), 0.1);
+        Assert.assertEquals("str", annotation.str());
+        Assert.assertEquals(MyEnum.YES, annotation.enumerated());
+        Assert.assertEquals(MyInterface.class, annotation.cls());
+        Assert.assertEquals(MyInterface.class, annotation.nested().cls());
+        Assert.assertEquals("nested", annotation.nested().innerNested().value());
+        Assert.assertEquals(MyEnum.YES, annotation.nested().innerNested().enumVal());
+        Assert.assertArrayEquals(new Class[]{MyInterface.class, boolean[].class}, annotation.nested().clsArray());
+        Assert.assertEquals("nested1", annotation.nested().innerNestedArray()[0].value());
+        Assert.assertEquals(MyEnum.YES, annotation.nested().innerNestedArray()[0].enumVal());
+        Assert.assertEquals("nested2", annotation.nested().innerNestedArray()[1].value());
+        Assert.assertEquals(MyEnum.NO, annotation.nested().innerNestedArray()[1].enumVal());
+
+        Assert.assertArrayEquals(new boolean[]{true, false}, annotation.boolArray());
+        Assert.assertArrayEquals(new char[]{'c', 'd'}, annotation.chArray());
+        Assert.assertArrayEquals(new byte[]{(byte) 42, (byte) 43}, annotation.bArray());
+        Assert.assertArrayEquals(new short[]{(short) 42, (short) 43}, annotation.sArray());
+        Assert.assertArrayEquals(new int[]{42, 43}, annotation.iArray());
+        Assert.assertArrayEquals(new long[]{42L, 43L}, annotation.lArray());
+        Assert.assertArrayEquals(new float[]{42.0F, 43.0F}, annotation.fArray(), 0.1f);
+        Assert.assertArrayEquals(new double[]{42.0, 43.0}, annotation.dArray(), 0.1);
+        Assert.assertArrayEquals(new String[]{"foo", "bar"}, annotation.strArray());
+        Assert.assertArrayEquals(new MyEnum[]{MyEnum.YES, MyEnum.NO}, annotation.enumeratedArray());
+        Assert.assertArrayEquals(new Class[]{MyInterface.class, char[][].class}, annotation.clsArray());
+        Assert.assertEquals(MyInterface.class, annotation.nestedArray()[0].cls());
+        Assert.assertEquals("nested1", annotation.nestedArray()[0].innerNested().value());
+        Assert.assertEquals(MyEnum.YES, annotation.nestedArray()[0].innerNested().enumVal());
+        Assert.assertArrayEquals(new Class[]{MyInterface.class, boolean[].class}, annotation.nestedArray()[0].clsArray());
+        Assert.assertEquals("nested11", annotation.nestedArray()[0].innerNestedArray()[0].value());
+        Assert.assertEquals(MyEnum.YES, annotation.nestedArray()[0].innerNestedArray()[0].enumVal());
+        Assert.assertEquals("nested12", annotation.nestedArray()[0].innerNestedArray()[1].value());
+        Assert.assertEquals(MyEnum.NO, annotation.nestedArray()[0].innerNestedArray()[1].enumVal());
+        Assert.assertEquals(MyInterface.class, annotation.nestedArray()[1].cls());
+        Assert.assertEquals("nested2", annotation.nestedArray()[1].innerNested().value());
+        Assert.assertEquals(MyEnum.YES, annotation.nestedArray()[1].innerNested().enumVal());
+        Assert.assertArrayEquals(new Class[]{MyInterface.class, boolean[].class}, annotation.nestedArray()[1].clsArray());
+        Assert.assertEquals("nested21", annotation.nestedArray()[1].innerNestedArray()[0].value());
+        Assert.assertEquals(MyEnum.YES, annotation.nestedArray()[1].innerNestedArray()[0].enumVal());
+        Assert.assertEquals("nested22", annotation.nestedArray()[1].innerNestedArray()[1].value());
+        Assert.assertEquals(MyEnum.NO, annotation.nestedArray()[1].innerNestedArray()[1].enumVal());
     }
 }

--- a/src/test/java/io/quarkus/gizmo/MyFullAnnotation.java
+++ b/src/test/java/io/quarkus/gizmo/MyFullAnnotation.java
@@ -1,0 +1,36 @@
+package io.quarkus.gizmo;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ ElementType.TYPE, ElementType.METHOD, ElementType.PARAMETER, ElementType.FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface MyFullAnnotation {
+    boolean bool();
+    char ch();
+    byte b();
+    short s();
+    int i();
+    long l();
+    float f();
+    double d();
+    String str();
+    MyEnum enumerated();
+    Class<?> cls();
+    MyNestedAnnotation nested();
+
+    boolean[] boolArray();
+    char[] chArray();
+    byte[] bArray();
+    short[] sArray();
+    int[] iArray();
+    long[] lArray();
+    float[] fArray();
+    double[] dArray();
+    String[] strArray();
+    MyEnum[] enumeratedArray();
+    Class<?>[] clsArray();
+    MyNestedAnnotation[] nestedArray();
+}

--- a/src/test/java/io/quarkus/gizmo/MyNestedAnnotation.java
+++ b/src/test/java/io/quarkus/gizmo/MyNestedAnnotation.java
@@ -1,0 +1,16 @@
+package io.quarkus.gizmo;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ ElementType.TYPE, ElementType.METHOD, ElementType.PARAMETER, ElementType.FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface MyNestedAnnotation {
+    Class<?> cls();
+    MyAnnotation innerNested();
+
+    Class<?>[] clsArray();
+    MyAnnotation[] innerNestedArray();
+}


### PR DESCRIPTION
The code in `AnnotationUtils` is completed to properly handle
all possible Jandex `AnnotationValue` instances, including
`AnnotationInstance` values (nested annotations).

With this, `AnnotationCreator` can store all `AnnotationValue`
and `AnnotationInstance` values, which is used to simplify
`AnnotatedElement.addAnnotation(AnnotationInstance)`.