### PR TITLE
Support Parameterized Types in Methods

### DIFF
--- a/src/main/java/io/quarkus/gizmo/MethodCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo/MethodCreatorImpl.java
@@ -50,6 +50,7 @@ class MethodCreatorImpl extends BytecodeCreatorImpl implements MethodCreator {
         this.methodDescriptor = methodDescriptor;
         this.declaringClassName = declaringClassName;
         this.classCreator = classCreator;
+        this.signature = DescriptorUtils.methodTypesToSignature(methodDescriptor.getRawReturnType(), methodDescriptor.getRawParameterTypes());
     }
 
     @Override

--- a/src/main/java/io/quarkus/gizmo/ParameterizedClass.java
+++ b/src/main/java/io/quarkus/gizmo/ParameterizedClass.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2018 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.quarkus.gizmo;
+
+/**
+ * Wrapper class to represent a parameterized class with its param types.
+ */
+public class ParameterizedClass {
+    private final Object type;
+    private final Object[] parameterTypes;
+
+    public ParameterizedClass(Object type, Object... parameterTypes) {
+        this.type = type;
+        this.parameterTypes = parameterTypes;
+    }
+
+    public Object getType() {
+        return type;
+    }
+
+    public Object[] getParameterTypes() {
+        return parameterTypes;
+    }
+}

--- a/src/test/java/io/quarkus/gizmo/MethodWithParameterizedReturnTypeTestCase.java
+++ b/src/test/java/io/quarkus/gizmo/MethodWithParameterizedReturnTypeTestCase.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2018 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.quarkus.gizmo;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class MethodWithParameterizedReturnTypeTestCase {
+
+    @Test
+    public void testMethodWithParamType() {
+        try (ClassCreator creator = ClassCreator.builder().className("com.MyTest").build()) {
+            MethodCreator method = creator.getMethodCreator("m", new ParameterizedClass(List.class, String.class));
+
+            Assert.assertEquals("()Ljava/util/List<Ljava/lang/String;>;", method.getSignature());
+        }
+    }
+}


### PR DESCRIPTION
This pull request handles the support of parameterized types when creating methods. Example:
```java
public List<String> methodName() {
}
```

Where `List<String>` is a parameterized type. 

In order to do this, we need to amend the `signature` of the method as the descriptor does not support it (it says class not found when trying to declare `Ljava.util.List<Ljava.lang.String;>;`). 

In order to resolve this, we have added a wrapper type `ParameterizedClass` where we can specify the wrapper type and the param types. Usage:

```
MethodCreator method = creator.getMethodCreator("methodName", new ParameterizedClass(List.class, String.class));
```

This pull request partially resolves: https://github.com/quarkusio/gizmo/issues/66 (which is intended to be for classes too)
Moreover, these changes are inspired by the changes in https://github.com/quarkusio/quarkus/pull/26074 (that there will be deprecated once gizmo dependency is bumped).

I've verified these changes in Quarkus upstream too (reverting the changes of the mentioned Quarkus pull request) and it worked fine.