### PR TITLE
Add build infrastructure to 2.x branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,28 @@
+---
+version: 2
+updates:
+  - package-ecosystem: maven
+    directory: "/"
+    schedule:
+      interval: daily
+      time: "21:00"
+      timezone: Europe/Paris
+    open-pull-requests-limit: 5
+  - package-ecosystem: maven
+    target-branch: "2.x"
+    directory: "/"
+    schedule:
+      interval: daily
+      time: "22:00"
+      timezone: Europe/Paris
+    open-pull-requests-limit: 5
+    labels: ['dependencies', '2.x']
+  - package-ecosystem: maven
+    target-branch: "1.x"
+    directory: "/"
+    schedule:
+      interval: daily
+      time: "23:00"
+      timezone: Europe/Paris
+    open-pull-requests-limit: 5
+    labels: ['dependencies', '1.x']

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,31 @@
+name: Gizmo 2 CI
+
+on:
+  push:
+    branches-ignore:
+      - 'dependabot/**'
+  pull_request:
+
+jobs:
+  build:
+    name: "Build with JDK ${{ matrix.java }}"
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        java: [ 17, 21 ]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK ${{ matrix.java }}
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: ${{ matrix.java }}
+          cache: maven
+
+      - name: Build with Maven
+        run: mvn -B clean package -Dno-format


### PR DESCRIPTION
Fixes #206

Note: I also copied the Dependabot config file as we will need it when we move `2.x` to `main`.