### PR TITLE
Allow using Maps to specify nested annotations

### DIFF
--- a/src/main/java/io/quarkus/gizmo/AnnotationCreator.java
+++ b/src/main/java/io/quarkus/gizmo/AnnotationCreator.java
@@ -16,7 +16,6 @@
 
 package io.quarkus.gizmo;
 
-//TODO: support for nested annotations (currently only Jandex types can be used)
 public interface AnnotationCreator {
 
     void addValue(String name, Object value);

--- a/src/main/java/io/quarkus/gizmo/AnnotationCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo/AnnotationCreatorImpl.java
@@ -16,7 +16,9 @@
 
 package io.quarkus.gizmo;
 
+import java.lang.annotation.Annotation;
 import java.lang.annotation.RetentionPolicy;
+import java.lang.reflect.Method;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -36,6 +38,9 @@ class AnnotationCreatorImpl implements AnnotationCreator {
 
     @Override
     public void addValue(String name, Object value) {
+        // TODO: Maybe typecheck value to ensure it matches the corresponding element type?
+        // TODO: If value is a Map, check if all its keys are elements for the annotation, and there are no
+        //       missing required elements
         values.put(name, value);
     }
 


### PR DESCRIPTION
All Java Annotations extend java.lang.annotation.Annotation,
which defines a method `annotationType` that return the type
of the annotation (and not the proxy class). As such, it can
be used as a key in a Map to specify the type of the Annotation
to create, with the remaining keys being the elements of the
Annotation.