### PR TITLE
StringSwitch - fix hashCode collisons

### DIFF
--- a/src/main/java/io/quarkus/gizmo/EnumSwitchImpl.java
+++ b/src/main/java/io/quarkus/gizmo/EnumSwitchImpl.java
@@ -74,7 +74,7 @@ class EnumSwitchImpl<E extends Enum<E>> extends AbstractSwitch<E> implements Swi
                     if (caseBlock != null && !fallThrough) {
                         caseBlock.breakScope(EnumSwitchImpl.this);
                     } else if (caseBlock == null) {
-                        // Add empty fall through block
+                        // Add an empty fall through block
                         caseBlock = new BytecodeCreatorImpl(EnumSwitchImpl.this);
                         caseEntry.setValue(caseBlock);
                     }


### PR DESCRIPTION
- the previous impl should be functionally equivalent but less efficient if a tested value has the same hashCode as one of the labels but none of the labels is equal to the tested value