### PR TITLE
Gizmo2: add LambdaTest

### DIFF
--- a/src/main/java/io/quarkus/gizmo2/creator/BlockCreator.java
+++ b/src/main/java/io/quarkus/gizmo2/creator/BlockCreator.java
@@ -2053,7 +2053,11 @@ public sealed interface BlockCreator extends SimpleTyped permits BlockCreatorImp
         return invokeInterface(method, instance, List.of(args));
     }
 
-    Expr invokeDynamic(final DynamicCallSiteDesc callSiteDesc);
+    Expr invokeDynamic(DynamicCallSiteDesc callSiteDesc, List<Expr> args);
+
+    default Expr invokeDynamic(DynamicCallSiteDesc callSiteDesc, Expr... args) {
+        return invokeDynamic(callSiteDesc, List.of(args));
+    }
 
     // control flow
 

--- a/src/main/java/io/quarkus/gizmo2/impl/BlockCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/BlockCreatorImpl.java
@@ -320,7 +320,7 @@ public final class BlockCreatorImpl extends Item implements BlockCreator {
         ClassDesc boxType = a.type();
         ClassDesc unboxType = unboxTypes.get(boxType);
         if (unboxType == null) {
-            throw new IllegalArgumentException("No unbox type for " + boxType);
+            throw new IllegalArgumentException("No unbox type for " + boxType.displayName());
         }
         return invokeVirtual(ClassMethodDesc.of(boxType, switch (TypeKind.from(unboxType)) {
             case BOOLEAN -> "booleanValue";

--- a/src/main/java/io/quarkus/gizmo2/impl/BlockCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/BlockCreatorImpl.java
@@ -648,7 +648,7 @@ public final class BlockCreatorImpl extends Item implements BlockCreator {
             ),
             encoded,
             ctorType
-        ));
+        ), captureExprs);
     }
 
     public Expr newAnonymousClass(final ConstructorDesc superCtor, final List<Expr> args, final Consumer<AnonymousClassCreator> builder) {
@@ -746,8 +746,17 @@ public final class BlockCreatorImpl extends Item implements BlockCreator {
         return addItem(new Invoke(Opcode.INVOKEINTERFACE, method, instance, args));
     }
 
-    public Expr invokeDynamic(final DynamicCallSiteDesc callSiteDesc) {
+    public Expr invokeDynamic(final DynamicCallSiteDesc callSiteDesc, final List<Expr> args) {
         return addItem(new Item() {
+            protected Node forEachDependency(Node node, final BiFunction<Item, Node, Node> op) {
+                node = node.prev();
+                for (int i = args.size() - 1; i >= 0; i--) {
+                    final Item arg = (Item) args.get(i);
+                    node = arg.process(node, op);
+                }
+                return node;
+            }
+
             public ClassDesc type() {
                 return callSiteDesc.invocationType().returnType();
             }

--- a/src/main/java/io/quarkus/gizmo2/impl/ExecutableCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/ExecutableCreatorImpl.java
@@ -219,8 +219,7 @@ public sealed abstract class ExecutableCreatorImpl extends AnnotatableCreatorImp
                 throw new IllegalStateException("Parameter already defined at position " + position);
             }
             pc = new ParamCreatorImpl(type.parameterType(position));
-            final MethodTypeDesc finalType = type;
-            slot = IntStream.range(0, position).map(i -> TypeKind.from(finalType.parameterType(i)).slotSize()).sum();
+            slot = firstSlot() + IntStream.range(0, position).mapToObj(type::parameterType).map(TypeKind::from).mapToInt(TypeKind::slotSize).sum();
         }
         ParamVarImpl pv = pc.apply(builder, name, position, slot);
         params[position] = pv;

--- a/src/test/java/io/quarkus/gizmo2/AnonClassTest.java
+++ b/src/test/java/io/quarkus/gizmo2/AnonClassTest.java
@@ -6,7 +6,6 @@ import java.lang.constant.ClassDesc;
 import java.lang.constant.MethodTypeDesc;
 import java.util.List;
 
-import io.github.dmlloyd.classfile.extras.reflect.AccessFlag;
 import io.quarkus.gizmo2.creator.MemberCreator;
 import io.quarkus.gizmo2.desc.ClassMethodDesc;
 import io.quarkus.gizmo2.desc.ConstructorDesc;
@@ -79,26 +78,4 @@ public final class AnonClassTest {
         tcm.staticMethod("runTest", Runnable.class).run();
     }
 
-    @Test
-    public void basicLambdaTest() {
-        TestClassMaker tcm = new TestClassMaker();
-        Gizmo g = Gizmo.create(tcm);
-        g.class_("io.quarkus.gizmo2.Outer", cc -> {
-            cc.staticMethod("runTest", smc -> {
-                smc.body(b0 -> {
-                    b0.printf("Starting test%n");
-                    Expr runnable = b0.lambda(Runnable.class, lc -> {
-                        lc.body(b1 -> {
-                            b1.printf("Inside the runnable%n");
-                            b1.return_();
-                        });
-                    });
-                    b0.invokeInterface(MethodDesc.of(Runnable.class, "run", void.class), runnable);
-                    b0.printf("After runnable%n");
-                    b0.return_();
-                });
-            });
-        });
-        tcm.staticMethod("runTest", Runnable.class).run();
-    }
 }

--- a/src/test/java/io/quarkus/gizmo2/LambdaTest.java
+++ b/src/test/java/io/quarkus/gizmo2/LambdaTest.java
@@ -81,7 +81,7 @@ public class LambdaTest {
                         });
                     }));
                     bc.invokeInterface(MethodDesc.of(Consumer.class, "accept", void.class, Object.class), consumer,
-                            suppliedValue);
+                            bc.box(suppliedValue));
                     var retVal = bc.invokeVirtual(MethodDesc.of(AtomicInteger.class, "get", int.class), ret);
                     bc.return_(retVal);
                 });

--- a/src/test/java/io/quarkus/gizmo2/LambdaTest.java
+++ b/src/test/java/io/quarkus/gizmo2/LambdaTest.java
@@ -1,0 +1,61 @@
+package io.quarkus.gizmo2;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+import java.util.function.IntSupplier;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.gizmo2.desc.MethodDesc;
+
+public class LambdaTest {
+
+    @Test
+    public void testBasicLambdas() {
+        TestClassMaker tcm = new TestClassMaker();
+        Gizmo g = Gizmo.create(tcm);
+        g.class_("io.quarkus.gizmo2.Lambdas", cc -> {
+            cc.staticMethod("test", mc -> {
+                // static int test() {
+                //    AtomicInteger ret = new AtomicInteger();
+                //    IntSupplier supplier = () -> 1;
+                //    int suppliedValue = supplier.getAsInt();
+                //    Consumer<Integer> consumer = i -> ret.set(i);
+                //    consumer.accept(suppliedValue);
+                //    return ret.get();
+                // }
+                mc.returning(int.class);
+                mc.body(bc -> {
+                    var ret = bc.define("ret", bc.new_(AtomicInteger.class));
+                    var supplier = bc.declare("supplier", IntSupplier.class);
+                    bc.set(supplier, bc.lambda(IntSupplier.class, lc -> {
+                        lc.body(lbc -> {
+                            lbc.return_(1);
+                        });
+                    }));
+                    var suppliedValue = bc.define("suppliedValue",
+                            bc.invokeInterface(MethodDesc.of(IntSupplier.class, "getAsInt", int.class), supplier));
+                    var consumer = bc.declare("consumer", Consumer.class);
+                    bc.set(consumer, bc.lambda(Consumer.class, lc -> {
+                        var capturedRet = lc.capture(ret);
+                        var input = lc.parameter("t", 0);
+                        lc.body(lbc -> {
+                            var suppliedValueInteger = lbc.cast(input, Integer.class);
+                            var suppliedValueInt = lbc.unbox(suppliedValueInteger);
+                            lbc.invokeInterface(MethodDesc.of(AtomicInteger.class, "set", void.class, int.class), capturedRet,
+                                    suppliedValueInt);
+                        });
+                    }));
+                    bc.invokeInterface(MethodDesc.of(Consumer.class, "accept", void.class, Object.class), consumer,
+                            suppliedValue);
+                    var retVal = bc.invokeVirtual(MethodDesc.of(AtomicInteger.class, "get", int.class), ret);
+                    bc.return_(retVal);
+                });
+            });
+        });
+        assertEquals(1, tcm.staticMethod("test", IntSupplier.class).getAsInt());
+    }
+
+}


### PR DESCRIPTION
```
java.lang.ClassCastException: class io.github.dmlloyd.classfile.impl.AbstractPoolEntry$MethodRefEntryImpl cannot be cast to class io.github.dmlloyd.classfile.constantpool.InterfaceMethodRefEntry (io.github.dmlloyd.classfile.impl.AbstractPoolEntry$MethodRefEntryImpl and io.github.dmlloyd.classfile.constantpool.InterfaceMethodRefEntry are in module io.github.dmlloyd.classfile@24.0 of loader 'app')
	at io.github.dmlloyd.classfile@24.0/io.github.dmlloyd.classfile.impl.AbstractInstruction$UnboundInvokeInstruction.writeTo(AbstractInstruction.java:1056)
	at io.github.dmlloyd.classfile@24.0/io.github.dmlloyd.classfile.impl.DirectCodeBuilder.with(DirectCodeBuilder.java:125)
	at io.github.dmlloyd.classfile@24.0/io.github.dmlloyd.classfile.impl.DirectCodeBuilder.with(DirectCodeBuilder.java:47)
	at io.github.dmlloyd.classfile@24.0/io.github.dmlloyd.classfile.impl.BlockCodeBuilderImpl.with(BlockCodeBuilderImpl.java:87)
	at io.github.dmlloyd.classfile@24.0/io.github.dmlloyd.classfile.impl.BlockCodeBuilderImpl.with(BlockCodeBuilderImpl.java:37)
	at io.github.dmlloyd.classfile@24.0/io.github.dmlloyd.classfile.CodeBuilder.invoke(CodeBuilder.java:540)
	at io.github.dmlloyd.classfile@24.0/io.github.dmlloyd.classfile.CodeBuilder.invoke(CodeBuilder.java:557)
	at io.quarkus.gizmo2@2.0.1-SNAPSHOT/io.quarkus.gizmo2.impl.Invoke.writeCode(Invoke.java:59)
	at io.quarkus.gizmo2@2.0.1-SNAPSHOT/io.quarkus.gizmo2.impl.BlockCreatorImpl.lambda$writeCode$39(BlockCreatorImpl.java:1230)
	at io.github.dmlloyd.classfile@24.0/io.github.dmlloyd.classfile.CodeBuilder.block(CodeBuilder.java:210)
	at io.quarkus.gizmo2@2.0.1-SNAPSHOT/io.quarkus.gizmo2.impl.BlockCreatorImpl.writeCode(BlockCreatorImpl.java:1226)
	at io.quarkus.gizmo2@2.0.1-SNAPSHOT/io.quarkus.gizmo2.impl.ExecutableCreatorImpl.doCode(ExecutableCreatorImpl.java:169)
	at io.quarkus.gizmo2@2.0.1-SNAPSHOT/io.quarkus.gizmo2.impl.ExecutableCreatorImpl.lambda$doBody$6(ExecutableCreatorImpl.java:153)
	at io.github.dmlloyd.classfile@24.0/io.github.dmlloyd.classfile.impl.DirectCodeBuilder.build(DirectCodeBuilder.java:92)
	at io.github.dmlloyd.classfile@24.0/io.github.dmlloyd.classfile.impl.DirectMethodBuilder.withCode(DirectMethodBuilder.java:118)
	at io.github.dmlloyd.classfile@24.0/io.github.dmlloyd.classfile.impl.DirectMethodBuilder.withCode(DirectMethodBuilder.java:125)
	at io.quarkus.gizmo2@2.0.1-SNAPSHOT/io.quarkus.gizmo2.impl.ExecutableCreatorImpl.doBody(ExecutableCreatorImpl.java:152)
	at io.quarkus.gizmo2@2.0.1-SNAPSHOT/io.quarkus.gizmo2.impl.ExecutableCreatorImpl.lambda$body$7(ExecutableCreatorImpl.java:180)
	at io.github.dmlloyd.classfile@24.0/io.github.dmlloyd.classfile.impl.DirectMethodBuilder.run(DirectMethodBuilder.java:139)
	at io.github.dmlloyd.classfile@24.0/io.github.dmlloyd.classfile.impl.DirectClassBuilder.withMethod(DirectClassBuilder.java:117)
	at io.github.dmlloyd.classfile@24.0/io.github.dmlloyd.classfile.ClassBuilder.withMethod(ClassBuilder.java:313)
	at io.quarkus.gizmo2@2.0.1-SNAPSHOT/io.quarkus.gizmo2.impl.ExecutableCreatorImpl.body(ExecutableCreatorImpl.java:179)
	at io.quarkus.gizmo2@2.0.1-SNAPSHOT/io.quarkus.gizmo2.impl.InstanceMethodCreatorImpl.body(InstanceMethodCreatorImpl.java:16)
	at io.quarkus.gizmo2@2.0.1-SNAPSHOT/io.quarkus.gizmo2.impl.LambdaCreatorImpl.body(LambdaCreatorImpl.java:30)
	at io.quarkus.gizmo2@2.0.1-SNAPSHOT/io.quarkus.gizmo2.LambdaTest.lambda$5(LambdaTest.java:44)
```

@dmlloyd Have you come across this before?