### PR TITLE
Introduce SignatureBuilder API

### DIFF
--- a/src/main/java/io/quarkus/gizmo/ClassSignatureBuilderImpl.java
+++ b/src/main/java/io/quarkus/gizmo/ClassSignatureBuilderImpl.java
@@ -1,0 +1,93 @@
+package io.quarkus.gizmo;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.jboss.jandex.DotName;
+
+import io.quarkus.gizmo.SignatureBuilder.ClassSignatureBuilder;
+import io.quarkus.gizmo.Type.ClassType;
+import io.quarkus.gizmo.Type.ParameterizedType;
+import io.quarkus.gizmo.Type.TypeVariable;
+
+class ClassSignatureBuilderImpl implements ClassSignatureBuilder {
+
+    private Type superClass = Type.classType(DotName.OBJECT_NAME);
+    private List<TypeVariable> typeParameters = new ArrayList<>();
+    private List<Type> superInterfaces = new ArrayList<>();
+
+    @Override
+    public String build() {
+        StringBuilder signature = new StringBuilder();
+
+        // type params
+        if (!typeParameters.isEmpty()) {
+            signature.append('<');
+            for (TypeVariable typeParameter : typeParameters) {
+                typeParameter.appendTypeParameterToSignature(signature);
+            }
+            signature.append('>');
+        }
+
+        // superclass
+        signature.append(superClass.toSignature());
+
+        // interfaces
+        if (!superInterfaces.isEmpty()) {
+            for (Type superInterface : superInterfaces) {
+                signature.append(superInterface.toSignature());
+            }
+        }
+        return signature.toString();
+    }
+
+    @Override
+    public ClassSignatureBuilder addTypeParameter(TypeVariable typeParameter) {
+        typeParameters.add(typeParameter);
+        return this;
+    }
+
+    @Override
+    public ClassSignatureBuilder setSuperClass(ClassType superClass) {
+        this.superClass = superClass;
+        return this;
+    }
+
+    @Override
+    public ClassSignatureBuilder setSuperClass(ParameterizedType superClass) {
+        if (containsWildcard(superClass)) {
+            throw new IllegalArgumentException("A super type may not specify a wilcard");
+        }
+        this.superClass = superClass;
+        return this;
+    }
+
+    @Override
+    public ClassSignatureBuilder addSuperInterface(ClassType interfaceType) {
+        superInterfaces.add(interfaceType);
+        return this;
+    }
+
+    @Override
+    public ClassSignatureBuilder addSuperInterface(ParameterizedType interfaceType) {
+        if (containsWildcard(interfaceType)) {
+            throw new IllegalArgumentException("A super type may not specify a wilcard");
+        }
+        superInterfaces.add(interfaceType);
+        return this;
+    }
+
+    private boolean containsWildcard(Type type) {
+        if (type.isWildcard()) {
+            return true;
+        } else if (type.isParameterizedType()) {
+            for (Type typeArgument : type.asParameterizedType().typeArguments) {
+                if (containsWildcard(typeArgument)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+}

--- a/src/main/java/io/quarkus/gizmo/ClassSignatureBuilderImpl.java
+++ b/src/main/java/io/quarkus/gizmo/ClassSignatureBuilderImpl.java
@@ -9,9 +9,10 @@ import io.quarkus.gizmo.Type.ParameterizedType;
 import io.quarkus.gizmo.Type.TypeVariable;
 
 class ClassSignatureBuilderImpl implements ClassSignatureBuilder {
-    private List<TypeVariable> typeParameters = new ArrayList<>();
-    private Type superClass = ClassType.OBJECT;
-    private List<Type> superInterfaces = new ArrayList<>();
+    
+    List<TypeVariable> typeParameters = new ArrayList<>();
+    Type superClass = ClassType.OBJECT;
+    List<Type> superInterfaces = new ArrayList<>();
 
     @Override
     public String build() {

--- a/src/main/java/io/quarkus/gizmo/ClassSignatureBuilderImpl.java
+++ b/src/main/java/io/quarkus/gizmo/ClassSignatureBuilderImpl.java
@@ -61,13 +61,13 @@ class ClassSignatureBuilderImpl implements ClassSignatureBuilder {
     }
 
     @Override
-    public ClassSignatureBuilder addSuperInterface(ClassType interfaceType) {
+    public ClassSignatureBuilder addInterface(ClassType interfaceType) {
         superInterfaces.add(interfaceType);
         return this;
     }
 
     @Override
-    public ClassSignatureBuilder addSuperInterface(ParameterizedType interfaceType) {
+    public ClassSignatureBuilder addInterface(ParameterizedType interfaceType) {
         if (containsWildcard(interfaceType)) {
             throw new IllegalArgumentException("A super type may not specify a wilcard");
         }

--- a/src/main/java/io/quarkus/gizmo/ClassSignatureBuilderImpl.java
+++ b/src/main/java/io/quarkus/gizmo/ClassSignatureBuilderImpl.java
@@ -3,17 +3,14 @@ package io.quarkus.gizmo;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.jboss.jandex.DotName;
-
 import io.quarkus.gizmo.SignatureBuilder.ClassSignatureBuilder;
 import io.quarkus.gizmo.Type.ClassType;
 import io.quarkus.gizmo.Type.ParameterizedType;
 import io.quarkus.gizmo.Type.TypeVariable;
 
 class ClassSignatureBuilderImpl implements ClassSignatureBuilder {
-
-    private Type superClass = Type.classType(DotName.OBJECT_NAME);
     private List<TypeVariable> typeParameters = new ArrayList<>();
+    private Type superClass = ClassType.OBJECT;
     private List<Type> superInterfaces = new ArrayList<>();
 
     @Override
@@ -30,12 +27,12 @@ class ClassSignatureBuilderImpl implements ClassSignatureBuilder {
         }
 
         // superclass
-        signature.append(superClass.toSignature());
+        superClass.appendToSignature(signature);
 
         // interfaces
         if (!superInterfaces.isEmpty()) {
             for (Type superInterface : superInterfaces) {
-                signature.append(superInterface.toSignature());
+                superInterface.appendToSignature(signature);
             }
         }
         return signature.toString();
@@ -58,6 +55,7 @@ class ClassSignatureBuilderImpl implements ClassSignatureBuilder {
         if (containsWildcard(superClass)) {
             throw new IllegalArgumentException("A super type may not specify a wilcard");
         }
+
         this.superClass = superClass;
         return this;
     }
@@ -81,7 +79,7 @@ class ClassSignatureBuilderImpl implements ClassSignatureBuilder {
         if (type.isWildcard()) {
             return true;
         } else if (type.isParameterizedType()) {
-            for (Type typeArgument : type.asParameterizedType().typeArguments) {
+            for (Type typeArgument : type.asParameterizedType().getTypeArguments()) {
                 if (containsWildcard(typeArgument)) {
                     return true;
                 }
@@ -89,5 +87,4 @@ class ClassSignatureBuilderImpl implements ClassSignatureBuilder {
         }
         return false;
     }
-
 }

--- a/src/main/java/io/quarkus/gizmo/ClassSignatureBuilderImpl.java
+++ b/src/main/java/io/quarkus/gizmo/ClassSignatureBuilderImpl.java
@@ -9,7 +9,7 @@ import io.quarkus.gizmo.Type.ParameterizedType;
 import io.quarkus.gizmo.Type.TypeVariable;
 
 class ClassSignatureBuilderImpl implements ClassSignatureBuilder {
-    
+
     List<TypeVariable> typeParameters = new ArrayList<>();
     Type superClass = ClassType.OBJECT;
     List<Type> superInterfaces = new ArrayList<>();
@@ -54,7 +54,7 @@ class ClassSignatureBuilderImpl implements ClassSignatureBuilder {
     @Override
     public ClassSignatureBuilder setSuperClass(ParameterizedType superClass) {
         if (containsWildcard(superClass)) {
-            throw new IllegalArgumentException("A super type may not specify a wilcard");
+            throw new IllegalArgumentException("An extended class type may not specify a wildcard");
         }
 
         this.superClass = superClass;
@@ -70,7 +70,7 @@ class ClassSignatureBuilderImpl implements ClassSignatureBuilder {
     @Override
     public ClassSignatureBuilder addInterface(ParameterizedType interfaceType) {
         if (containsWildcard(interfaceType)) {
-            throw new IllegalArgumentException("A super type may not specify a wilcard");
+            throw new IllegalArgumentException("An implemented interface type may not specify a wildcard");
         }
         superInterfaces.add(interfaceType);
         return this;

--- a/src/main/java/io/quarkus/gizmo/FieldSignatureBuilderImpl.java
+++ b/src/main/java/io/quarkus/gizmo/FieldSignatureBuilderImpl.java
@@ -5,12 +5,13 @@ import java.util.Objects;
 import io.quarkus.gizmo.SignatureBuilder.FieldSignatureBuilder;
 
 class FieldSignatureBuilderImpl implements FieldSignatureBuilder {
-
     private Type type;
 
     @Override
     public String build() {
-        return type.toSignature();
+        StringBuilder signature = new StringBuilder();
+        type.appendToSignature(signature);
+        return signature.toString();
     }
 
     @Override
@@ -18,5 +19,4 @@ class FieldSignatureBuilderImpl implements FieldSignatureBuilder {
         this.type = Objects.requireNonNull(type);
         return this;
     }
-
 }

--- a/src/main/java/io/quarkus/gizmo/FieldSignatureBuilderImpl.java
+++ b/src/main/java/io/quarkus/gizmo/FieldSignatureBuilderImpl.java
@@ -1,0 +1,22 @@
+package io.quarkus.gizmo;
+
+import java.util.Objects;
+
+import io.quarkus.gizmo.SignatureBuilder.FieldSignatureBuilder;
+
+class FieldSignatureBuilderImpl implements FieldSignatureBuilder {
+
+    private Type type;
+
+    @Override
+    public String build() {
+        return type.toSignature();
+    }
+
+    @Override
+    public FieldSignatureBuilder setType(Type type) {
+        this.type = Objects.requireNonNull(type);
+        return this;
+    }
+
+}

--- a/src/main/java/io/quarkus/gizmo/MethodSignatureBuilderImpl.java
+++ b/src/main/java/io/quarkus/gizmo/MethodSignatureBuilderImpl.java
@@ -1,0 +1,80 @@
+package io.quarkus.gizmo;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import io.quarkus.gizmo.SignatureBuilder.MethodSignatureBuilder;
+import io.quarkus.gizmo.Type.ClassType;
+import io.quarkus.gizmo.Type.TypeVariable;
+
+class MethodSignatureBuilderImpl implements MethodSignatureBuilder {
+
+    private Type returnType = Type.voidType();
+    private List<Type> parameterTypes = new ArrayList<>();
+    private List<TypeVariable> typeParameters = new ArrayList<>();
+    private List<Type> exceptions = new ArrayList<>();
+
+    @Override
+    public String build() {
+        StringBuilder signature = new StringBuilder();
+
+        // type params
+        if (!typeParameters.isEmpty()) {
+            signature.append('<');
+            for (TypeVariable typeParameter : typeParameters) {
+                typeParameter.appendTypeParameterToSignature(signature);
+            }
+            signature.append('>');
+        }
+
+        // params
+        signature.append('(');
+        for (Type parameterType : parameterTypes) {
+            signature.append(parameterType.toSignature());
+        }
+        signature.append(')');
+
+        // return type
+        signature.append(returnType.toSignature());
+
+        // exceptions
+        if (!exceptions.isEmpty()) {
+            for (Type exceptionType : exceptions) {
+                signature.append('^').append(exceptionType.toSignature());
+            }
+        }
+        return signature.toString();
+    }
+
+    @Override
+    public MethodSignatureBuilder addTypeParameter(TypeVariable typeParameter) {
+        typeParameters.add(Objects.requireNonNull(typeParameter));
+        return this;
+    }
+
+    @Override
+    public MethodSignatureBuilder setReturnType(Type returnType) {
+        this.returnType = Objects.requireNonNull(returnType);
+        return this;
+    }
+
+    @Override
+    public MethodSignatureBuilder addParameter(Type parameterType) {
+        this.parameterTypes.add(Objects.requireNonNull(parameterType));
+        return this;
+    }
+
+    @Override
+    public MethodSignatureBuilder addException(ClassType exceptionType) {
+        this.exceptions.add(Objects.requireNonNull(exceptionType));
+        return this;
+    }
+
+    @Override
+    public MethodSignatureBuilder addException(TypeVariable exceptionType) {
+        this.exceptions.add(Objects.requireNonNull(exceptionType));
+        return this;
+    }
+
+}

--- a/src/main/java/io/quarkus/gizmo/MethodSignatureBuilderImpl.java
+++ b/src/main/java/io/quarkus/gizmo/MethodSignatureBuilderImpl.java
@@ -7,12 +7,12 @@ import java.util.Objects;
 import io.quarkus.gizmo.SignatureBuilder.MethodSignatureBuilder;
 import io.quarkus.gizmo.Type.ClassType;
 import io.quarkus.gizmo.Type.TypeVariable;
+import io.quarkus.gizmo.Type.VoidType;
 
 class MethodSignatureBuilderImpl implements MethodSignatureBuilder {
-
-    private Type returnType = Type.voidType();
-    private List<Type> parameterTypes = new ArrayList<>();
     private List<TypeVariable> typeParameters = new ArrayList<>();
+    private Type returnType = VoidType.INSTANCE;
+    private List<Type> parameterTypes = new ArrayList<>();
     private List<Type> exceptions = new ArrayList<>();
 
     @Override
@@ -28,22 +28,24 @@ class MethodSignatureBuilderImpl implements MethodSignatureBuilder {
             signature.append('>');
         }
 
-        // params
+        // param types
         signature.append('(');
         for (Type parameterType : parameterTypes) {
-            signature.append(parameterType.toSignature());
+            parameterType.appendToSignature(signature);
         }
         signature.append(')');
 
         // return type
-        signature.append(returnType.toSignature());
+        returnType.appendToSignature(signature);
 
-        // exceptions
+        // exception types
         if (!exceptions.isEmpty()) {
             for (Type exceptionType : exceptions) {
-                signature.append('^').append(exceptionType.toSignature());
+                signature.append('^');
+                exceptionType.appendToSignature(signature);
             }
         }
+
         return signature.toString();
     }
 
@@ -60,7 +62,7 @@ class MethodSignatureBuilderImpl implements MethodSignatureBuilder {
     }
 
     @Override
-    public MethodSignatureBuilder addParameter(Type parameterType) {
+    public MethodSignatureBuilder addParameterType(Type parameterType) {
         this.parameterTypes.add(Objects.requireNonNull(parameterType));
         return this;
     }
@@ -76,5 +78,4 @@ class MethodSignatureBuilderImpl implements MethodSignatureBuilder {
         this.exceptions.add(Objects.requireNonNull(exceptionType));
         return this;
     }
-
 }

--- a/src/main/java/io/quarkus/gizmo/SignatureBuilder.java
+++ b/src/main/java/io/quarkus/gizmo/SignatureBuilder.java
@@ -37,9 +37,9 @@ public interface SignatureBuilder {
         
         ClassSignatureBuilder setSuperClass(ParameterizedType superClass);
 
-        ClassSignatureBuilder addSuperInterface(ClassType interfaceType);
+        ClassSignatureBuilder addInterface(ClassType interfaceType);
         
-        ClassSignatureBuilder addSuperInterface(ParameterizedType interfaceType);
+        ClassSignatureBuilder addInterface(ParameterizedType interfaceType);
     }
 
     /**

--- a/src/main/java/io/quarkus/gizmo/SignatureBuilder.java
+++ b/src/main/java/io/quarkus/gizmo/SignatureBuilder.java
@@ -1,0 +1,62 @@
+package io.quarkus.gizmo;
+
+import io.quarkus.gizmo.Type.ClassType;
+import io.quarkus.gizmo.Type.ParameterizedType;
+import io.quarkus.gizmo.Type.TypeVariable;
+
+/**
+ * Builds a signature as defined in JVMS 17, chapter "4.7.9.1. Signatures".
+ * 
+ * @see SignatureElement#setSignature(String)
+ */
+public interface SignatureBuilder {
+
+    static ClassSignatureBuilder forClass() {
+        return new ClassSignatureBuilderImpl();
+    }
+
+    static MethodSignatureBuilder forMethod() {
+        return new MethodSignatureBuilderImpl();
+    }
+
+    static FieldSignatureBuilder forField() {
+        return new FieldSignatureBuilderImpl();
+    }
+
+    /**
+     * @return the signature
+     */
+    String build();
+
+    interface ClassSignatureBuilder extends SignatureBuilder {
+
+        ClassSignatureBuilder addTypeParameter(TypeVariable typeParameter);
+
+        ClassSignatureBuilder setSuperClass(ClassType superClass);
+        
+        ClassSignatureBuilder setSuperClass(ParameterizedType superClass);
+
+        ClassSignatureBuilder addSuperInterface(ClassType interfaceType);
+        
+        ClassSignatureBuilder addSuperInterface(ParameterizedType interfaceType);
+    }
+
+    interface MethodSignatureBuilder extends SignatureBuilder {
+
+        MethodSignatureBuilder addTypeParameter(TypeVariable typeParameter);
+
+        MethodSignatureBuilder setReturnType(Type returnType);
+
+        MethodSignatureBuilder addParameter(Type parameter);
+
+        MethodSignatureBuilder addException(ClassType exceptionType);
+        
+        MethodSignatureBuilder addException(TypeVariable exceptionType);
+    }
+
+    interface FieldSignatureBuilder extends SignatureBuilder {
+
+        FieldSignatureBuilder setType(Type type);
+    }
+
+}

--- a/src/main/java/io/quarkus/gizmo/SignatureBuilder.java
+++ b/src/main/java/io/quarkus/gizmo/SignatureBuilder.java
@@ -5,12 +5,11 @@ import io.quarkus.gizmo.Type.ParameterizedType;
 import io.quarkus.gizmo.Type.TypeVariable;
 
 /**
- * Builds a signature as defined in JVMS 17, chapter "4.7.9.1. Signatures".
+ * Builds a generic signature as defined in JVMS 17, chapter "4.7.9.1. Signatures".
  * 
  * @see SignatureElement#setSignature(String)
  */
 public interface SignatureBuilder {
-
     static ClassSignatureBuilder forClass() {
         return new ClassSignatureBuilderImpl();
     }
@@ -24,12 +23,14 @@ public interface SignatureBuilder {
     }
 
     /**
-     * @return the signature
+     * @return the generic signature
      */
     String build();
 
+    /**
+     * Builds a generic signature of a class (including interfaces).
+     */
     interface ClassSignatureBuilder extends SignatureBuilder {
-
         ClassSignatureBuilder addTypeParameter(TypeVariable typeParameter);
 
         ClassSignatureBuilder setSuperClass(ClassType superClass);
@@ -41,22 +42,25 @@ public interface SignatureBuilder {
         ClassSignatureBuilder addSuperInterface(ParameterizedType interfaceType);
     }
 
+    /**
+     * Builds a generic signature of a method (including constructors).
+     */
     interface MethodSignatureBuilder extends SignatureBuilder {
-
         MethodSignatureBuilder addTypeParameter(TypeVariable typeParameter);
 
         MethodSignatureBuilder setReturnType(Type returnType);
 
-        MethodSignatureBuilder addParameter(Type parameter);
+        MethodSignatureBuilder addParameterType(Type parameterType);
 
         MethodSignatureBuilder addException(ClassType exceptionType);
         
         MethodSignatureBuilder addException(TypeVariable exceptionType);
     }
 
+    /**
+     * Builds a generic signature of a field. Also usable for building generic signatures of record components.
+     */
     interface FieldSignatureBuilder extends SignatureBuilder {
-
         FieldSignatureBuilder setType(Type type);
     }
-
 }

--- a/src/main/java/io/quarkus/gizmo/SignatureElement.java
+++ b/src/main/java/io/quarkus/gizmo/SignatureElement.java
@@ -1,11 +1,18 @@
 package io.quarkus.gizmo;
 
 /**
- * An element that has a signature attribute
+ * An element that has a signature attribute.
  */
 public interface SignatureElement<S> {
 
     String getSignature();
 
+    /**
+     * Use the convenient {@link SignatureBuilder} to build signatures for classes, methods and fields.
+     * 
+     * @param signature The signature as defined in JVMS 17, chapter "4.7.9.1. Signatures"
+     * @return the element
+     * @see SignatureBuilder
+     */
     S setSignature(String signature);
 }

--- a/src/main/java/io/quarkus/gizmo/SignatureElement.java
+++ b/src/main/java/io/quarkus/gizmo/SignatureElement.java
@@ -10,7 +10,7 @@ public interface SignatureElement<S> {
     /**
      * Use the convenient {@link SignatureBuilder} to build signatures for classes, methods and fields.
      * 
-     * @param signature The signature as defined in JVMS 17, chapter "4.7.9.1. Signatures"
+     * @param signature The generic signature as defined in JVMS 17, chapter "4.7.9.1. Signatures"
      * @return the element
      * @see SignatureBuilder
      */

--- a/src/main/java/io/quarkus/gizmo/Type.java
+++ b/src/main/java/io/quarkus/gizmo/Type.java
@@ -1,0 +1,464 @@
+package io.quarkus.gizmo;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.PrimitiveType.Primitive;
+
+/**
+ * This interface can be used to build a JVM signature for classes, methods and fields.
+ * <p>
+ * Implementations are instantiated via factory methods; for example {@link #voidType()} and {@link #classType(Class)}.
+ * 
+ * @see SignatureBuilder
+ */
+public interface Type {
+
+    // Factory methods
+
+    public static VoidType voidType() {
+        return VoidType.INSTANCE;
+    }
+
+    public static PrimitiveType byteType() {
+        return PrimitiveType.BYTE;
+    }
+
+    public static PrimitiveType booleanType() {
+        return PrimitiveType.BOOLEAN;
+    }
+
+    public static PrimitiveType intType() {
+        return PrimitiveType.INT;
+    }
+
+    public static PrimitiveType longType() {
+        return PrimitiveType.LONG;
+    }
+
+    public static PrimitiveType shortType() {
+        return PrimitiveType.SHORT;
+    }
+
+    public static PrimitiveType doubleType() {
+        return PrimitiveType.DOUBLE;
+    }
+
+    public static PrimitiveType floatType() {
+        return PrimitiveType.FLOAT;
+    }
+
+    public static PrimitiveType charType() {
+        return PrimitiveType.CHAR;
+    }
+
+    public static ClassType classType(DotName name) {
+        return classType(Objects.requireNonNull(name).toString().replace('.', '/'));
+    }
+
+    public static ClassType classType(String name) {
+        return new ClassType(name, null);
+    }
+
+    public static ClassType classType(Class<?> classType) {
+        return classType(Objects.requireNonNull(classType).getName().replace('.', '/'));
+    }
+
+    public static ParameterizedType parameterizedType(ClassType classType, Type... typeArguments) {
+        if (typeArguments.length == 0) {
+            throw new IllegalArgumentException("No type arguments");
+        }
+        return new ParameterizedType(classType, Arrays.asList(typeArguments), null);
+    }
+
+    public static ArrayType arrayType(Type elementType) {
+        return new ArrayType(elementType, 1);
+    }
+
+    public static ArrayType arrayType(Type elementType, int dimensions) {
+        return new ArrayType(elementType, dimensions);
+    }
+
+    public static TypeVariable typeVariable(String name) {
+        return typeVariable(name, ClassType.OBJECT);
+    }
+
+    public static TypeVariable typeVariable(String name, Type classBound, Type... interfaceBounds) {
+        return new TypeVariable(name, classBound, Arrays.asList(interfaceBounds));
+    }
+
+    public static WildcardType wildcardTypeWithUpperBound(Type bound) {
+        return new WildcardType(bound, null);
+    }
+
+    public static WildcardType wildcardTypeWithLowerBound(Type bound) {
+        return new WildcardType(null, bound);
+    }
+
+    public static WildcardType wildcardTypeUnbounded() {
+        return new WildcardType(ClassType.OBJECT, null);
+    }
+
+    /**
+     * 
+     * @param signature
+     */
+    void appendToSignature(StringBuilder signature);
+
+    /**
+     * 
+     * @return the signature as defined in JVMS 17, chapter "4.7.9.1. Signatures"
+     */
+    default String toSignature() {
+        StringBuilder sb = new StringBuilder();
+        appendToSignature(sb);
+        return sb.toString();
+    }
+
+    default boolean isVoid() {
+        return false;
+    }
+
+    default boolean isPrimitive() {
+        return false;
+    }
+
+    default boolean isClass() {
+        return false;
+    }
+
+    default boolean isArray() {
+        return false;
+    }
+
+    default boolean isParameterizedType() {
+        return false;
+    }
+
+    default boolean isTypeVariable() {
+        return false;
+    }
+
+    default boolean isWildcard() {
+        return false;
+    }
+
+    default VoidType asVoid() {
+        throw new IllegalStateException("Not a void");
+    }
+
+    default PrimitiveType asPrimitive() {
+        throw new IllegalStateException("Not a primitive");
+    }
+
+    default ClassType asClass() {
+        throw new IllegalStateException("Not a class");
+    }
+
+    default ArrayType asArray() {
+        throw new IllegalStateException("Not an array");
+    }
+
+    default ParameterizedType asParameterizedType() {
+        throw new IllegalStateException("Not a parameterized type");
+    }
+
+    default TypeVariable asTypeVariable() {
+        throw new IllegalStateException("Not a type variable");
+    }
+
+    default WildcardType asWildcard() {
+        throw new IllegalStateException("Not a wildcard type");
+    }
+
+    // Implementations
+
+    public static class WildcardType implements Type {
+
+        final Type lowerBound;
+        final Type upperBound;
+
+        WildcardType(Type upperBound, Type lowerBound) {
+            if (upperBound == null && lowerBound == null) {
+                throw new NullPointerException();
+            }
+            this.upperBound = upperBound;
+            this.lowerBound = lowerBound;
+        }
+
+        @Override
+        public boolean isWildcard() {
+            return true;
+        }
+
+        @Override
+        public WildcardType asWildcard() {
+            return this;
+        }
+
+        @Override
+        public void appendToSignature(StringBuilder signature) {
+            if (lowerBound != null) {
+                signature.append('-').append(lowerBound.toSignature());
+            } else if (upperBound.isClass() && upperBound.asClass().name.equals(ClassType.OBJECT.name)) {
+                signature.append('*');
+            } else {
+                signature.append('+').append(upperBound.toSignature());
+            }
+        }
+
+    }
+
+    public static class TypeVariable implements Type {
+
+        final String name;
+        final Type classBound;
+        final List<Type> interfaceBounds;
+
+        TypeVariable(String name, Type classBound, List<Type> interfaceBounds) {
+            this.name = Objects.requireNonNull(name);
+            this.classBound = classBound;
+            this.interfaceBounds = interfaceBounds;
+        }
+
+        @Override
+        public void appendToSignature(StringBuilder signature) {
+            signature.append('T').append(name).append(';').toString();
+        }
+
+        public void appendTypeParameterToSignature(StringBuilder signature) {
+            signature.append(name).append(":");
+            if (classBound != null) {
+                signature.append(classBound.toSignature());
+            }
+            for (Type bound : interfaceBounds) {
+                signature.append(":").append(bound.toSignature());
+            }
+        }
+
+        @Override
+        public boolean isTypeVariable() {
+            return true;
+        }
+
+        @Override
+        public TypeVariable asTypeVariable() {
+            return this;
+        }
+
+    }
+
+    public static class ArrayType implements Type {
+
+        final Type elementType;
+        final int dimensions;
+
+        ArrayType(Type elementType, int dimensions) {
+            this.elementType = Objects.requireNonNull(elementType);
+            this.dimensions = dimensions;
+        }
+
+        @Override
+        public void appendToSignature(StringBuilder signature) {
+            for (int i = 0; i < dimensions; i++) {
+                signature.append('[');
+            }
+            signature.append(elementType.toSignature());
+        }
+
+        @Override
+        public boolean isArray() {
+            return true;
+        }
+
+        @Override
+        public ArrayType asArray() {
+            return this;
+        }
+
+    }
+
+    public static class ParameterizedType implements Type {
+
+        final ClassType classType;
+        final List<Type> typeArguments;
+        final Type declaringClassType;
+
+        ParameterizedType(ClassType classType, List<Type> typeArguments, Type declaringClassType) {
+            this.classType = Objects.requireNonNull(classType);
+            this.typeArguments = typeArguments;
+            this.declaringClassType = declaringClassType;
+        }
+
+        @Override
+        public void appendToSignature(StringBuilder signature) {
+            if (declaringClassType != null) {
+                // Append the declaring class and remove the last semicolon
+                declaringClassType.appendToSignature(signature);
+                signature.deleteCharAt(signature.length() - 1);
+                signature.append('.');
+            } else {
+                signature.append('L');
+            }
+            signature.append(classType.name);
+            if (!typeArguments.isEmpty()) {
+                signature.append('<');
+                for (Type argument : typeArguments) {
+                    signature.append(argument.toSignature());
+                }
+                signature.append('>');
+            }
+            signature.append(';');
+        }
+
+        @Override
+        public boolean isParameterizedType() {
+            return true;
+        }
+
+        @Override
+        public ParameterizedType asParameterizedType() {
+            return this;
+        }
+
+        /**
+         * Build a signature like <code>Lorg/acme/Parent<TT;>.Inner;</code>.
+         * 
+         * @param simpleName
+         * @return the nested class
+         */
+        public ClassType nestedClassType(String simpleName) {
+            return new ClassType(simpleName, this);
+        }
+
+        /**
+         * Build a signature like <code>Lorg/acme/Parent<TT;>.Inner<TU;>;</code>.
+         * 
+         * @param simpleName
+         * @return the nested class
+         */
+        public ParameterizedType nestedParameterizedType(String simpleName, Type... typeArguments) {
+            return new ParameterizedType(Type.classType(simpleName), Arrays.asList(typeArguments), this);
+        }
+
+    }
+
+    public static class ClassType implements Type {
+
+        public static ClassType OBJECT = classType(DotName.OBJECT_NAME);
+
+        final String name;
+        final Type declaringClassType;
+
+        ClassType(String name, Type declaringClassType) {
+            this.name = Objects.requireNonNull(name);
+            this.declaringClassType = declaringClassType;
+        }
+
+        @Override
+        public void appendToSignature(StringBuilder signature) {
+            if (declaringClassType != null) {
+                // Append the declaring class and remove the last semicolon
+                declaringClassType.appendToSignature(signature);
+                signature.deleteCharAt(signature.length() - 1);
+                signature.append('.');
+            } else {
+                signature.append('L');
+            }
+            signature.append(name).append(';');
+        }
+
+        @Override
+        public boolean isClass() {
+            return true;
+        }
+
+        @Override
+        public ClassType asClass() {
+            return this;
+        }
+
+    }
+
+    public static class VoidType implements Type {
+
+        public static final VoidType INSTANCE = new VoidType();
+
+        @Override
+        public void appendToSignature(StringBuilder signature) {
+            signature.append("V");
+        }
+
+        @Override
+        public boolean isVoid() {
+            return true;
+        }
+
+        @Override
+        public VoidType asVoid() {
+            return this;
+        }
+
+    }
+
+    public static class PrimitiveType implements Type {
+
+        public static final PrimitiveType BYTE = new PrimitiveType(Primitive.BYTE);
+        public static final PrimitiveType CHAR = new PrimitiveType(Primitive.CHAR);
+        public static final PrimitiveType DOUBLE = new PrimitiveType(Primitive.DOUBLE);
+        public static final PrimitiveType FLOAT = new PrimitiveType(Primitive.FLOAT);
+        public static final PrimitiveType INT = new PrimitiveType(Primitive.INT);
+        public static final PrimitiveType LONG = new PrimitiveType(Primitive.LONG);
+        public static final PrimitiveType SHORT = new PrimitiveType(Primitive.SHORT);
+        public static final PrimitiveType BOOLEAN = new PrimitiveType(Primitive.BOOLEAN);
+
+        final Primitive primitive;
+
+        PrimitiveType(Primitive primitive) {
+            this.primitive = Objects.requireNonNull(primitive);
+        }
+
+        @Override
+        public void appendToSignature(StringBuilder signature) {
+            signature.append(toSignature());
+        }
+
+        @Override
+        public String toSignature() {
+            switch (primitive) {
+                case BOOLEAN:
+                    return "Z";
+                case BYTE:
+                    return "B";
+                case CHAR:
+                    return "C";
+                case DOUBLE:
+                    return "D";
+                case FLOAT:
+                    return "F";
+                case INT:
+                    return "I";
+                case LONG:
+                    return "J";
+                case SHORT:
+                    return "S";
+                default:
+                    throw new IllegalStateException();
+            }
+        }
+
+        @Override
+        public boolean isPrimitive() {
+            return true;
+        }
+
+        @Override
+        public PrimitiveType asPrimitive() {
+            return this;
+        }
+
+    }
+
+}

--- a/src/main/java/io/quarkus/gizmo/Type.java
+++ b/src/main/java/io/quarkus/gizmo/Type.java
@@ -260,8 +260,8 @@ public abstract class Type {
     public static final class ClassType extends Type {
         public static final ClassType OBJECT = new ClassType("java/lang/Object", null);
 
-        private final String name; // always slash-delimited
-        private final Type owner;
+        final String name; // always slash-delimited
+        final Type owner;
 
         ClassType(String name, Type owner) {
             this.name = Objects.requireNonNull(name);
@@ -344,9 +344,10 @@ public abstract class Type {
     }
 
     public static final class ParameterizedType extends Type {
-        private final ClassType genericClass;
-        private final List<Type> typeArguments;
-        private final Type owner;
+        
+        final ClassType genericClass;
+        final List<Type> typeArguments;
+        final Type owner;
 
         ParameterizedType(ClassType genericClass, List<Type> typeArguments, Type owner) {
             this.genericClass = Objects.requireNonNull(genericClass);

--- a/src/main/java/io/quarkus/gizmo/Type.java
+++ b/src/main/java/io/quarkus/gizmo/Type.java
@@ -1,6 +1,7 @@
 package io.quarkus.gizmo;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
@@ -8,26 +9,29 @@ import org.jboss.jandex.DotName;
 import org.jboss.jandex.PrimitiveType.Primitive;
 
 /**
- * This interface can be used to build a JVM signature for classes, methods and fields.
+ * Used to express types when {@linkplain SignatureBuilder building} a generic signature of some declaration.
  * <p>
- * Implementations are instantiated via factory methods; for example {@link #voidType()} and {@link #classType(Class)}.
+ * Implementations are created via factory methods such as {@link #voidType()} and {@link #classType(Class)}.
  * 
  * @see SignatureBuilder
  */
-public interface Type {
-
+public abstract class Type {
     // Factory methods
 
     public static VoidType voidType() {
         return VoidType.INSTANCE;
     }
 
+    public static PrimitiveType booleanType() {
+        return PrimitiveType.BOOLEAN;
+    }
+
     public static PrimitiveType byteType() {
         return PrimitiveType.BYTE;
     }
 
-    public static PrimitiveType booleanType() {
-        return PrimitiveType.BOOLEAN;
+    public static PrimitiveType shortType() {
+        return PrimitiveType.SHORT;
     }
 
     public static PrimitiveType intType() {
@@ -38,39 +42,35 @@ public interface Type {
         return PrimitiveType.LONG;
     }
 
-    public static PrimitiveType shortType() {
-        return PrimitiveType.SHORT;
+    public static PrimitiveType floatType() {
+        return PrimitiveType.FLOAT;
     }
 
     public static PrimitiveType doubleType() {
         return PrimitiveType.DOUBLE;
     }
 
-    public static PrimitiveType floatType() {
-        return PrimitiveType.FLOAT;
-    }
-
     public static PrimitiveType charType() {
         return PrimitiveType.CHAR;
     }
 
-    public static ClassType classType(DotName name) {
-        return classType(Objects.requireNonNull(name).toString().replace('.', '/'));
+    public static ClassType classType(DotName className) {
+        return classType(className.toString());
     }
 
-    public static ClassType classType(String name) {
-        return new ClassType(name, null);
+    public static ClassType classType(String className) {
+        return new ClassType(className.replace('.', '/'), null);
     }
 
-    public static ClassType classType(Class<?> classType) {
-        return classType(Objects.requireNonNull(classType).getName().replace('.', '/'));
+    public static ClassType classType(Class<?> clazz) {
+        return classType(clazz.getName());
     }
 
-    public static ParameterizedType parameterizedType(ClassType classType, Type... typeArguments) {
+    public static ParameterizedType parameterizedType(ClassType genericClass, Type... typeArguments) {
         if (typeArguments.length == 0) {
             throw new IllegalArgumentException("No type arguments");
         }
-        return new ParameterizedType(classType, Arrays.asList(typeArguments), null);
+        return new ParameterizedType(genericClass, Arrays.asList(typeArguments), null);
     }
 
     public static ArrayType arrayType(Type elementType) {
@@ -85,285 +85,219 @@ public interface Type {
         return typeVariable(name, ClassType.OBJECT);
     }
 
+    public static TypeVariable typeVariable(String name, Type classOrTypeVariableBound) {
+        Type bound = Objects.requireNonNull(classOrTypeVariableBound);
+        if (!bound.isClass() && !bound.isParameterizedType() && !bound.isTypeVariable()) {
+            throw new IllegalArgumentException("Type variable bound must be a class or a type variable");
+        }
+        return new TypeVariable(name, bound, Collections.emptyList());
+    }
+
     public static TypeVariable typeVariable(String name, Type classBound, Type... interfaceBounds) {
+        if (classBound != null && !classBound.isClass() && !classBound.isParameterizedType()) {
+            throw new IllegalArgumentException("First type variable bound must be a class");
+        }
+        for (Type interfaceBound : interfaceBounds) {
+            if (!interfaceBound.isClass() && !interfaceBound.isParameterizedType()) {
+                throw new IllegalArgumentException("Next type variable bounds must all be interfaces");
+            }
+        }
+
         return new TypeVariable(name, classBound, Arrays.asList(interfaceBounds));
     }
 
     public static WildcardType wildcardTypeWithUpperBound(Type bound) {
-        return new WildcardType(bound, null);
+        return new WildcardType(Objects.requireNonNull(bound), null);
     }
 
     public static WildcardType wildcardTypeWithLowerBound(Type bound) {
-        return new WildcardType(null, bound);
+        return new WildcardType(null, Objects.requireNonNull(bound));
     }
 
     public static WildcardType wildcardTypeUnbounded() {
         return new WildcardType(ClassType.OBJECT, null);
     }
 
-    /**
-     * 
-     * @param signature
-     */
-    void appendToSignature(StringBuilder signature);
+    // implementation details
 
-    /**
-     * 
-     * @return the signature as defined in JVMS 17, chapter "4.7.9.1. Signatures"
-     */
-    default String toSignature() {
-        StringBuilder sb = new StringBuilder();
-        appendToSignature(sb);
-        return sb.toString();
-    }
+    abstract void appendToSignature(StringBuilder signature);
 
-    default boolean isVoid() {
+    boolean isVoid() {
         return false;
     }
 
-    default boolean isPrimitive() {
+    boolean isPrimitive() {
         return false;
     }
 
-    default boolean isClass() {
+    boolean isClass() {
         return false;
     }
 
-    default boolean isArray() {
+    boolean isArray() {
         return false;
     }
 
-    default boolean isParameterizedType() {
+    boolean isParameterizedType() {
         return false;
     }
 
-    default boolean isTypeVariable() {
+    boolean isTypeVariable() {
         return false;
     }
 
-    default boolean isWildcard() {
+    boolean isWildcard() {
         return false;
     }
 
-    default VoidType asVoid() {
+    VoidType asVoid() {
         throw new IllegalStateException("Not a void");
     }
 
-    default PrimitiveType asPrimitive() {
+    PrimitiveType asPrimitive() {
         throw new IllegalStateException("Not a primitive");
     }
 
-    default ClassType asClass() {
+    ClassType asClass() {
         throw new IllegalStateException("Not a class");
     }
 
-    default ArrayType asArray() {
+    ArrayType asArray() {
         throw new IllegalStateException("Not an array");
     }
 
-    default ParameterizedType asParameterizedType() {
+    ParameterizedType asParameterizedType() {
         throw new IllegalStateException("Not a parameterized type");
     }
 
-    default TypeVariable asTypeVariable() {
+    TypeVariable asTypeVariable() {
         throw new IllegalStateException("Not a type variable");
     }
 
-    default WildcardType asWildcard() {
+    WildcardType asWildcard() {
         throw new IllegalStateException("Not a wildcard type");
     }
 
-    // Implementations
+    // Types
 
-    public static class WildcardType implements Type {
+    public static final class VoidType extends Type {
+        public static final VoidType INSTANCE = new VoidType();
 
-        final Type lowerBound;
-        final Type upperBound;
-
-        WildcardType(Type upperBound, Type lowerBound) {
-            if (upperBound == null && lowerBound == null) {
-                throw new NullPointerException();
-            }
-            this.upperBound = upperBound;
-            this.lowerBound = lowerBound;
+        @Override
+        void appendToSignature(StringBuilder signature) {
+            signature.append("V");
         }
 
         @Override
-        public boolean isWildcard() {
+        boolean isVoid() {
             return true;
         }
 
         @Override
-        public WildcardType asWildcard() {
+        VoidType asVoid() {
             return this;
+        }
+    }
+
+    public static final class PrimitiveType extends Type {
+        public static final PrimitiveType BOOLEAN = new PrimitiveType(Primitive.BOOLEAN);
+        public static final PrimitiveType BYTE = new PrimitiveType(Primitive.BYTE);
+        public static final PrimitiveType SHORT = new PrimitiveType(Primitive.SHORT);
+        public static final PrimitiveType INT = new PrimitiveType(Primitive.INT);
+        public static final PrimitiveType LONG = new PrimitiveType(Primitive.LONG);
+        public static final PrimitiveType FLOAT = new PrimitiveType(Primitive.FLOAT);
+        public static final PrimitiveType DOUBLE = new PrimitiveType(Primitive.DOUBLE);
+        public static final PrimitiveType CHAR = new PrimitiveType(Primitive.CHAR);
+
+        private final Primitive primitive;
+
+        PrimitiveType(Primitive primitive) {
+            this.primitive = Objects.requireNonNull(primitive);
         }
 
         @Override
-        public void appendToSignature(StringBuilder signature) {
-            if (lowerBound != null) {
-                signature.append('-').append(lowerBound.toSignature());
-            } else if (upperBound.isClass() && upperBound.asClass().name.equals(ClassType.OBJECT.name)) {
-                signature.append('*');
-            } else {
-                signature.append('+').append(upperBound.toSignature());
+        void appendToSignature(StringBuilder signature) {
+            switch (primitive) {
+                case BOOLEAN:
+                    signature.append("Z");
+                    break;
+                case BYTE:
+                    signature.append("B");
+                    break;
+                case SHORT:
+                    signature.append("S");
+                case INT:
+                    signature.append("I");
+                    break;
+                case LONG:
+                    signature.append("J");
+                    break;
+                case FLOAT:
+                    signature.append("F");
+                    break;
+                case DOUBLE:
+                    signature.append("D");
+                    break;
+                case CHAR:
+                    signature.append("C");
+                    break;
+                default:
+                    throw new IllegalStateException("Unknown primitive type: " + primitive.toString());
             }
         }
 
+        @Override
+        boolean isPrimitive() {
+            return true;
+        }
+
+        @Override
+        PrimitiveType asPrimitive() {
+            return this;
+        }
     }
 
-    public static class TypeVariable implements Type {
+    public static final class ClassType extends Type {
+        public static final ClassType OBJECT = new ClassType("java/lang/Object", null);
 
-        final String name;
-        final Type classBound;
-        final List<Type> interfaceBounds;
+        private final String name; // always slash-delimited
+        private final Type owner;
 
-        TypeVariable(String name, Type classBound, List<Type> interfaceBounds) {
+        ClassType(String name, Type owner) {
             this.name = Objects.requireNonNull(name);
-            this.classBound = classBound;
-            this.interfaceBounds = interfaceBounds;
-        }
-
-        @Override
-        public void appendToSignature(StringBuilder signature) {
-            signature.append('T').append(name).append(';').toString();
-        }
-
-        public void appendTypeParameterToSignature(StringBuilder signature) {
-            signature.append(name).append(":");
-            if (classBound != null) {
-                signature.append(classBound.toSignature());
-            }
-            for (Type bound : interfaceBounds) {
-                signature.append(":").append(bound.toSignature());
-            }
-        }
-
-        @Override
-        public boolean isTypeVariable() {
-            return true;
-        }
-
-        @Override
-        public TypeVariable asTypeVariable() {
-            return this;
-        }
-
-    }
-
-    public static class ArrayType implements Type {
-
-        final Type elementType;
-        final int dimensions;
-
-        ArrayType(Type elementType, int dimensions) {
-            this.elementType = Objects.requireNonNull(elementType);
-            this.dimensions = dimensions;
-        }
-
-        @Override
-        public void appendToSignature(StringBuilder signature) {
-            for (int i = 0; i < dimensions; i++) {
-                signature.append('[');
-            }
-            signature.append(elementType.toSignature());
-        }
-
-        @Override
-        public boolean isArray() {
-            return true;
-        }
-
-        @Override
-        public ArrayType asArray() {
-            return this;
-        }
-
-    }
-
-    public static class ParameterizedType implements Type {
-
-        final ClassType classType;
-        final List<Type> typeArguments;
-        final Type declaringClassType;
-
-        ParameterizedType(ClassType classType, List<Type> typeArguments, Type declaringClassType) {
-            this.classType = Objects.requireNonNull(classType);
-            this.typeArguments = typeArguments;
-            this.declaringClassType = declaringClassType;
-        }
-
-        @Override
-        public void appendToSignature(StringBuilder signature) {
-            if (declaringClassType != null) {
-                // Append the declaring class and remove the last semicolon
-                declaringClassType.appendToSignature(signature);
-                signature.deleteCharAt(signature.length() - 1);
-                signature.append('.');
-            } else {
-                signature.append('L');
-            }
-            signature.append(classType.name);
-            if (!typeArguments.isEmpty()) {
-                signature.append('<');
-                for (Type argument : typeArguments) {
-                    signature.append(argument.toSignature());
-                }
-                signature.append('>');
-            }
-            signature.append(';');
-        }
-
-        @Override
-        public boolean isParameterizedType() {
-            return true;
-        }
-
-        @Override
-        public ParameterizedType asParameterizedType() {
-            return this;
+            this.owner = owner;
         }
 
         /**
-         * Build a signature like <code>Lorg/acme/Parent<TT;>.Inner;</code>.
-         * 
-         * @param simpleName
-         * @return the nested class
+         * Allows building a signature like {@code Lcom/example/Outer.Inner;}. This is usually
+         * unnecessary, because {@code Lcom/example/Outer$Inner} is also a valid signature,
+         * but it's occasionally useful to build a signature of more complex inner types.
+         *
+         * @param simpleName simple name of the member class nested in this class
+         * @return the inner class
          */
-        public ClassType nestedClassType(String simpleName) {
+        public ClassType innerClass(String simpleName) {
             return new ClassType(simpleName, this);
         }
 
         /**
-         * Build a signature like <code>Lorg/acme/Parent<TT;>.Inner<TU;>;</code>.
-         * 
-         * @param simpleName
-         * @return the nested class
+         * Allows build a signature like {@code Lcom/example/Outer.Inner<TU;>;}. This is usually
+         * unnecessary, because {@code Lcom/example/Outer$Inner<TU;>;} is also a valid signature,
+         * but it's occasionally useful to build a signature of more complex inner types.
+         *
+         * @param simpleName simple name of the generic member class nested in this class
+         * @return the inner parameterized type
          */
-        public ParameterizedType nestedParameterizedType(String simpleName, Type... typeArguments) {
-            return new ParameterizedType(Type.classType(simpleName), Arrays.asList(typeArguments), this);
-        }
-
-    }
-
-    public static class ClassType implements Type {
-
-        public static ClassType OBJECT = classType(DotName.OBJECT_NAME);
-
-        final String name;
-        final Type declaringClassType;
-
-        ClassType(String name, Type declaringClassType) {
-            this.name = Objects.requireNonNull(name);
-            this.declaringClassType = declaringClassType;
+        public ParameterizedType innerParameterizedType(String simpleName, Type... typeArguments) {
+            return new ParameterizedType(new ClassType(simpleName, null), Arrays.asList(typeArguments), this);
         }
 
         @Override
-        public void appendToSignature(StringBuilder signature) {
-            if (declaringClassType != null) {
-                // Append the declaring class and remove the last semicolon
-                declaringClassType.appendToSignature(signature);
-                signature.deleteCharAt(signature.length() - 1);
-                signature.append('.');
+        void appendToSignature(StringBuilder signature) {
+            if (owner != null) {
+                // Append the owner class and replace the last semicolon with a period
+                owner.appendToSignature(signature);
+                signature.setCharAt(signature.length() - 1, '.');
             } else {
                 signature.append('L');
             }
@@ -371,94 +305,184 @@ public interface Type {
         }
 
         @Override
-        public boolean isClass() {
+        boolean isClass() {
             return true;
         }
 
         @Override
-        public ClassType asClass() {
+        ClassType asClass() {
             return this;
         }
-
     }
 
-    public static class VoidType implements Type {
+    public static final class ArrayType extends Type {
+        private final Type elementType;
+        private final int dimensions;
 
-        public static final VoidType INSTANCE = new VoidType();
-
-        @Override
-        public void appendToSignature(StringBuilder signature) {
-            signature.append("V");
+        ArrayType(Type elementType, int dimensions) {
+            this.elementType = Objects.requireNonNull(elementType);
+            this.dimensions = dimensions;
         }
 
         @Override
-        public boolean isVoid() {
+        void appendToSignature(StringBuilder signature) {
+            for (int i = 0; i < dimensions; i++) {
+                signature.append('[');
+            }
+            elementType.appendToSignature(signature);
+        }
+
+        @Override
+        boolean isArray() {
             return true;
         }
 
         @Override
-        public VoidType asVoid() {
+        ArrayType asArray() {
+            return this;
+        }
+    }
+
+    public static final class ParameterizedType extends Type {
+        private final ClassType genericClass;
+        private final List<Type> typeArguments;
+        private final Type owner;
+
+        ParameterizedType(ClassType genericClass, List<Type> typeArguments, Type owner) {
+            this.genericClass = Objects.requireNonNull(genericClass);
+            this.typeArguments = Objects.requireNonNull(typeArguments);
+            this.owner = owner;
+        }
+
+        /**
+         * Allows build a signature like {@code Lcom/example/Outer<TT;>.Inner;}.
+         *
+         * @param simpleName simple name of the member class nested in this parameterized type
+         * @return the inner class
+         */
+        public ClassType innerClass(String simpleName) {
+            return new ClassType(simpleName, this);
+        }
+
+        /**
+         * Allows building a signature like {@code Lcom/example/Outer<TT;>.Inner<TU;>;}.
+         *
+         * @param simpleName simple name of the generic member class nested in this parameterized type
+         * @return the inner parameterized type
+         */
+        public ParameterizedType innerParameterizedType(String simpleName, Type... typeArguments) {
+            return new ParameterizedType(new ClassType(simpleName, null), Arrays.asList(typeArguments), this);
+        }
+
+        @Override
+        void appendToSignature(StringBuilder signature) {
+            if (owner != null) {
+                // Append the owner class and replace the last semicolon with a period
+                owner.appendToSignature(signature);
+                signature.setCharAt(signature.length() - 1, '.');
+            } else {
+                signature.append('L');
+            }
+            signature.append(genericClass.name);
+            if (!typeArguments.isEmpty()) {
+                signature.append('<');
+                for (Type typeArgument : typeArguments) {
+                    typeArgument.appendToSignature(signature);
+                }
+                signature.append('>');
+            }
+            signature.append(';');
+        }
+
+        @Override
+        boolean isParameterizedType() {
+            return true;
+        }
+
+        @Override
+        ParameterizedType asParameterizedType() {
             return this;
         }
 
+        List<Type> getTypeArguments() {
+            return Collections.unmodifiableList(typeArguments);
+        }
     }
 
-    public static class PrimitiveType implements Type {
+    public static final class TypeVariable extends Type {
+        private final String name;
+        private final Type firstBound; // may be null if all bounds are interfaces
+        private final List<Type> nextBounds;
 
-        public static final PrimitiveType BYTE = new PrimitiveType(Primitive.BYTE);
-        public static final PrimitiveType CHAR = new PrimitiveType(Primitive.CHAR);
-        public static final PrimitiveType DOUBLE = new PrimitiveType(Primitive.DOUBLE);
-        public static final PrimitiveType FLOAT = new PrimitiveType(Primitive.FLOAT);
-        public static final PrimitiveType INT = new PrimitiveType(Primitive.INT);
-        public static final PrimitiveType LONG = new PrimitiveType(Primitive.LONG);
-        public static final PrimitiveType SHORT = new PrimitiveType(Primitive.SHORT);
-        public static final PrimitiveType BOOLEAN = new PrimitiveType(Primitive.BOOLEAN);
-
-        final Primitive primitive;
-
-        PrimitiveType(Primitive primitive) {
-            this.primitive = Objects.requireNonNull(primitive);
+        TypeVariable(String name, Type firstBound, List<Type> nextBounds) {
+            this.name = Objects.requireNonNull(name);
+            this.firstBound = firstBound;
+            this.nextBounds = Objects.requireNonNull(nextBounds);
         }
 
         @Override
-        public void appendToSignature(StringBuilder signature) {
-            signature.append(toSignature());
+        void appendToSignature(StringBuilder signature) {
+            signature.append('T').append(name).append(';');
         }
 
-        @Override
-        public String toSignature() {
-            switch (primitive) {
-                case BOOLEAN:
-                    return "Z";
-                case BYTE:
-                    return "B";
-                case CHAR:
-                    return "C";
-                case DOUBLE:
-                    return "D";
-                case FLOAT:
-                    return "F";
-                case INT:
-                    return "I";
-                case LONG:
-                    return "J";
-                case SHORT:
-                    return "S";
-                default:
-                    throw new IllegalStateException();
+        void appendTypeParameterToSignature(StringBuilder signature) {
+            signature.append(name).append(":");
+            if (firstBound != null) {
+                firstBound.appendToSignature(signature);
+            }
+            for (Type bound : nextBounds) {
+                signature.append(":");
+                bound.appendToSignature(signature);
             }
         }
 
         @Override
-        public boolean isPrimitive() {
+        boolean isTypeVariable() {
             return true;
         }
 
         @Override
-        public PrimitiveType asPrimitive() {
+        TypeVariable asTypeVariable() {
+            return this;
+        }
+    }
+
+    public static final class WildcardType extends Type {
+        private final Type upperBound;
+        private final Type lowerBound;
+
+        WildcardType(Type upperBound, Type lowerBound) {
+            if (upperBound == null && lowerBound == null) {
+                throw new NullPointerException();
+            }
+            if (upperBound != null && lowerBound != null) {
+                throw new IllegalArgumentException();
+            }
+            this.upperBound = upperBound;
+            this.lowerBound = lowerBound;
+        }
+
+        @Override
+        boolean isWildcard() {
+            return true;
+        }
+
+        @Override
+        WildcardType asWildcard() {
             return this;
         }
 
+        @Override
+        void appendToSignature(StringBuilder signature) {
+            if (lowerBound != null) {
+                signature.append('-');
+                lowerBound.appendToSignature(signature);
+            } else if (upperBound.isClass() && upperBound.asClass().name.equals(ClassType.OBJECT.name)) {
+                signature.append('*');
+            } else {
+                signature.append('+');
+                upperBound.appendToSignature(signature);
+            }
+        }
     }
-
 }

--- a/src/test/java/io/quarkus/gizmo/SignaturesTest.java
+++ b/src/test/java/io/quarkus/gizmo/SignaturesTest.java
@@ -214,8 +214,8 @@ public class SignaturesTest {
                 SignatureBuilder.forClass()
                         .addTypeParameter(Type.typeVariable("T"))
                         .setSuperClass(Type.parameterizedType(Type.classType(List.class), Type.typeVariable("T")))
-                        .addSuperInterface(Type.classType(Serializable.class))
-                        .addSuperInterface(Type.parameterizedType(Type.classType(Comparable.class), Type.typeVariable("T")))
+                        .addInterface(Type.classType(Serializable.class))
+                        .addInterface(Type.parameterizedType(Type.classType(Comparable.class), Type.typeVariable("T")))
                         .build());
 
         // public class OuterParam<T extends Serializable> {
@@ -243,7 +243,7 @@ public class SignaturesTest {
                                         .innerClass("InnerInnerRaw")
                                         .innerParameterizedType("InnerInnerInnerParam", Type.classType(String.class))
                         )
-                        .addSuperInterface(Type.parameterizedType(Type.classType("io.quarkus.gizmo.test.OuterParam$NestedParam"), Type.typeVariable("V")))
+                        .addInterface(Type.parameterizedType(Type.classType("io.quarkus.gizmo.test.OuterParam$NestedParam"), Type.typeVariable("V")))
                         .build());
 
         try {

--- a/src/test/java/io/quarkus/gizmo/SignaturesTest.java
+++ b/src/test/java/io/quarkus/gizmo/SignaturesTest.java
@@ -1,0 +1,230 @@
+package io.quarkus.gizmo;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import java.io.Serializable;
+import java.util.List;
+import java.util.Map;
+
+import org.jboss.jandex.DotName;
+import org.junit.Test;
+
+import io.quarkus.gizmo.SignaturesTest.Nested.Inner.Inner2;
+import io.quarkus.gizmo.SignaturesTest.NestedParam.InnerParam;
+
+public class SignaturesTest {
+
+    @Test
+    public void testMethodSignatures() {
+        // void test()
+        assertEquals("()V",
+                SignatureBuilder.forMethod().build());
+
+        // void test(long l)
+        assertEquals("(J)V",
+                SignatureBuilder.forMethod().addParameter(Type.longType()).build());
+
+        // List<String> test(List<?> list)
+        assertEquals("(Ljava/util/List<*>;)Ljava/util/List<Ljava/lang/String;>;",
+                SignatureBuilder.forMethod()
+                        .setReturnType(Type.parameterizedType(Type.classType(List.class), Type.classType(String.class)))
+                        .addParameter(Type.parameterizedType(Type.classType(List.class), Type.wildcardTypeUnbounded()))
+                        .build());
+
+        // Object test()
+        assertEquals("()Ljava/lang/Object;",
+                SignatureBuilder.forMethod().setReturnType(Type.classType(DotName.OBJECT_NAME)).build());
+
+        // <T extends Comparable<T>>  String[] test(T t)
+        assertEquals("<T::Ljava/lang/Comparable<TT;>;>(TT;)[Ljava/lang/String;",
+                SignatureBuilder.forMethod()
+                        .setReturnType(Type.arrayType(Type.classType(String.class)))
+                        .addParameter(Type.typeVariable("T"))
+                        .addTypeParameter(Type.typeVariable("T", null,
+                                Type.parameterizedType(Type.classType(Comparable.class), Type.typeVariable("T"))))
+                        .build());
+
+        // <R> List<R> test(int a, T t)
+        assertEquals("(ITT;)Ljava/util/List<TR;>;",
+                SignatureBuilder.forMethod()
+                        .setReturnType(
+                                Type.parameterizedType(Type.classType(DotName.createSimple(List.class)),
+                                        Type.typeVariable("R")))
+                        .addParameter(Type.intType())
+                        .addParameter(Type.typeVariable("T")).build());
+
+        // boolean test(int i)
+        assertEquals("(I)Z",
+                SignatureBuilder.forMethod()
+                        .setReturnType(Type.booleanType())
+                        .addParameter(Type.intType()).build());
+
+        // <T extends Number & Comparable<T>, U extends Comparable<U>, V extends Exception> T bbb(U arg, W arg2, OuterParam<W> self)
+        assertEquals(
+                "<T:Ljava/lang/Number;:Ljava/lang/Comparable<TT;>;U::Ljava/lang/Comparable<TU;>;V:Ljava/lang/Exception;>(TU;TW;Ltest/OuterParam<TW;>;)TT;",
+                SignatureBuilder.forMethod()
+                        .setReturnType(Type.typeVariable("T"))
+                        .addParameter(Type.typeVariable("U"))
+                        .addParameter(Type.typeVariable("W"))
+                        .addParameter(Type.parameterizedType(Type.classType("test/OuterParam"),
+                                Type.typeVariable("W")))
+                        .addTypeParameter(Type.typeVariable("T", Type.classType(Number.class),
+                                Type.parameterizedType(
+                                        Type.classType(Comparable.class),
+                                        Type.typeVariable("T"))))
+                        .addTypeParameter(Type.typeVariable("U", null,
+                                Type.parameterizedType(Type.classType(Comparable.class),
+                                        Type.typeVariable("U"))))
+                        .addTypeParameter(Type.typeVariable("V", Type.classType(Exception.class))).build());
+
+        // <T extends Number & Comparable<T>, U extends Comparable<U>, V extends Exception> T test(List<? extends U> arg, W arg2, Foo arg3) throws IllegalArgumentException, V
+        assertEquals(
+                "<T:Ljava/lang/Number;:Ljava/lang/Comparable<TT;>;U::Ljava/lang/Comparable<TU;>;V:Ljava/lang/Exception;>(Ljava/util/List<+TU;>;TW;Lio/quarkus/gizmo/SignaturesTest$NestedParam<TP;>.Inner;)TT;^Ljava/lang/IllegalArgumentException;^TV;",
+                SignatureBuilder.forMethod()
+                        .setReturnType(Type.typeVariable("T"))
+                        .addTypeParameter(Type.typeVariable("T", Type.classType(Number.class),
+                                Type.parameterizedType(Type.classType(Comparable.class), Type.typeVariable("T"))))
+                        .addTypeParameter(Type.typeVariable("U", null,
+                                Type.parameterizedType(Type.classType(Comparable.class), Type.typeVariable("U"))))
+                        .addTypeParameter(Type.typeVariable("V", Type.classType(Exception.class)))
+                        .addParameter(Type.parameterizedType(Type.classType(List.class),
+                                Type.wildcardTypeWithUpperBound(Type.typeVariable("U"))))
+                        .addParameter(Type.typeVariable("W"))
+                        .addParameter(Type.parameterizedType(Type.classType(NestedParam.class), Type.typeVariable("P"))
+                                .nestedClassType(
+                                        NestedParam.Inner.class.getSimpleName()))
+                        .addException(Type.classType(IllegalArgumentException.class))
+                        .addException(Type.typeVariable("V"))
+                        .build());
+
+        // Nested.Inner.Inner2 test()
+        assertEquals("()Lio/quarkus/gizmo/SignaturesTest$Nested$Inner$Inner2;",
+                SignatureBuilder.forMethod()
+                        .setReturnType(Type.classType(Inner2.class))
+                        .build());
+    }
+
+    @Test
+    public void testFieldSignatures() {
+        // List<String> foo;
+        assertEquals("Ljava/util/List<Ljava/lang/String;>;",
+                SignatureBuilder.forField()
+                        .setType(Type.parameterizedType(Type.classType(List.class), Type.classType(String.class)))
+                        .build());
+
+        // T foo;
+        assertEquals("TT;",
+                SignatureBuilder.forField()
+                        .setType(Type.typeVariable("T"))
+                        .build());
+
+        // List<T extends Number> foo;
+        assertEquals("Ljava/util/List<TT;>;",
+                SignatureBuilder.forField()
+                        .setType(Type.parameterizedType(Type.classType(List.class),
+                                Type.typeVariable("T", Type.classType(Number.class))))
+                        .build());
+
+        // double foo;
+        assertEquals("D",
+                SignatureBuilder.forField()
+                        .setType(Type.doubleType())
+                        .build());
+
+        // List<?> foo;
+        assertEquals("Ljava/util/List<*>;",
+                SignatureBuilder.forField()
+                        .setType(Type.parameterizedType(Type.classType(List.class), Type.wildcardTypeUnbounded()))
+                        .build());
+
+        // Map<? extends Number,? super Number> foo;
+        assertEquals("Ljava/util/Map<+Ljava/lang/Number;-Ljava/lang/Number;>;",
+                SignatureBuilder.forField()
+                        .setType(Type.parameterizedType(Type.classType(Map.class),
+                                Type.wildcardTypeWithUpperBound(Type.classType(Number.class)),
+                                Type.wildcardTypeWithLowerBound(Type.classType(Number.class))))
+                        .build());
+
+        // Signature not needed
+        // Nested foo;
+        assertEquals("Lio/quarkus/gizmo/SignaturesTest$Nested;",
+                SignatureBuilder.forField()
+                        .setType(Type.classType(Nested.class))
+                        .build());
+
+        // Signature not needed
+        // NestedParam.Inner.Inner2 foo;
+        assertEquals("Lio/quarkus/gizmo/SignaturesTest$NestedParam$InnerParam$Inner2;",
+                SignatureBuilder.forField()
+                        .setType(Type.classType(NestedParam.InnerParam.Inner2.class))
+                        .build());
+
+        // NestedParam.InnerParam<T> foo;
+        assertEquals("Lio/quarkus/gizmo/SignaturesTest$NestedParam<TP;>.InnerParam<TP;>;",
+                SignatureBuilder.forField()
+                        .setType(Type.parameterizedType(Type.classType(NestedParam.class), Type.typeVariable("P"))
+                                .nestedParameterizedType(InnerParam.class.getSimpleName(), Type.typeVariable("P")))
+                        .build());
+    }
+
+    @Test
+    public void testClassSignatures() {
+        // class Foo<T>
+        assertEquals("<T:Ljava/lang/Object;>Ljava/lang/Object;",
+                SignatureBuilder.forClass()
+                        .addTypeParameter(Type.typeVariable("T"))
+                        .build());
+
+        // class Foo<T> extends List<T>
+        assertEquals("<T:Ljava/lang/Object;>Ljava/util/List<TT;>;",
+                SignatureBuilder.forClass()
+                        .addTypeParameter(Type.typeVariable("T"))
+                        .setSuperClass(Type.parameterizedType(Type.classType(List.class), Type.typeVariable("T")))
+                        .build());
+
+        // class Foo<T> extends List<T> implements Serializable, Comparable<T>
+        assertEquals("<T:Ljava/lang/Object;>Ljava/util/List<TT;>;Ljava/io/Serializable;Ljava/lang/Comparable<TT;>;",
+                SignatureBuilder.forClass()
+                        .addTypeParameter(Type.typeVariable("T"))
+                        .setSuperClass(Type.parameterizedType(Type.classType(List.class), Type.typeVariable("T")))
+                        .addSuperInterface(Type.classType(Serializable.class))
+                        .addSuperInterface(Type.parameterizedType(Type.classType(Comparable.class), Type.typeVariable("T")))
+                        .build());
+
+        try {
+            SignatureBuilder.forClass()
+                    .setSuperClass(Type.parameterizedType(Type.classType(List.class), Type.wildcardTypeUnbounded()));
+            fail();
+        } catch (Exception expected) {
+        }
+    }
+
+    public static class Nested {
+
+        public class Inner {
+
+            class Inner2 {
+
+            }
+        }
+
+    }
+
+    public static class NestedParam<P> {
+
+        InnerParam<P> inner;
+
+        public class Inner {
+        }
+
+        public class InnerParam<I> {
+
+            class Inner2 {
+
+            }
+        }
+
+    }
+
+}


### PR DESCRIPTION
This pull request supersedes https://github.com/quarkusio/gizmo/pull/116.

Usage example:
```java
import io.quarkus.gizmo.SignatureBuilder;
import io.quarkus.gizmo.Type;

// List<String> test();
method.setSignature(SignatureBuilder.forMethod()
   .setReturnType(Type.parameterizedType(Type.classType(List.class), Type.classType(String.class)))
   .build()
)
```

See also `io.quarkus.gizmo.SignaturesTest`.