### PR TITLE
Don't avoid using TCCL for classes under the `java.` package prefix

### DIFF
--- a/src/main/java/io/quarkus/gizmo/BytecodeCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo/BytecodeCreatorImpl.java
@@ -352,7 +352,7 @@ class BytecodeCreatorImpl implements BytecodeCreator {
         Objects.requireNonNull(className);
         final Class<?> primitiveType = matchPossiblyPrimitive(className);
         if (primitiveType == null) {
-            if (useTccl && !className.startsWith("java.")) {
+            if (useTccl) {
                 if (cachedTccl == null) {
                     ResultHandle currentThread = invokeStaticMethod(THREAD_CURRENT_THREAD);
                     cachedTccl = invokeVirtualMethod(THREAD_GET_TCCL, currentThread);

--- a/src/test/java/io/quarkus/gizmo/LoadClassTestCase.java
+++ b/src/test/java/io/quarkus/gizmo/LoadClassTestCase.java
@@ -50,6 +50,32 @@ public class LoadClassTestCase {
     }
 
     @Test
+    public void testLoadNonPublicClass() throws Exception {
+        TestClassLoader cl = new TestClassLoader(getClass().getClassLoader());
+        try (ClassCreator creator = ClassCreator.builder().classOutput(cl).className("com.MyTest").interfaces(Supplier.class).build()) {
+            MethodCreator method = creator.getMethodCreator("get", Object.class);
+            ResultHandle stringHandle = method.loadClass("java.util.Collections$EmptyList");
+            method.returnValue(stringHandle);
+        }
+        Class<?> clazz = cl.loadClass("com.MyTest");
+        Supplier myInterface = (Supplier) clazz.getDeclaredConstructor().newInstance();
+        Assert.assertThrows(IllegalAccessError.class, myInterface::get);
+    }
+
+    @Test
+    public void testLoadNonPublicClassFromTCCL() throws Exception {
+        TestClassLoader cl = new TestClassLoader(getClass().getClassLoader());
+        try (ClassCreator creator = ClassCreator.builder().classOutput(cl).className("com.MyTest").interfaces(Supplier.class).build()) {
+            MethodCreator method = creator.getMethodCreator("get", Object.class);
+            ResultHandle stringHandle = method.loadClassFromTCCL("java.util.Collections$EmptyList");
+            method.returnValue(stringHandle);
+        }
+        Class<?> clazz = cl.loadClass("com.MyTest");
+        Supplier myInterface = (Supplier) clazz.getDeclaredConstructor().newInstance();
+        Assert.assertEquals(Class.forName("java.util.Collections$EmptyList"), myInterface.get());
+    }
+
+    @Test
     public void testLoadVoidClass() throws Exception {
         TestClassLoader cl = new TestClassLoader(getClass().getClassLoader());
         try (ClassCreator creator = ClassCreator.builder().classOutput(cl).className("com.MyTest").interfaces(Supplier.class).build()) {


### PR DESCRIPTION
Classes under `java.` are not always guaranteed to be visible to the current bytecode, thus we should still use TCCL to be on the safe side.

According to the documentation of `loadClassFromTCCL`:

https://github.com/quarkusio/gizmo/blob/091fe32bf498650cc0278f9f51e96bdb901ef18b/src/main/java/io/quarkus/gizmo/BytecodeCreator.java#L338-L339

On the other hand the documentation of `loadClass` makes clear that it requires the class being loaded to be accessible from the generated bytecode:

https://github.com/quarkusio/gizmo/blob/091fe32bf498650cc0278f9f51e96bdb901ef18b/src/main/java/io/quarkus/gizmo/BytecodeCreator.java#L299-L301

This PR:

* Adds tests loading a private class using both methods.
* Reverts: https://github.com/quarkusio/gizmo/commit/091fe32bf498650cc0278f9f51e96bdb901ef18b
* Fixes: https://github.com/quarkusio/quarkus/issues/28431