### PR TITLE
Various performance improvements

### DIFF
--- a/src/main/java/io/quarkus/gizmo/ResultHandle.java
+++ b/src/main/java/io/quarkus/gizmo/ResultHandle.java
@@ -57,11 +57,13 @@ public class ResultHandle {
     }
 
     private void verifyType(String current) {
-        if (current.length() == 0) {
+        if (current.isEmpty()) {
             throw new RuntimeException("Invalid type " + type);
         }
-        if (current.length() == 1) {
-            switch (current.charAt(0)) {
+        int length = current.length();
+        char firstChar = current.charAt(0);
+        if (length == 1) {
+            switch (firstChar) {
                 case 'Z':
                 case 'B':
                 case 'S':
@@ -75,10 +77,10 @@ public class ResultHandle {
                     throw new RuntimeException("Invalid type " + type);
             }
         } else {
-            if (current.charAt(0) == '[') {
+            if (firstChar == '[') {
                 verifyType(current.substring(1));
             } else {
-                if (!(current.startsWith("L") && current.endsWith(";"))) {
+                if (!(firstChar == 'L' && current.charAt(length - 1) == ';')) {
                     throw new RuntimeException("Invalid type " + type);
                 }
             }


### PR DESCRIPTION
- save on unneeded isScopedWithin calls
- optimize findActiveResultHandles to not need an additional set to hold handles
- only query arc.debug system property once
- remove additional list construction from getInputResultHandles
- use constants for equality check to determine load constants instead


Related to https://github.com/quarkusio/quarkus/issues/45631

This change saves about 25ms in dev mode hot reload time for the reproducer in 45631 with quarkus 2.18.1