### PR TITLE
Fixes in preparation for lambdas

### DIFF
--- a/src/main/java/io/quarkus/gizmo2/ClassOutput.java
+++ b/src/main/java/io/quarkus/gizmo2/ClassOutput.java
@@ -14,9 +14,9 @@ public interface ClassOutput {
     /**
      * Add a new class.
      *
-     * @param name the fully qualified (dot-separated) binary class name
-     * @param builder the
-     * @return the descriptor
+     * @param name the fully qualified (dot-separated) binary class name (must not be {@code null})
+     * @param builder the builder for the class (must not be {@code null})
+     * @return the descriptor of the created class (not {@code null})
      */
     default ClassDesc class_(String name, Consumer<ClassCreator> builder) {
         return class_(ClassDesc.of(name), builder);
@@ -26,7 +26,7 @@ public interface ClassOutput {
      * Add a new class.
      *
      * @param desc the class descriptor (must not be {@code null})
-     * @param builder the
+     * @param builder the builder for the class (must not be {@code null})
      * @return the descriptor given for {@code desc}
      */
     ClassDesc class_(ClassDesc desc, Consumer<ClassCreator> builder);
@@ -35,8 +35,8 @@ public interface ClassOutput {
      * Add a new interface.
      *
      * @param name the fully qualified (dot-separated) binary class name
-     * @param builder the
-     * @return the descriptor
+     * @param builder the builder for the interface (must not be {@code null})
+     * @return the descriptor of the created interface (not {@code null})
      */
     default ClassDesc interface_(String name, Consumer<InterfaceCreator> builder) {
         return interface_(ClassDesc.of(name), builder);
@@ -46,7 +46,7 @@ public interface ClassOutput {
      * Add a new interface.
      *
      * @param desc the class descriptor (must not be {@code null})
-     * @param builder the
+     * @param builder the builder for the class (must not be {@code null})
      * @return the descriptor given for {@code desc}
      */
     ClassDesc interface_(ClassDesc desc, Consumer<InterfaceCreator> builder);

--- a/src/main/java/io/quarkus/gizmo2/Expr.java
+++ b/src/main/java/io/quarkus/gizmo2/Expr.java
@@ -11,7 +11,7 @@ import io.quarkus.gizmo2.impl.GizmoImpl;
 /**
  * An expression.
  */
-public sealed interface Expr permits Constant, LValueExpr, Item {
+public sealed interface Expr permits Constant, LValueExpr, Var, Item {
     /**
      * {@return the expression type (not {@code null})}
      */

--- a/src/main/java/io/quarkus/gizmo2/FieldVar.java
+++ b/src/main/java/io/quarkus/gizmo2/FieldVar.java
@@ -5,7 +5,7 @@ import java.lang.constant.ClassDesc;
 /**
  * A variable corresponding to a field.
  */
-public sealed interface FieldVar extends Var permits InstanceFieldVar, StaticFieldVar {
+public sealed interface FieldVar extends Var, LValueExpr permits InstanceFieldVar, StaticFieldVar {
     default ClassDesc type() {
         return desc().type();
     }

--- a/src/main/java/io/quarkus/gizmo2/LValueExpr.java
+++ b/src/main/java/io/quarkus/gizmo2/LValueExpr.java
@@ -5,6 +5,6 @@ import io.quarkus.gizmo2.impl.LValueExprImpl;
 /**
  * An expression that can be the target of an assignment.
  */
-public sealed interface LValueExpr extends Expr permits LValueExprImpl, Var {
+public sealed interface LValueExpr extends Expr permits FieldVar, LocalVar, ParamVar, LValueExprImpl {
 
 }

--- a/src/main/java/io/quarkus/gizmo2/LocalVar.java
+++ b/src/main/java/io/quarkus/gizmo2/LocalVar.java
@@ -6,7 +6,7 @@ import io.quarkus.gizmo2.impl.LocalVarImpl;
 /**
  * A local variable.
  */
-public sealed interface LocalVar extends Var permits LocalVarImpl {
+public sealed interface LocalVar extends Var, LValueExpr permits LocalVarImpl {
     /**
      * {@return the block that owns this local variable}
      */

--- a/src/main/java/io/quarkus/gizmo2/ParamVar.java
+++ b/src/main/java/io/quarkus/gizmo2/ParamVar.java
@@ -5,7 +5,7 @@ import io.quarkus.gizmo2.impl.ParamVarImpl;
 /**
  * A variable representing a method call parameter.
  */
-public sealed interface ParamVar extends Var permits ParamVarImpl {
+public sealed interface ParamVar extends Var, LValueExpr permits ParamVarImpl {
     /**
      * {@return the parameter index, counting from zero}
      * The index does not include any "{@code this}" variable.

--- a/src/main/java/io/quarkus/gizmo2/Var.java
+++ b/src/main/java/io/quarkus/gizmo2/Var.java
@@ -1,9 +1,11 @@
 package io.quarkus.gizmo2;
 
+import io.quarkus.gizmo2.impl.ThisExpr;
+
 /**
  * An lvalue expression that is stored in a variable.
  */
-public sealed interface Var extends LValueExpr permits LocalVar, ParamVar, FieldVar {
+public sealed interface Var extends Expr permits FieldVar, LocalVar, ParamVar, ThisExpr {
     /**
      * {@return the variable name}
      */

--- a/src/main/java/io/quarkus/gizmo2/creator/BlockCreator.java
+++ b/src/main/java/io/quarkus/gizmo2/creator/BlockCreator.java
@@ -1712,17 +1712,18 @@ public sealed interface BlockCreator permits BlockCreatorImpl {
      * @return the lambda object (not {@code null})
      */
     default Expr lambda(Class<?> type, Consumer<LambdaCreator> builder) {
-        return lambda(Util.classDesc(type), builder);
+        // todo: extract SAM from type
+        throw new UnsupportedOperationException();
     }
 
     /**
      * Construct a lambda instance with the given type.
      *
-     * @param type the type of the lambda (must not be {@code null})
+     * @param sam the descriptor of the single abstract method of the lambda (must not be {@code null})
      * @param builder the builder for the lambda body (must not be {@code null})
      * @return the lambda object (not {@code null})
      */
-    Expr lambda(ClassDesc type, Consumer<LambdaCreator> builder);
+    Expr lambda(MethodDesc sam, Consumer<LambdaCreator> builder);
 
 
     // conversion

--- a/src/main/java/io/quarkus/gizmo2/creator/BodyCreator.java
+++ b/src/main/java/io/quarkus/gizmo2/creator/BodyCreator.java
@@ -1,0 +1,15 @@
+package io.quarkus.gizmo2.creator;
+
+import java.util.function.Consumer;
+
+/**
+ * A creator that has a body.
+ */
+public sealed interface BodyCreator permits InstanceBodyCreator, LambdaCreator, StaticExecutableCreator, TryCreator {
+    /**
+     * Build the body of this executable code.
+     *
+     * @param builder the builder (must not be {@code null})
+     */
+    void body(Consumer<BlockCreator> builder);
+}

--- a/src/main/java/io/quarkus/gizmo2/creator/ConstructorCreator.java
+++ b/src/main/java/io/quarkus/gizmo2/creator/ConstructorCreator.java
@@ -7,7 +7,7 @@ import io.quarkus.gizmo2.impl.ConstructorCreatorImpl;
 /**
  * A creator for an instance constructor.
  */
-public sealed interface ConstructorCreator extends InstanceExecutableCreator permits ConstructorCreatorImpl {
+public sealed interface ConstructorCreator extends InstanceExecutableCreator, MemberCreator permits ConstructorCreatorImpl {
     /**
      * {@return the descriptor of the constructor (not {@code null})}
      */

--- a/src/main/java/io/quarkus/gizmo2/creator/ExecutableCreator.java
+++ b/src/main/java/io/quarkus/gizmo2/creator/ExecutableCreator.java
@@ -11,7 +11,7 @@ import io.quarkus.gizmo2.impl.Util;
 /**
  * A creator for an executable.
  */
-public sealed interface ExecutableCreator extends MemberCreator permits InstanceExecutableCreator, MethodCreator, StaticExecutableCreator, ExecutableCreatorImpl {
+public sealed interface ExecutableCreator permits InstanceExecutableCreator, MethodCreator, StaticExecutableCreator, ExecutableCreatorImpl {
     /**
      * {@return the type descriptor of this executable (not {@code null})}
      */

--- a/src/main/java/io/quarkus/gizmo2/creator/FieldCreator.java
+++ b/src/main/java/io/quarkus/gizmo2/creator/FieldCreator.java
@@ -11,6 +11,8 @@ import io.quarkus.gizmo2.impl.Util;
  * A creator for a field.
  */
 public sealed interface FieldCreator extends MemberCreator permits InstanceFieldCreator, StaticFieldCreator, FieldCreatorImpl {
+    ClassDesc type();
+
     /**
      * {@return the field type descriptor}
      */

--- a/src/main/java/io/quarkus/gizmo2/creator/InstanceBodyCreator.java
+++ b/src/main/java/io/quarkus/gizmo2/creator/InstanceBodyCreator.java
@@ -1,0 +1,13 @@
+package io.quarkus.gizmo2.creator;
+
+import io.quarkus.gizmo2.Var;
+
+/**
+ * A thing which has an instance body.
+ */
+public sealed interface InstanceBodyCreator extends BodyCreator permits InstanceExecutableCreator {
+    /**
+     * {@return the {@code this} expression}
+     */
+    Var this_();
+}

--- a/src/main/java/io/quarkus/gizmo2/creator/InstanceExecutableCreator.java
+++ b/src/main/java/io/quarkus/gizmo2/creator/InstanceExecutableCreator.java
@@ -1,25 +1,7 @@
 package io.quarkus.gizmo2.creator;
 
-import java.util.function.Consumer;
-
-import io.quarkus.gizmo2.Expr;
-
 /**
  * A creator for instance executables.
  */
-public sealed interface InstanceExecutableCreator extends ExecutableCreator permits ConstructorCreator, InstanceMethodCreator {
-
-    /**
-     * Build the body.
-     * The builder accepts the outermost block.
-     *
-     * @param builder the builder (must not be {@code null})
-     */
-    void body(Consumer<BlockCreator> builder);
-
-    /**
-     * @return the {@code this} expression
-     */
-    Expr this_();
-
+public sealed interface InstanceExecutableCreator extends ExecutableCreator, InstanceBodyCreator permits ConstructorCreator, InstanceMethodCreator {
 }

--- a/src/main/java/io/quarkus/gizmo2/creator/LambdaCreator.java
+++ b/src/main/java/io/quarkus/gizmo2/creator/LambdaCreator.java
@@ -4,21 +4,36 @@ import java.lang.constant.ClassDesc;
 import java.util.function.Consumer;
 
 import io.quarkus.gizmo2.Expr;
-import io.quarkus.gizmo2.LocalVar;
+import io.quarkus.gizmo2.ParamVar;
 import io.quarkus.gizmo2.Var;
 import io.quarkus.gizmo2.impl.LambdaCreatorImpl;
 
 /**
  * A creator for a lambda instance.
  */
-public sealed interface LambdaCreator extends StaticExecutableCreator permits LambdaCreatorImpl {
+public sealed interface LambdaCreator extends BodyCreator permits LambdaCreatorImpl {
     /**
-     * {@return the descriptor of the lambda type}
+     * {@return the descriptor of the lambda functional interface}
      */
-    ClassDesc lambdaType();
+    ClassDesc type();
+
+    /**
+     * Access a parameter of the functional interface method declaration.
+     *
+     * @param name the name to assign to the parameter (must not be {@code null})
+     * @param position the parameter position, starting from 0
+     * @return the parameter's variable (not {@code null})
+     */
+    ParamVar param(String name, int position);
 
     /**
      * Capture an enclosing value as a variable so that it may be used in the lambda body.
+     * All values that are created outside the lambda must be captured into new variables
+     * (even {@code this}) in order to be used within the lambda, otherwise a generation-time
+     * exception may be thrown.
+     * <p>
+     * If the given expression is a variable, the given name overrides the variable's name
+     * within the scope of the lambda.
      *
      * @param name the name of the variable (must not be {@code null})
      * @param value the capture value (must not be {@code null})
@@ -32,7 +47,7 @@ public sealed interface LambdaCreator extends StaticExecutableCreator permits La
      * @param outer the enclosing variable to capture (must not be {@code null})
      * @return the captured variable (not {@code null})
      */
-    default Var capture(LocalVar outer) {
+    default Var capture(Var outer) {
         return capture(outer.name(), outer);
     }
 

--- a/src/main/java/io/quarkus/gizmo2/creator/MemberCreator.java
+++ b/src/main/java/io/quarkus/gizmo2/creator/MemberCreator.java
@@ -1,6 +1,7 @@
 package io.quarkus.gizmo2.creator;
 
 import java.lang.constant.ClassDesc;
+import java.lang.constant.ConstantDesc;
 
 import io.github.dmlloyd.classfile.extras.reflect.AccessFlag;
 import io.quarkus.gizmo2.Annotatable;
@@ -8,7 +9,14 @@ import io.quarkus.gizmo2.Annotatable;
 /**
  * A generalized creator for any kind of class member.
  */
-public sealed interface MemberCreator extends Annotatable permits ExecutableCreator, FieldCreator {
+public sealed interface MemberCreator extends Annotatable permits ConstructorCreator,
+                                                                  FieldCreator,
+                                                                  MethodCreator {
+    /**
+     * {@return the type of this member (not {@code null})}
+     */
+    ConstantDesc type();
+
     /**
      * Add the given flag to this member.
      *

--- a/src/main/java/io/quarkus/gizmo2/creator/MethodCreator.java
+++ b/src/main/java/io/quarkus/gizmo2/creator/MethodCreator.java
@@ -8,7 +8,7 @@ import io.quarkus.gizmo2.impl.MethodCreatorImpl;
 /**
  * A creator for any kind of method on a class.
  */
-public sealed interface MethodCreator extends ExecutableCreator permits AbstractMethodCreator, InstanceMethodCreator, StaticMethodCreator, MethodCreatorImpl {
+public sealed interface MethodCreator extends ExecutableCreator, MemberCreator permits AbstractMethodCreator, InstanceMethodCreator, StaticMethodCreator, MethodCreatorImpl {
 
     /**
      * {@return the descriptor of the method}

--- a/src/main/java/io/quarkus/gizmo2/creator/StaticExecutableCreator.java
+++ b/src/main/java/io/quarkus/gizmo2/creator/StaticExecutableCreator.java
@@ -1,16 +1,7 @@
 package io.quarkus.gizmo2.creator;
 
-import java.util.function.Consumer;
-
 /**
  * A creator for any kind of non-instance executable creator.
  */
-public sealed interface StaticExecutableCreator extends ExecutableCreator permits LambdaCreator, StaticMethodCreator {
-
-    /**
-     * Build the body of this executable code.
-     *
-     * @param builder the builder (must not be {@code null})
-     */
-    void body(Consumer<BlockCreator> builder);
+public sealed interface StaticExecutableCreator extends ExecutableCreator, BodyCreator permits StaticMethodCreator {
 }

--- a/src/main/java/io/quarkus/gizmo2/creator/TryCreator.java
+++ b/src/main/java/io/quarkus/gizmo2/creator/TryCreator.java
@@ -11,7 +11,7 @@ import io.quarkus.gizmo2.impl.TryImpl;
 /**
  * A creator for a {@code try}-{@code catch}-{@code finally} construct.
  */
-public sealed interface TryCreator permits TryImpl {
+public sealed interface TryCreator extends BodyCreator permits TryImpl {
 
     /**
      * Build the body of the {@code try} statement.

--- a/src/main/java/io/quarkus/gizmo2/impl/BlockCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/BlockCreatorImpl.java
@@ -1,28 +1,6 @@
 package io.quarkus.gizmo2.impl;
 
-import static java.lang.constant.ConstantDescs.CD_Boolean;
-import static java.lang.constant.ConstantDescs.CD_Byte;
-import static java.lang.constant.ConstantDescs.CD_Character;
-import static java.lang.constant.ConstantDescs.CD_Class;
-import static java.lang.constant.ConstantDescs.CD_Double;
-import static java.lang.constant.ConstantDescs.CD_Enum;
-import static java.lang.constant.ConstantDescs.CD_Float;
-import static java.lang.constant.ConstantDescs.CD_Integer;
-import static java.lang.constant.ConstantDescs.CD_Long;
-import static java.lang.constant.ConstantDescs.CD_Object;
-import static java.lang.constant.ConstantDescs.CD_Short;
-import static java.lang.constant.ConstantDescs.CD_String;
-import static java.lang.constant.ConstantDescs.CD_Throwable;
-import static java.lang.constant.ConstantDescs.CD_Void;
-import static java.lang.constant.ConstantDescs.CD_boolean;
-import static java.lang.constant.ConstantDescs.CD_byte;
-import static java.lang.constant.ConstantDescs.CD_char;
-import static java.lang.constant.ConstantDescs.CD_double;
-import static java.lang.constant.ConstantDescs.CD_float;
-import static java.lang.constant.ConstantDescs.CD_int;
-import static java.lang.constant.ConstantDescs.CD_long;
-import static java.lang.constant.ConstantDescs.CD_short;
-import static java.lang.constant.ConstantDescs.CD_void;
+import static java.lang.constant.ConstantDescs.*;
 import static java.util.Collections.nCopies;
 
 import java.io.PrintStream;
@@ -607,7 +585,7 @@ sealed public class BlockCreatorImpl extends Item implements BlockCreator, Scope
         throw new UnsupportedOperationException();
     }
 
-    public Expr lambda(final ClassDesc type, final Consumer<LambdaCreator> builder) {
+    public Expr lambda(final MethodDesc sam, final Consumer<LambdaCreator> builder) {
         throw new UnsupportedOperationException();
     }
 

--- a/src/main/java/io/quarkus/gizmo2/impl/ConstructorCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/ConstructorCreatorImpl.java
@@ -8,7 +8,7 @@ import java.util.function.Consumer;
 
 import io.github.dmlloyd.classfile.CodeBuilder;
 import io.github.dmlloyd.classfile.extras.reflect.AccessFlag;
-import io.quarkus.gizmo2.Expr;
+import io.quarkus.gizmo2.Var;
 import io.quarkus.gizmo2.creator.BlockCreator;
 import io.quarkus.gizmo2.creator.ConstructorCreator;
 import io.quarkus.gizmo2.desc.ConstructorDesc;
@@ -35,12 +35,16 @@ public final class ConstructorCreatorImpl extends ExecutableCreatorImpl implemen
         super.doCode(builder, cb, params);
     }
 
+    public String name() {
+        return ConstructorCreator.super.name();
+    }
+
     public void body(final Consumer<BlockCreator> builder) {
-        super.body(bc -> builder.accept(bc));
+        super.body(builder);
     }
 
     @Override
-    public Expr this_() {
+    public Var this_() {
         return new ThisExpr(owner());
     }
 

--- a/src/main/java/io/quarkus/gizmo2/impl/DefaultMethodCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/DefaultMethodCreatorImpl.java
@@ -5,7 +5,7 @@ import java.util.function.Consumer;
 
 import io.github.dmlloyd.classfile.CodeBuilder;
 import io.github.dmlloyd.classfile.extras.reflect.AccessFlag;
-import io.quarkus.gizmo2.Expr;
+import io.quarkus.gizmo2.Var;
 import io.quarkus.gizmo2.creator.BlockCreator;
 import io.quarkus.gizmo2.creator.InstanceMethodCreator;
 
@@ -24,7 +24,7 @@ public final class DefaultMethodCreatorImpl extends MethodCreatorImpl implements
     }
 
     @Override
-    public Expr this_() {
+    public Var this_() {
         return new ThisExpr(owner());
     }
 

--- a/src/main/java/io/quarkus/gizmo2/impl/ExecutableCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/ExecutableCreatorImpl.java
@@ -64,6 +64,8 @@ public sealed abstract class ExecutableCreatorImpl extends AnnotatableCreatorImp
         }
     }
 
+    abstract String name();
+
     void body(final Consumer<BlockCreator> builder) {
         owner.zb.withMethod(name(), type(), flags, mb -> {
             doBody(builder, mb);

--- a/src/main/java/io/quarkus/gizmo2/impl/FieldCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/FieldCreatorImpl.java
@@ -104,4 +104,8 @@ public abstract sealed class FieldCreatorImpl extends AnnotatableCreatorImpl imp
     public String name() {
         return name;
     }
+
+    public ClassDesc type() {
+        return type;
+    }
 }

--- a/src/main/java/io/quarkus/gizmo2/impl/InstanceMethodCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/InstanceMethodCreatorImpl.java
@@ -5,7 +5,7 @@ import java.util.function.Consumer;
 
 import io.github.dmlloyd.classfile.CodeBuilder;
 import io.github.dmlloyd.classfile.extras.reflect.AccessFlag;
-import io.quarkus.gizmo2.Expr;
+import io.quarkus.gizmo2.Var;
 import io.quarkus.gizmo2.creator.BlockCreator;
 import io.quarkus.gizmo2.creator.InstanceMethodCreator;
 
@@ -20,11 +20,11 @@ public final class InstanceMethodCreatorImpl extends MethodCreatorImpl implement
     }
 
     public void body(final Consumer<BlockCreator> builder) {
-        super.body(bc -> builder.accept(bc));
+        super.body(builder);
     }
     
     @Override
-    public Expr this_() {
+    public Var this_() {
         return new ThisExpr(owner());
     }
 

--- a/src/main/java/io/quarkus/gizmo2/impl/LValueExprImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/LValueExprImpl.java
@@ -4,7 +4,7 @@ import io.quarkus.gizmo2.AccessMode;
 import io.quarkus.gizmo2.Constant;
 import io.quarkus.gizmo2.LValueExpr;
 
-non-sealed public abstract class LValueExprImpl extends Item implements LValueExpr {
+public non-sealed abstract class LValueExprImpl extends Item implements LValueExpr {
     LValueExprImpl() {}
 
     abstract Item emitGet(final BlockCreatorImpl block, final AccessMode mode);

--- a/src/main/java/io/quarkus/gizmo2/impl/LambdaCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/LambdaCreatorImpl.java
@@ -2,7 +2,6 @@ package io.quarkus.gizmo2.impl;
 
 import java.lang.annotation.RetentionPolicy;
 import java.lang.constant.ClassDesc;
-import java.lang.constant.MethodTypeDesc;
 import java.util.function.Consumer;
 
 import io.github.dmlloyd.classfile.Annotation;
@@ -28,7 +27,11 @@ public final class LambdaCreatorImpl implements LambdaCreator {
 
     }
 
-    public MethodTypeDesc type() {
+    public ClassDesc type() {
+        return null;
+    }
+
+    public ParamVar param(final String name, final int position) {
         return null;
     }
 

--- a/src/main/java/io/quarkus/gizmo2/impl/PrivateInterfaceMethodCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/PrivateInterfaceMethodCreatorImpl.java
@@ -5,7 +5,7 @@ import java.util.function.Consumer;
 
 import io.github.dmlloyd.classfile.CodeBuilder;
 import io.github.dmlloyd.classfile.extras.reflect.AccessFlag;
-import io.quarkus.gizmo2.Expr;
+import io.quarkus.gizmo2.Var;
 import io.quarkus.gizmo2.creator.BlockCreator;
 import io.quarkus.gizmo2.creator.InstanceMethodCreator;
 
@@ -20,11 +20,11 @@ public final class PrivateInterfaceMethodCreatorImpl extends MethodCreatorImpl i
     }
 
     public void body(final Consumer<BlockCreator> builder) {
-        super.body(bc -> builder.accept(bc));
+        super.body(builder);
     }
 
     @Override
-    public Expr this_() {
+    public Var this_() {
         return new ThisExpr(owner());
     }
 

--- a/src/main/java/io/quarkus/gizmo2/impl/ThisExpr.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/ThisExpr.java
@@ -3,8 +3,9 @@ package io.quarkus.gizmo2.impl;
 import java.lang.constant.ClassDesc;
 
 import io.github.dmlloyd.classfile.CodeBuilder;
+import io.quarkus.gizmo2.Var;
 
-final class ThisExpr extends Item {
+public final class ThisExpr extends Item implements Var {
     private final ClassDesc type;
 
     ThisExpr(final ClassDesc type) {
@@ -21,5 +22,9 @@ final class ThisExpr extends Item {
 
     public void writeCode(final CodeBuilder cb, final BlockCreatorImpl block) {
         cb.aload(0);
+    }
+
+    public String name() {
+        return "this";
     }
 }

--- a/src/main/java/io/quarkus/gizmo2/impl/Util.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/Util.java
@@ -17,6 +17,8 @@ import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodType;
 import java.lang.invoke.SerializedLambda;
 import java.lang.reflect.UndeclaredThrowableException;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Set;
 import java.util.function.IntPredicate;
 
@@ -119,5 +121,37 @@ public final class Util {
             }
         }
         return low;
+    }
+
+    /**
+     * Append a value to an immutable list without unneeded allocations.
+     * If the list length is greater than some threshold, return an {@code ArrayList}
+     * containing the original list, the addend, and some extra space for new values.
+     *
+     * @param original the original list (must not be {@code null})
+     * @param addend the value to add (must not be {@code null})
+     * @return the new list (not {@code null})
+     * @param <T> the value type
+     */
+    public static <T> List<T> listWith(List<T> original, T addend) {
+        assert ! (original instanceof ArrayList<?>);
+        // this is a no-op if nobody did anything wrong
+        original = List.copyOf(original);
+        return switch (original.size()) {
+            case 0 -> List.of(addend);
+            case 1 -> List.of(original.get(0), addend);
+            case 2 -> List.of(original.get(0), original.get(1), addend);
+            default -> {
+                var a = new ArrayList<T>();
+                a.addAll(original);
+                a.add(addend);
+                yield a;
+            }
+        };
+    }
+
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    public static <T, R> List<R> reinterpretCast(List<T> list) {
+        return (List) list;
     }
 }


### PR DESCRIPTION
* Shuffle some type hierarchies around to make `this` a `Var` and allow a lambda body to share common interfaces with method bodies
* Fix some Javadoc
* Correct the signature of the `lambda()` method itself