### PR TITLE
Add support for division

### DIFF
--- a/src/main/java/io/quarkus/gizmo/BytecodeCreator.java
+++ b/src/main/java/io/quarkus/gizmo/BytecodeCreator.java
@@ -997,6 +997,15 @@ public interface BytecodeCreator extends AutoCloseable {
     ResultHandle multiply(ResultHandle a1, ResultHandle a2);
 
     /**
+     * Divides the first result handles by the second and returns the result
+     *
+     * @param a1 The first number
+     * @param a2 The second number
+     * @return The result
+     */
+    ResultHandle divide(ResultHandle a1, ResultHandle a2);
+
+    /**
      * Computes the bitwise AND of the two result handles and returns the result
      *
      * @param a1 The first number

--- a/src/main/java/io/quarkus/gizmo/BytecodeCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo/BytecodeCreatorImpl.java
@@ -1334,6 +1334,11 @@ class BytecodeCreatorImpl implements BytecodeCreator {
     }
 
     @Override
+    public ResultHandle divide(ResultHandle a1, ResultHandle a2) {
+        return emitBinaryArithmetic(Opcodes.IDIV, a1, a2);
+    }
+
+    @Override
     public ResultHandle bitwiseAnd(ResultHandle a1, ResultHandle a2) {
         return emitBinaryArithmetic(Opcodes.IAND, a1, a2);
     }

--- a/src/test/java/io/quarkus/gizmo/ArithmeticTestCase.java
+++ b/src/test/java/io/quarkus/gizmo/ArithmeticTestCase.java
@@ -85,4 +85,41 @@ public class ArithmeticTestCase {
         assertEquals(42.0F, clazz.getMethod("multiplyFloats").invoke(null));
         assertEquals(72.0D, clazz.getMethod("multiplyDoubles").invoke(null));
     }
+
+    @Test
+    public void testDivision() throws Exception {
+        TestClassLoader cl = new TestClassLoader(getClass().getClassLoader());
+        try (ClassCreator creator = ClassCreator.builder().classOutput(cl).className("com.MyTest").build()) {
+            MethodCreator divideInts = creator.getMethodCreator("divideInts", Object.class).setModifiers(Opcodes.ACC_PUBLIC | Opcodes.ACC_STATIC);
+            ResultHandle int1 = divideInts.load(2);
+            ResultHandle int2 = divideInts.load(3);
+            divideInts.returnValue(divideInts.divide(int1, int2));
+
+            MethodCreator divideImproperInts = creator.getMethodCreator("divideImproperInts", Object.class).setModifiers(Opcodes.ACC_PUBLIC | Opcodes.ACC_STATIC);
+            ResultHandle int11 = divideInts.load(18);
+            ResultHandle int22 = divideInts.load(5);
+            divideImproperInts.returnValue(divideImproperInts.divide(int11, int22));
+
+            MethodCreator divideLongs = creator.getMethodCreator("divideLongs", Object.class).setModifiers(Opcodes.ACC_PUBLIC | Opcodes.ACC_STATIC);
+            ResultHandle long1 = divideLongs.load(5L);
+            ResultHandle long2 = divideLongs.load(4L);
+            divideLongs.returnValue(divideLongs.divide(long1, long2));
+
+            MethodCreator divideFloats = creator.getMethodCreator("divideFloats", Object.class).setModifiers(Opcodes.ACC_PUBLIC | Opcodes.ACC_STATIC);
+            ResultHandle float1 = divideLongs.load(6.0F);
+            ResultHandle float2 = divideLongs.load(7.0F);
+            divideFloats.returnValue(divideFloats.divide(float1, float2));
+
+            MethodCreator divideDoubles = creator.getMethodCreator("divideDoubles", Object.class).setModifiers(Opcodes.ACC_PUBLIC | Opcodes.ACC_STATIC);
+            ResultHandle double1 = divideLongs.load(8.0D);
+            ResultHandle double2 = divideLongs.load(9.0D);
+            divideDoubles.returnValue(divideDoubles.divide(double1, double2));
+        }
+        Class<?> clazz = cl.loadClass("com.MyTest");
+        assertEquals(0, clazz.getMethod("divideInts").invoke(null));
+        assertEquals(3, clazz.getMethod("divideImproperInts").invoke(null));
+        assertEquals(1L, clazz.getMethod("divideLongs").invoke(null));
+        assertEquals(0.85714287F, clazz.getMethod("divideFloats").invoke(null));
+        assertEquals(0.8888888888888888D, clazz.getMethod("divideDoubles").invoke(null));
+    }
 }

--- a/src/test/java/io/quarkus/gizmo/ArithmeticTestCase.java
+++ b/src/test/java/io/quarkus/gizmo/ArithmeticTestCase.java
@@ -75,14 +75,14 @@ public class ArithmeticTestCase {
             multiplyFloats.returnValue(multiplyFloats.multiply(float1, float2));
 
             MethodCreator multiplyDoubles = creator.getMethodCreator("multiplyDoubles", Object.class).setModifiers(Opcodes.ACC_PUBLIC | Opcodes.ACC_STATIC);
-            ResultHandle double1 = multiplyLongs.load(8.0F);
-            ResultHandle double2 = multiplyLongs.load(9.0F);
+            ResultHandle double1 = multiplyLongs.load(8.0D);
+            ResultHandle double2 = multiplyLongs.load(9.0D);
             multiplyDoubles.returnValue(multiplyDoubles.multiply(double1, double2));
         }
         Class<?> clazz = cl.loadClass("com.MyTest");
         assertEquals(6, clazz.getMethod("multiplyInts").invoke(null));
         assertEquals(20L, clazz.getMethod("multiplyLongs").invoke(null));
         assertEquals(42.0F, clazz.getMethod("multiplyFloats").invoke(null));
-        assertEquals(72.0F, clazz.getMethod("multiplyDoubles").invoke(null));
+        assertEquals(72.0D, clazz.getMethod("multiplyDoubles").invoke(null));
     }
 }


### PR DESCRIPTION
I noticed that we support multiplication, but not division. Doing it the hard way would be hard, since there's no public access to `emitBinaryOperation`. 

While I was adding test cases I noticed that the double test case for multiplication is actually using floats, so I've fixed that. 