### PR TITLE
Fix AnnotatedElement#addAnnotation(AnnotationInstance)

### DIFF
--- a/src/main/java/io/quarkus/gizmo/AnnotatedElement.java
+++ b/src/main/java/io/quarkus/gizmo/AnnotatedElement.java
@@ -32,11 +32,12 @@ public interface AnnotatedElement {
 
     default AnnotationCreator addAnnotation(Class<?> annotationType) {
         Retention retention = annotationType.getAnnotation(Retention.class);
-        return addAnnotation(annotationType.getName(), retention == null ? RetentionPolicy.SOURCE : retention.value());
+        return addAnnotation(annotationType.getName(), retention == null ? RetentionPolicy.CLASS : retention.value());
     }
 
     default void addAnnotation(AnnotationInstance annotation) {
-        AnnotationCreator ac = addAnnotation(annotation.name().toString());
+        RetentionPolicy retention = annotation.runtimeVisible() ? RetentionPolicy.RUNTIME : RetentionPolicy.CLASS;
+        AnnotationCreator ac = addAnnotation(annotation.name().toString(), retention);
         for (AnnotationValue member : annotation.values()) {
             ac.addValue(member.name(), member);
         }

--- a/src/test/java/io/quarkus/gizmo/AnnotationClassRuntimePolicy.java
+++ b/src/test/java/io/quarkus/gizmo/AnnotationClassRuntimePolicy.java
@@ -1,0 +1,11 @@
+package io.quarkus.gizmo;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Retention(RetentionPolicy.CLASS)
+public @interface AnnotationClassRuntimePolicy {
+
+    String value();
+
+}

--- a/src/test/java/io/quarkus/gizmo/AnnotationNoRuntimePolicy.java
+++ b/src/test/java/io/quarkus/gizmo/AnnotationNoRuntimePolicy.java
@@ -1,0 +1,7 @@
+package io.quarkus.gizmo;
+
+public @interface AnnotationNoRuntimePolicy {
+
+    String value();
+
+}


### PR DESCRIPTION
- reflect the original retention policy
- also use RetentionPolicy.CLASS by default if no Retention annotation is found for AnnotatedElement#addAnnotation(Class<?>)
- fixes #198