### PR TITLE
fix primitive constants

### DIFF
--- a/src/main/java/io/quarkus/gizmo2/Constant.java
+++ b/src/main/java/io/quarkus/gizmo2/Constant.java
@@ -99,6 +99,54 @@ public sealed interface Constant extends Expr, Constable permits ConstantImpl {
      * {@return a constant for the given value}
      * @param value the value to create a constant from (must not be {@code null})
      */
+    static Constant of(Byte value) {
+        return ConstantImpl.of(value);
+    }
+
+    /**
+     * {@return a constant for the given value}
+     * @param value the value to create a constant from
+     */
+    static Constant of(byte value) {
+        return ConstantImpl.of(value);
+    }
+
+    /**
+     * {@return a constant for the given value}
+     * @param value the value to create a constant from (must not be {@code null})
+     */
+    static Constant of(Short value) {
+        return ConstantImpl.of(value);
+    }
+
+    /**
+     * {@return a constant for the given value}
+     * @param value the value to create a constant from
+     */
+    static Constant of(short value) {
+        return ConstantImpl.of(value);
+    }
+
+    /**
+     * {@return a constant for the given value}
+     * @param value the value to create a constant from (must not be {@code null})
+     */
+    static Constant of(Character value) {
+        return ConstantImpl.of(value);
+    }
+
+    /**
+     * {@return a constant for the given value}
+     * @param value the value to create a constant from
+     */
+    static Constant of(char value) {
+        return ConstantImpl.of(value);
+    }
+
+    /**
+     * {@return a constant for the given value}
+     * @param value the value to create a constant from (must not be {@code null})
+     */
     static Constant of(Integer value) {
         return ConstantImpl.of(value);
     }
@@ -156,6 +204,14 @@ public sealed interface Constant extends Expr, Constable permits ConstantImpl {
      * @param value the value to create a constant from
      */
     static Constant of(double value) {
+        return ConstantImpl.of(value);
+    }
+
+    /**
+     * {@return a constant for the given value}
+     * @param value the value to create a constant from
+     */
+    static Constant of(Boolean value) {
         return ConstantImpl.of(value);
     }
 

--- a/src/main/java/io/quarkus/gizmo2/impl/GizmoImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/GizmoImpl.java
@@ -18,6 +18,8 @@ import io.quarkus.gizmo2.StaticFieldVar;
 import io.quarkus.gizmo2.creator.ClassCreator;
 import io.quarkus.gizmo2.creator.InterfaceCreator;
 import io.quarkus.gizmo2.impl.constant.ArrayVarHandleConstant;
+import io.quarkus.gizmo2.impl.constant.ByteConstant;
+import io.quarkus.gizmo2.impl.constant.CharConstant;
 import io.quarkus.gizmo2.impl.constant.ClassConstant;
 import io.quarkus.gizmo2.impl.constant.ConstantImpl;
 import io.quarkus.gizmo2.impl.constant.DoubleConstant;
@@ -27,6 +29,7 @@ import io.quarkus.gizmo2.impl.constant.FloatConstant;
 import io.quarkus.gizmo2.impl.constant.IntConstant;
 import io.quarkus.gizmo2.impl.constant.LongConstant;
 import io.quarkus.gizmo2.impl.constant.NullConstant;
+import io.quarkus.gizmo2.impl.constant.ShortConstant;
 import io.quarkus.gizmo2.impl.constant.StaticFieldVarHandleConstant;
 import io.quarkus.gizmo2.impl.constant.StaticFinalFieldConstant;
 import io.quarkus.gizmo2.impl.constant.StringConstant;
@@ -96,6 +99,18 @@ public final class GizmoImpl implements Gizmo {
 
     public StringConstant stringConstant(String value) {
         return (StringConstant) constants.computeIfAbsent(value, StringConstant::new);
+    }
+
+    public ByteConstant byteConstant(Byte value) {
+        return (ByteConstant) funnyHashCodeConstants.computeIfAbsent(new ByteConstant(value), Function.identity());
+    }
+
+    public ShortConstant shortConstant(Short value) {
+        return (ShortConstant) funnyHashCodeConstants.computeIfAbsent(new ShortConstant(value), Function.identity());
+    }
+
+    public CharConstant charConstant(Character value) {
+        return (CharConstant) funnyHashCodeConstants.computeIfAbsent(new CharConstant(value), Function.identity());
     }
 
     public IntConstant intConstant(Integer value) {

--- a/src/main/java/io/quarkus/gizmo2/impl/Rel.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/Rel.java
@@ -24,7 +24,7 @@ final class Rel extends Item {
             if (kind.if_acmp == null) {
                 throw new IllegalStateException("Invalid comparison for reference types");
             }
-        } else if (a.typeKind() != TypeKind.INT) {
+        } else if (a.typeKind().asLoadable() != TypeKind.INT) {
             throw new UnsupportedOperationException("Only supported on int and reference types");
         }
     }

--- a/src/main/java/io/quarkus/gizmo2/impl/constant/ByteConstant.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/constant/ByteConstant.java
@@ -1,0 +1,40 @@
+package io.quarkus.gizmo2.impl.constant;
+
+import java.lang.constant.DynamicConstantDesc;
+import java.util.Optional;
+
+import static java.lang.constant.ConstantDescs.CD_byte;
+
+public class ByteConstant extends IntBasedConstant {
+    private final Byte value;
+
+    public ByteConstant(Byte value) {
+        super(CD_byte);
+        this.value = value;
+    }
+
+    @Override
+    int intValue() {
+        return value;
+    }
+
+    public boolean equals(final ConstantImpl obj) {
+        return obj instanceof ByteConstant other && equals(other);
+    }
+
+    public boolean equals(final ByteConstant other) {
+        return this == other || other != null && value.equals(other.value);
+    }
+
+    public int hashCode() {
+        return value.hashCode();
+    }
+
+    public DynamicConstantDesc<Byte> desc() {
+        return describeConstable().get();
+    }
+
+    public Optional<DynamicConstantDesc<Byte>> describeConstable() {
+        return value.describeConstable();
+    }
+}

--- a/src/main/java/io/quarkus/gizmo2/impl/constant/CharConstant.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/constant/CharConstant.java
@@ -1,0 +1,40 @@
+package io.quarkus.gizmo2.impl.constant;
+
+import java.lang.constant.DynamicConstantDesc;
+import java.util.Optional;
+
+import static java.lang.constant.ConstantDescs.CD_char;
+
+public class CharConstant extends IntBasedConstant {
+    private final Character value;
+
+    public CharConstant(Character value) {
+        super(CD_char);
+        this.value = value;
+    }
+
+    @Override
+    int intValue() {
+        return value;
+    }
+
+    public boolean equals(final ConstantImpl obj) {
+        return obj instanceof CharConstant other && equals(other);
+    }
+
+    public boolean equals(final CharConstant other) {
+        return this == other || other != null && value.equals(other.value);
+    }
+
+    public int hashCode() {
+        return value.hashCode();
+    }
+
+    public DynamicConstantDesc<Character> desc() {
+        return describeConstable().get();
+    }
+
+    public Optional<DynamicConstantDesc<Character>> describeConstable() {
+        return value.describeConstable();
+    }
+}

--- a/src/main/java/io/quarkus/gizmo2/impl/constant/IntBasedConstant.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/constant/IntBasedConstant.java
@@ -1,0 +1,53 @@
+package io.quarkus.gizmo2.impl.constant;
+
+import io.github.dmlloyd.classfile.CodeBuilder;
+import io.quarkus.gizmo2.impl.BlockCreatorImpl;
+
+import java.lang.constant.ClassDesc;
+import java.lang.constant.ConstantDesc;
+import java.lang.constant.ConstantDescs;
+import java.util.Optional;
+
+abstract class IntBasedConstant extends ConstantImpl {
+    IntBasedConstant(ClassDesc type) {
+        super(type);
+    }
+
+    abstract int intValue();
+
+    public void writeCode(final CodeBuilder cb, final BlockCreatorImpl block) {
+        int i = intValue();
+        switch (i) {
+            case -5 -> {
+                cb.iconst_5();
+                cb.ineg();
+            }
+            case -4 -> {
+                cb.iconst_4();
+                cb.ineg();
+            }
+            case -3 -> {
+                cb.iconst_3();
+                cb.ineg();
+            }
+            case -2 -> {
+                cb.iconst_2();
+                cb.ineg();
+            }
+            default -> cb.loadConstant(i);
+        }
+    }
+
+    public boolean isZero() {
+        return intValue() == 0;
+    }
+
+    public boolean isNonZero() {
+        return intValue() != 0;
+    }
+
+    public StringBuilder toShortString(final StringBuilder b) {
+        int i = intValue();
+        return b.append(i).append(" (0x").append(Integer.toHexString(i)).append(')');
+    }
+}

--- a/src/main/java/io/quarkus/gizmo2/impl/constant/IntConstant.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/constant/IntConstant.java
@@ -7,7 +7,7 @@ import java.util.Optional;
 import io.github.dmlloyd.classfile.CodeBuilder;
 import io.quarkus.gizmo2.impl.BlockCreatorImpl;
 
-public final class IntConstant extends ConstantImpl {
+public final class IntConstant extends IntBasedConstant {
     private final Integer value;
 
     public IntConstant(Integer value) {
@@ -20,38 +20,7 @@ public final class IntConstant extends ConstantImpl {
     }
 
     public int intValue() {
-        return value.intValue();
-    }
-
-    public void writeCode(final CodeBuilder cb, final BlockCreatorImpl block) {
-        int unboxed = value.intValue();
-        switch (unboxed) {
-            case -5 -> {
-                cb.iconst_5();
-                cb.ineg();
-            }
-            case -4 -> {
-                cb.iconst_4();
-                cb.ineg();
-            }
-            case -3 -> {
-                cb.iconst_3();
-                cb.ineg();
-            }
-            case -2 -> {
-                cb.iconst_2();
-                cb.ineg();
-            }
-            default -> cb.loadConstant(value);
-        }
-    }
-
-    public boolean isZero() {
-        return value.intValue() == 0;
-    }
-
-    public boolean isNonZero() {
-        return value.intValue() != 0;
+        return value;
     }
 
     public boolean equals(final ConstantImpl obj) {
@@ -72,9 +41,5 @@ public final class IntConstant extends ConstantImpl {
 
     public Optional<Integer> describeConstable() {
         return Optional.of(value);
-    }
-
-    public StringBuilder toShortString(final StringBuilder b) {
-        return b.append(value).append(" (0x").append(Integer.toHexString(value.intValue())).append(')');
     }
 }

--- a/src/main/java/io/quarkus/gizmo2/impl/constant/ShortConstant.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/constant/ShortConstant.java
@@ -1,0 +1,40 @@
+package io.quarkus.gizmo2.impl.constant;
+
+import java.lang.constant.DynamicConstantDesc;
+import java.util.Optional;
+
+import static java.lang.constant.ConstantDescs.CD_short;
+
+public class ShortConstant extends IntBasedConstant {
+    private final Short value;
+
+    public ShortConstant(Short value) {
+        super(CD_short);
+        this.value = value;
+    }
+
+    @Override
+    int intValue() {
+        return value;
+    }
+
+    public boolean equals(final ConstantImpl obj) {
+        return obj instanceof ShortConstant other && equals(other);
+    }
+
+    public boolean equals(final ShortConstant other) {
+        return this == other || other != null && value.equals(other.value);
+    }
+
+    public int hashCode() {
+        return value.hashCode();
+    }
+
+    public DynamicConstantDesc<Short> desc() {
+        return describeConstable().get();
+    }
+
+    public Optional<DynamicConstantDesc<Short>> describeConstable() {
+        return value.describeConstable();
+    }
+}

--- a/src/test/java/io/quarkus/gizmo2/BoxUnboxTest.java
+++ b/src/test/java/io/quarkus/gizmo2/BoxUnboxTest.java
@@ -26,21 +26,27 @@ public class BoxUnboxTest {
                 mc.returning(Object.class);
                 mc.body(bc -> {
                     var boolVal = bc.box(Constant.of(true));
+                    var byteVal = bc.box(Constant.of((byte) 123));
+                    var shortVal = bc.box(Constant.of((short) 456));
+                    var charVal = bc.box(Constant.of('a'));
                     var intVal = bc.box(Constant.of(65536));
                     var longVal = bc.box(Constant.of(Long.MAX_VALUE));
                     var floatVal = bc.box(Constant.of((float) 1.1));
                     var doubleVal = bc.box(Constant.of(1.2));
-                    bc.return_(bc.listOf(boolVal, intVal, longVal, floatVal, doubleVal));
+                    bc.return_(bc.listOf(boolVal, byteVal, shortVal, charVal, intVal, longVal, floatVal, doubleVal));
                 });
             });
         });
         @SuppressWarnings("unchecked")
         List<Object> list = (List<Object>) tcm.staticMethod("test", Supplier.class).get();
         assertEquals(Boolean.TRUE, list.get(0));
-        assertEquals(Integer.valueOf(65536), list.get(1));
-        assertEquals(Long.MAX_VALUE, list.get(2));
-        assertEquals(Float.valueOf((float) 1.1), list.get(3));
-        assertEquals(Double.valueOf(1.2), list.get(4));
+        assertEquals((byte) 123, list.get(1));
+        assertEquals((short) 456, list.get(2));
+        assertEquals('a', list.get(3));
+        assertEquals(65536, list.get(4));
+        assertEquals(Long.MAX_VALUE, list.get(5));
+        assertEquals(1.1F, list.get(6));
+        assertEquals(1.2, list.get(7));
     }
 
     @Test
@@ -49,25 +55,37 @@ public class BoxUnboxTest {
         Gizmo g = Gizmo.create(tcm);
         g.class_("io.quarkus.gizmo2.Unbox", cc -> {
             cc.staticMethod("test", mc -> {
-                // static int test(Boolean b, Integer i, Long l, Float f, Double d) {
-                //    if (!b) {
+                // static int test(Boolean bool, Byte b, Short s, Character c, Integer i, Long l, Float f, Double d) {
+                //    if (!bool) {
                 //       return 1;
                 //    }
+                //    if (b != (byte) 123) {
+                //        return 2;
+                //    }
+                //    if (s != (short) 456) {
+                //        return 3;
+                //    }
+                //    if (c != 'a') {
+                //        return 4;
+                //    }
                 //    if (i != 10) {
-                //       return 2;
+                //       return 5;
                 //    }
                 //    if (l != 100l) {
-                //       return 3;
+                //       return 6;
                 //    }
                 //    if (f != (float) 1.2) {
-                //       return 4;
+                //       return 7;
                 //    }
                 //    if (d != 2.1) {
-                //       return 5;
+                //       return 8;
                 //    }
                 //    return 0;
                 // }
-                var b = mc.parameter("b", Boolean.class);
+                var bool = mc.parameter("bool", Boolean.class);
+                var b = mc.parameter("b", Byte.class);
+                var s = mc.parameter("s", Short.class);
+                var c = mc.parameter("c", Character.class);
                 var i = mc.parameter("i", Integer.class);
                 var l = mc.parameter("l", Long.class);
                 var f = mc.parameter("f", Float.class);
@@ -79,22 +97,23 @@ public class BoxUnboxTest {
                     var lu = bc.define("lv", bc.unbox(l));
                     var fu = bc.define("fv", bc.unbox(f));
                     var du = bc.define("dv", bc.unbox(d));
-                    bc.unless(bc.unbox(b), fail -> fail.return_(1));
-                    bc.if_(bc.ne(bc.unbox(i), 10), fail -> fail.return_(2));
-                    bc.if_(bc.ne(lu, 100l), fail -> fail.return_(3));
-                    bc.if_(bc.ne(fu, (float) 1.2), fail -> fail.return_(4));
-                    bc.if_(bc.ne(du, 2.1), fail -> fail.return_(5));
+                    bc.unless(bc.unbox(bool), fail -> fail.return_(1));
+                    bc.if_(bc.ne(bc.unbox(b), Constant.of((byte) 123)), fail -> fail.return_(2));
+                    bc.if_(bc.ne(bc.unbox(s), Constant.of((short) 456)), fail -> fail.return_(3));
+                    bc.if_(bc.ne(bc.unbox(c), Constant.of('a')), fail -> fail.return_(4));
+                    bc.if_(bc.ne(bc.unbox(i), 10), fail -> fail.return_(5));
+                    bc.if_(bc.ne(lu, 100L), fail -> fail.return_(6));
+                    bc.if_(bc.ne(fu, 1.2F), fail -> fail.return_(7));
+                    bc.if_(bc.ne(du, 2.1), fail -> fail.return_(8));
                     bc.return_(0);
                 });
             });
         });
-        assertEquals(0, tcm.staticMethod("test", BoxSupplier.class).get(Boolean.TRUE, 10, 100l, (float) 1.2, 2.1));
+        assertEquals(0, tcm.staticMethod("test", BoxSupplier.class)
+                .get(Boolean.TRUE, (byte) 123, (short) 456, 'a', 10, 100L, 1.2F, 2.1));
     }
 
     public interface BoxSupplier {
-
-        int get(Boolean b, Integer i, Long l, Float f, Double d);
-
+        int get(Boolean bool, Byte b, Short s, Character c, Integer i, Long l, Float f, Double d);
     }
-
 }

--- a/src/test/java/io/quarkus/gizmo2/PrimitiveConstantsTest.java
+++ b/src/test/java/io/quarkus/gizmo2/PrimitiveConstantsTest.java
@@ -1,0 +1,48 @@
+package io.quarkus.gizmo2;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.function.Supplier;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class PrimitiveConstantsTest {
+    @Test
+    public void primitiveConstants() {
+        test(() -> Constant.of((byte) 1), "B");
+        test(() -> Constant.of((short) 2), "S");
+        test(() -> Constant.of('a'), "C");
+        test(() -> Constant.of(4), "I");
+        test(() -> Constant.of(5L), "J");
+        test(() -> Constant.of(6.0F), "F");
+        test(() -> Constant.of(7.0), "D");
+        test(() -> Constant.of(true), "Z");
+    }
+
+    @Test
+    public void wrappersAsPrimitiveConstants() {
+        test(() -> Constant.of((Byte) (byte) 1), "B");
+        test(() -> Constant.of((Short) (short) 2), "S");
+        test(() -> Constant.of((Character) 'a'), "C");
+        test(() -> Constant.of((Integer) 4), "I");
+        test(() -> Constant.of((Long) 5L), "J");
+        test(() -> Constant.of((Float) 6.0F), "F");
+        test(() -> Constant.of((Double) 7.0), "D");
+        test(() -> Constant.of(Boolean.TRUE), "Z");
+    }
+
+    private void test(Supplier<Constant> bytecode, String expectedResult) {
+        TestClassMaker tcm = new TestClassMaker();
+        Gizmo g = Gizmo.create(tcm);
+        g.class_("io.quarkus.gizmo2.TestPrimitiveConstants", cc -> {
+            cc.staticMethod("returnDescriptor", mc -> {
+                mc.returning(Object.class); // in fact always `String`
+                mc.body(bc -> {
+                    Constant c = bytecode.get();
+                    bc.return_(c.type().descriptorString());
+                });
+            });
+        });
+        assertEquals(expectedResult, tcm.staticMethod("returnDescriptor", Supplier.class).get());
+    }
+}

--- a/src/test/java/io/quarkus/gizmo2/TestSwitch.java
+++ b/src/test/java/io/quarkus/gizmo2/TestSwitch.java
@@ -5,12 +5,57 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import java.lang.constant.ClassDesc;
 import java.util.function.IntUnaryOperator;
-import java.util.function.ToIntFunction;
 
 import io.quarkus.gizmo2.impl.constant.IntConstant;
 import org.junit.jupiter.api.Test;
 
 public final class TestSwitch {
+
+    @FunctionalInterface
+    public interface CharUnaryOperator {
+        char apply(char operand);
+    }
+
+    @Test
+    public void testCharSwitch() {
+        TestClassMaker tcm = new TestClassMaker();
+        Gizmo g = Gizmo.create(tcm);
+        g.class_(ClassDesc.of("io.quarkus.gizmo2.TestCharSwitchExpr"), zc -> {
+            zc.staticMethod("frobnicate", mc -> {
+                mc.returning(char.class);
+                ParamVar cp = mc.parameter("cp", char.class);
+                mc.body(b0 -> {
+                    b0.return_(b0.switch_(CD_char, cp, sc -> {
+                        sc.case_(cc -> {
+                            cc.of('a');
+                            cc.body(b1 -> b1.yield(Constant.of('i')));
+                        });
+                        sc.case_(cc -> {
+                            cc.of('e');
+                            cc.body(b1 -> b1.yield(Constant.of('o')));
+                        });
+                        sc.case_(cc -> {
+                            cc.of('i');
+                            cc.body(b1 -> b1.yield(Constant.of('u')));
+                        });
+                        sc.case_(cc -> {
+                            cc.of('o');
+                            cc.body(b1 -> b1.yield(Constant.of('a')));
+                        });
+                        sc.case_(cc -> {
+                            cc.of('u');
+                            cc.body(b1 -> b1.yield(Constant.of('e')));
+                        });
+                        sc.default_(b1 -> b1.yield(cp));
+                    }));
+                });
+            });
+        });
+        CharUnaryOperator frobnicate = tcm.staticMethod("frobnicate", CharUnaryOperator.class);
+        assertEquals('i', frobnicate.apply('a'));
+        assertEquals('q', frobnicate.apply('q'));
+        assertEquals('o', frobnicate.apply('e'));
+    }
 
     @Test
     public void testIntSwitch() {
@@ -24,23 +69,23 @@ public final class TestSwitch {
                     b0.return_(b0.switch_(CD_int, cp, sc -> {
                         sc.case_(cc -> {
                             cc.of('a');
-                            cc.body(b1 -> b1.yield(IntConstant.of('i')));
+                            cc.body(b1 -> b1.yield(Constant.of((int) 'i')));
                         });
                         sc.case_(cc -> {
                             cc.of('e');
-                            cc.body(b1 -> b1.yield(IntConstant.of('o')));
+                            cc.body(b1 -> b1.yield(Constant.of((int) 'o')));
                         });
                         sc.case_(cc -> {
                             cc.of('i');
-                            cc.body(b1 -> b1.yield(IntConstant.of('u')));
+                            cc.body(b1 -> b1.yield(Constant.of((int) 'u')));
                         });
                         sc.case_(cc -> {
                             cc.of('o');
-                            cc.body(b1 -> b1.yield(IntConstant.of('a')));
+                            cc.body(b1 -> b1.yield(Constant.of((int) 'a')));
                         });
                         sc.case_(cc -> {
                             cc.of('u');
-                            cc.body(b1 -> b1.yield(IntConstant.of('e')));
+                            cc.body(b1 -> b1.yield(Constant.of((int) 'e')));
                         });
                         sc.default_(b1 -> b1.yield(cp));
                     }));


### PR DESCRIPTION
We need constants of types `byte`, `short` and `char` because without them, we cannot statically make a difference between them and `int`, which may lead to all kinds of issues. For example, we could emit an invocation of a different overload of a method than expected, if the target class has an overload of the method for both `byte` (or `short` or `char`) and `int`.

In addition to that, this commit also adds `Constant.of(Boolean)`, because `java.lang.Boolean` constants were not of the primitive type, unlike all others. This might be a bad idea, but all other constants of wrapper types are in fact constants of the corresponding primitive type, and consistency is warranted. We might later want to rethink that.