### PR TITLE
Upgrade to Jandex 3.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
 
     <properties>
         <version.asm>9.3</version.asm>
-        <version.jandex>2.4.3.Final</version.jandex>
+        <version.jandex>3.0.0</version.jandex>
         <version.junit>4.13.2</version.junit>
         <nexus-staging-maven-plugin.version>1.6.13</nexus-staging-maven-plugin.version>
         <jacoco.version>0.8.8</jacoco.version>
@@ -69,7 +69,7 @@
             <version>${version.asm}</version>
         </dependency>
         <dependency>
-            <groupId>org.jboss</groupId>
+            <groupId>io.smallrye</groupId>
             <artifactId>jandex</artifactId>
             <version>${version.jandex}</version>
         </dependency>


### PR DESCRIPTION
This is technically a breaking change, so would require at least a 1.2 release. Also, it isn't really necessary, Gizmo doesn't use anything from Jandex that changed in a breaking manner, so Gizmo compiled against Jandex 2.4 works with Jandex 3.0 at runtime just fine. I figured I'll submit a PR anyway, as we'll want everyone to move to Jandex 3.0 over time :-)