### PR TITLE
Add nested AnnotationCreator alternative; add Javadoc for AnnotationCreator

### DIFF
--- a/src/main/java/io/quarkus/gizmo/AnnotationCreator.java
+++ b/src/main/java/io/quarkus/gizmo/AnnotationCreator.java
@@ -16,8 +16,65 @@
 
 package io.quarkus.gizmo;
 
+import java.lang.annotation.Annotation;
+import java.util.Map;
+import java.util.function.Consumer;
+
 public interface AnnotationCreator {
 
+    /**
+     * Add a new element with the given {@code name} and {@code value}. If {@code value} is a {@link Map},
+     * it is treated as a nested annotation, with the map's entries being the nested annotation's
+     * elements' names and values; the map must have an "annotationType" entry whose value is either
+     * the class or the class name of the nested annotation. Alternatively,
+     * {@link AnnotationCreator#addNested(String, String)} or {@link AnnotationCreator#addNested(String, Class)} can
+     * be used to create nested annotations.
+     *
+     * @param name The name of the annotation element to add
+     * @param value The value of the annotation element to add
+     */
     void addValue(String name, Object value);
 
+    /**
+     * Adds a nested annotation element, and return a new {@link AnnotationCreator} to populate it.
+     *
+     * @param name The name of the nested annotation element
+     * @param annotationType The class name of the nested annotation
+     * @return A new {@link AnnotationCreator} that can be used to populate the nested annotation.
+     */
+    AnnotationCreator addNested(String name, String annotationType);
+
+    /**
+     * Adds a nested annotation element, and return a new {@link AnnotationCreator} to populate it.
+     *
+     * @param name The name of the nested annotation element
+     * @param annotationType The class of the nested annotation
+     * @return A new {@link AnnotationCreator} that can be used to populate the nested annotation.
+     */
+    default AnnotationCreator addNested(String name, Class<? extends Annotation> annotationType) {
+        return addNested(name, annotationType.getName());
+    }
+
+    /**
+     * Adds an array of nested annotation element, using the given AnnotationCreator consumers to generate it.
+     *
+     * @param name The name of the nested annotation element
+     * @param annotationType The class name of the nested annotation
+     * @param annotationArrayCreator Consumers that generate the elements of the array
+     */
+    void addNestedArray(String name, String annotationType, AnnotationCreatorConsumer... annotationArrayCreator);
+
+    /**
+     * Adds an array of nested annotation element, using the given AnnotationCreator consumers to generate it.
+     *
+     * @param name The name of the nested annotation element
+     * @param annotationType The class of the nested annotation
+     * @param annotationArrayCreator Consumers that generate the elements of the array
+     */
+
+    default void addNestedArray(String name, Class<? extends Annotation> annotationType, AnnotationCreatorConsumer... annotationArrayCreator) {
+        addNestedArray(name, annotationType.getName(), annotationArrayCreator);
+    }
+
+    interface AnnotationCreatorConsumer extends Consumer<AnnotationCreator> {}
 }

--- a/src/main/java/io/quarkus/gizmo/AnnotationCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo/AnnotationCreatorImpl.java
@@ -16,9 +16,7 @@
 
 package io.quarkus.gizmo;
 
-import java.lang.annotation.Annotation;
 import java.lang.annotation.RetentionPolicy;
-import java.lang.reflect.Method;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -42,6 +40,29 @@ class AnnotationCreatorImpl implements AnnotationCreator {
         // TODO: If value is a Map, check if all its keys are elements for the annotation, and there are no
         //       missing required elements
         values.put(name, value);
+    }
+
+    @Override
+    public AnnotationCreator addNested(String name, String annotationType) {
+        AnnotationCreatorImpl nested = new AnnotationCreatorImpl(annotationType, retentionPolicy);
+        Map<String, Object> nestedAnnotationValues = nested.getValues();
+        nestedAnnotationValues.put("annotationType", annotationType);
+        addValue(name, nestedAnnotationValues);
+        return nested;
+    }
+
+    @Override
+    public void addNestedArray(String name, String annotationType, AnnotationCreatorConsumer... annotationArrayCreator) {
+        @SuppressWarnings("rawtypes")
+        Map[] nestedArray = new Map[annotationArrayCreator.length];
+        for (int i = 0; i < annotationArrayCreator.length; i++) {
+            AnnotationCreatorImpl nested = new AnnotationCreatorImpl(annotationType, retentionPolicy);
+            Map<String, Object> nestedAnnotationValues = nested.getValues();
+            nestedAnnotationValues.put("annotationType", annotationType);
+            annotationArrayCreator[i].accept(nested);
+            nestedArray[i] = nestedAnnotationValues;
+        }
+        addValue(name, nestedArray);
     }
 
     public Map<String, Object> getValues() {

--- a/src/main/java/io/quarkus/gizmo/AnnotationUtils.java
+++ b/src/main/java/io/quarkus/gizmo/AnnotationUtils.java
@@ -1,13 +1,11 @@
 package io.quarkus.gizmo;
 
-import java.lang.annotation.Annotation;
 import java.lang.reflect.Array;
 import java.util.Map;
 
 import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.AnnotationValue;
 import org.objectweb.asm.AnnotationVisitor;
-import org.objectweb.asm.Type;
 
 final class AnnotationUtils {
 
@@ -34,8 +32,7 @@ final class AnnotationUtils {
                 throw new IllegalStateException("The annotationValueMap (" + annotationValueMap + ") does not have entry for " +
                         "required value \"annotationType\".");
             }
-            Class<? extends Annotation> annotationType = (Class<? extends Annotation>) annotationValueMap.get("annotationType");
-            String descriptor = Type.getDescriptor(annotationType);
+            String descriptor = DescriptorUtils.objectToDescriptor(annotationValueMap.get("annotationType"));
             AnnotationVisitor nestedVisitor = visitor.visitAnnotation(key, descriptor);
             for (Map.Entry<String, Object> annotationInstanceValueEntry : annotationValueMap.entrySet()) {
                 final String parameterName = annotationInstanceValueEntry.getKey();


### PR DESCRIPTION
Add a new method to support creating nested annotations using
AnnotationCreators. It works by creating a new AnnotationCreator
and adding its value map as a value to the parent AnnotationCreator
(thus any changes made to the nested AnnotationCreator update the
map in the parent's values). Also added Javadoc so these features
are discoverable.