### PR TITLE
Update GitHub Actions configuration

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -8,19 +8,23 @@ on:
 
 jobs:
   build:
+    name: "Build with JDK ${{ matrix.java }}"
     runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false
       matrix:
-        java: [ 8, 11, 16, '17-ea' ]
+        java: [ 8, 11, 17 ]
 
     steps:
-      - uses: actions/checkout@v1
+      - name: Checkout
+        uses: actions/checkout@v3
+
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           distribution: temurin
           java-version: ${{ matrix.java }}
+
       - name: Build with Maven
         run: mvn -B package --file pom.xml


### PR DESCRIPTION
- stop running with Java 16 and 17-ea, start running with Java 17
- use latest versions of the actions
- add name for the job and the checkout step