### PR TITLE
Gizmo2: introduce OptionalOps

### DIFF
--- a/src/main/java/io/quarkus/gizmo2/creator/BlockCreator.java
+++ b/src/main/java/io/quarkus/gizmo2/creator/BlockCreator.java
@@ -10,6 +10,7 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.locks.Lock;
 import java.util.function.BiConsumer;
@@ -29,6 +30,7 @@ import io.quarkus.gizmo2.creator.ops.IteratorOps;
 import io.quarkus.gizmo2.creator.ops.ListOps;
 import io.quarkus.gizmo2.creator.ops.MapOps;
 import io.quarkus.gizmo2.creator.ops.ObjectOps;
+import io.quarkus.gizmo2.creator.ops.OptionalOps;
 import io.quarkus.gizmo2.creator.ops.SetOps;
 import io.quarkus.gizmo2.creator.ops.StringOps;
 import io.quarkus.gizmo2.desc.ConstructorDesc;
@@ -2596,7 +2598,7 @@ public sealed interface BlockCreator extends SimpleTyped permits BlockCreatorImp
     default MapOps withMap(Expr receiver) {
         return new MapOps(this, receiver);
     }
-
+    
     /**
      * {@return a convenience wrapper for accessing instance methods of {@link Iterator}}
      * @param receiver the instance to invoke upon (must not be {@code null})
@@ -2605,6 +2607,14 @@ public sealed interface BlockCreator extends SimpleTyped permits BlockCreatorImp
         return new IteratorOps(this, receiver);
     }
 
+    /**
+     * {@return a convenience wrapper for accessing instance methods of {@link Optional}}
+     * @param receiver the instance to invoke upon (must not be {@code null})
+     */
+    default OptionalOps withOptional(Expr receiver) {
+        return new OptionalOps(this, receiver);
+    }
+    
     /**
      * Generate a call to {@link Class#forName(String)} which uses the defining class loader of this class.
      *
@@ -2656,7 +2666,7 @@ public sealed interface BlockCreator extends SimpleTyped permits BlockCreatorImp
     /**
      * Generate a call to {@link Map#of()} or one of its variants, based on the number of arguments.
      *
-     * @param entries
+     * @param items the keys and values from which the map is populated
      * @return map expression (not {@code null})
      * @see BlockCreator#withMap(Expr)
      */
@@ -2665,13 +2675,31 @@ public sealed interface BlockCreator extends SimpleTyped permits BlockCreatorImp
     /**
      * Generate a call to {@link Map#of()} or one of its variants, based on the number of arguments.
      *
-     * @param entries
+     * @param items the keys and values from which the map is populated
      * @return map expression (not {@code null})
      * @see BlockCreator#withMap(Expr)
      */
     default Expr mapOf(Expr... items) {
         return mapOf(List.of(items));
     }
+    
+    /**
+     * Generate a call to {@link Optional#of()}.
+     * 
+     * @param value the expression to pass in to the call (must not be {@code null})
+     * @return optional expression (not {@code null})
+     * @see BlockCreator#withOptional(Expr)
+     */
+    Expr optionalOf(Expr value);
+    
+    /**
+     * Generate a call to {@link Optional#ofNullable(Object)}.
+     * 
+     * @param value the expression to pass in to the call (must not be {@code null})
+     * @return optional expression (not {@code null})
+     * @see BlockCreator#withOptional(Expr)
+     */
+    Expr optionalOfNullable(Expr value);
     
     /**
      * Iterate the given target.

--- a/src/main/java/io/quarkus/gizmo2/creator/ops/OptionalOps.java
+++ b/src/main/java/io/quarkus/gizmo2/creator/ops/OptionalOps.java
@@ -1,0 +1,60 @@
+package io.quarkus.gizmo2.creator.ops;
+
+import java.util.Optional;
+
+import io.quarkus.gizmo2.Expr;
+import io.quarkus.gizmo2.creator.BlockCreator;
+
+/**
+ * Operations on {@link Optional}.
+ */
+public class OptionalOps extends ObjectOps {
+
+    /**
+     * Construct a new instance.
+     * 
+     * @param bc the block creator to wrap (must not be {@code null})
+     * @param obj the optional object (must not be {@code null})
+     */
+    public OptionalOps(BlockCreator bc, Expr obj) {
+        super(Optional.class, bc, obj);
+    }
+
+    /**
+     * Generate a call to {@link Optional#get()}.
+     *
+     * @return the expression of the result (not {@code null})
+     */
+    public Expr get() {
+        return invokeInstance(Object.class, "get");
+    }
+
+    /**
+     * Generate a call to {@link Optional#get()}.
+     *
+     * @return the expression of the result (not {@code null})
+     */
+    public Expr isPresent() {
+        return invokeInstance(boolean.class, "isPresent");
+    }
+
+    /**
+     * Generate a call to {@link Optional#get()}.
+     *
+     * @return the expression of the result (not {@code null})
+     */
+    public Expr isEmpty() {
+        return invokeInstance(boolean.class, "isEmpty");
+    }
+
+    /**
+     * Generate a call to {@link Optional#get()}.
+     *
+     * @param other the expression to be returned, if no value is present
+     * @return the expression of the result (not {@code null})
+     */
+    public Expr orElse(Expr other) {
+        return invokeInstance(Object.class, "orElse", Object.class, other);
+    }
+
+}

--- a/src/main/java/io/quarkus/gizmo2/impl/BlockCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/BlockCreatorImpl.java
@@ -1181,6 +1181,16 @@ public final class BlockCreatorImpl extends Item implements BlockCreator {
             throw new UnsupportedOperationException("Maps with more than 10 entries are not supported");
         }
     }
+    
+    @Override
+    public Expr optionalOf(Expr value) {
+        return invokeStatic(MethodDesc.of(Optional.class, "of", Optional.class, Object.class), value);
+    }
+
+    @Override
+    public Expr optionalOfNullable(Expr value) {
+        return invokeStatic(MethodDesc.of(Optional.class, "ofNullable", Optional.class, Object.class), value);
+    }
 
     public void line(final int lineNumber) {
         addItem(new Item() {

--- a/src/test/java/io/quarkus/gizmo2/OptionalOpsTest.java
+++ b/src/test/java/io/quarkus/gizmo2/OptionalOpsTest.java
@@ -1,0 +1,60 @@
+package io.quarkus.gizmo2;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.function.IntSupplier;
+
+import org.junit.jupiter.api.Test;
+
+public class OptionalOpsTest {
+
+    @Test
+    public void testOps() {
+        TestClassMaker tcm = new TestClassMaker();
+        Gizmo g = Gizmo.create(tcm);
+        g.class_("io.quarkus.gizmo2.OptionalOps", cc -> {
+            cc.staticMethod("test", mc -> {
+                // static int test() {
+                //    Optional foo = Optional.of("foo");
+                //    Optional bar = Optional.ofNullable("bar");
+                //    Optional baz = Optional.ofNullable(null);
+                //    if (foo.isEmpty()) {
+                //       return 1;
+                //    }
+                //    if (!foo.isPresent()) {
+                //       return 2;
+                //    }
+                //    if (!foo.get().equals("foo")) {
+                //       return 3;
+                //    }
+                //    if (bar.isEmpty()) {
+                //       return 4;
+                //    }
+                //    if (baz.isPresent()) {
+                //       return 5;
+                //    }
+                //    if (!baz.orElse("qux").equals("qux")) {
+                //       return 5;
+                //    }
+                //    return 0;
+                // }
+                mc.returning(int.class);
+                mc.body(bc -> {
+                    var foo = bc.define("foo", bc.optionalOf(Constant.of("foo")));
+                    var bar = bc.define("bar", bc.optionalOfNullable(Constant.of("bar")));
+                    var baz = bc.define("baz", bc.optionalOfNullable(Constant.ofNull(String.class)));
+                    bc.if_(bc.withOptional(foo).isEmpty(), fail -> fail.return_(1));
+                    bc.unless(bc.withOptional(foo).isPresent(), fail -> fail.return_(2));
+                    bc.unless(bc.exprEquals(Constant.of("foo"), bc.withOptional(foo).get()), fail -> fail.return_(3));
+                    bc.if_(bc.withOptional(bar).isEmpty(), fail -> fail.return_(4));
+                    bc.if_(bc.withOptional(baz).isPresent(), fail -> fail.return_(5));
+                    var qux = Constant.of("qux");
+                    bc.unless(bc.exprEquals(qux, bc.withOptional(baz).orElse(qux)), fail -> fail.return_(6));
+                    bc.return_(0);
+                });
+            });
+        });
+        assertEquals(0, tcm.staticMethod("test", IntSupplier.class).getAsInt());
+    }
+
+}


### PR DESCRIPTION
An alternative to `io.quarkus.gizmo.Gizmo#optionalOperations(BytecodeCreator)`.