### PR TITLE
Generate source JAR for the test JAR

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -159,6 +159,12 @@
                                     <goal>jar-no-fork</goal>
                                 </goals>
                             </execution>
+                            <execution>
+                                <id>attach-test-sources</id>
+                                <goals>
+                                    <goal>test-jar-no-fork</goal>
+                                </goals>
+                            </execution>
                         </executions>
                     </plugin>
                     <plugin>


### PR DESCRIPTION
Tests in other projects (notably, Quarkus) sometimes use the `TestClassLoader` from Gizmo's test JAR, so I think it would be nice to have a source JAR for it.