### PR TITLE
Make FieldCreator support signature

### DIFF
--- a/src/main/java/io/quarkus/gizmo/FieldCreator.java
+++ b/src/main/java/io/quarkus/gizmo/FieldCreator.java
@@ -17,7 +17,7 @@
 package io.quarkus.gizmo;
 
 
-public interface FieldCreator extends MemberCreator<FieldCreator>, AnnotatedElement {
+public interface FieldCreator extends MemberCreator<FieldCreator>, AnnotatedElement, SignatureElement<FieldCreator> {
 
     FieldDescriptor getFieldDescriptor();
 

--- a/src/main/java/io/quarkus/gizmo/FieldCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo/FieldCreatorImpl.java
@@ -26,7 +26,7 @@ import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.FieldVisitor;
 import org.objectweb.asm.Opcodes;
 
-class FieldCreatorImpl implements FieldCreator, SignatureElement<FieldCreatorImpl> {
+class FieldCreatorImpl implements FieldCreator {
 
     private final FieldDescriptor fieldDescriptor;
     private final List<AnnotationCreatorImpl> annotations = new ArrayList<>();
@@ -80,7 +80,7 @@ class FieldCreatorImpl implements FieldCreator, SignatureElement<FieldCreatorImp
     }
 
     @Override
-    public FieldCreatorImpl setSignature(String signature) {
+    public FieldCreator setSignature(String signature) {
         this.signature = signature;
         return this;
     }


### PR DESCRIPTION
Imagine the following field, which injects a smallrye reactive messaging `Emitter`:
```
@Channel(value = "event")
Emitter<Event> eventEmitter;
```
Smallrye requires the `Emitter` to have a type argument that represents the message the `Emitter` is supposed to send.

Such a field cannot be generated without the `setSignature()` call, which is currently unavailable in the `FieldCreator` interface:
```
FieldCreator fieldCreator = classCreator.getFieldCreator("eventEmitter", Emitter.class);
fieldCreator.setSignature("Lorg/eclipse/microprofile/reactive/messaging/Emitter<Lorg/something/messaging/Event;>;");
```