### PR TITLE
fix the ArrayStore item

### DIFF
--- a/src/main/java/io/quarkus/gizmo2/creator/BlockCreator.java
+++ b/src/main/java/io/quarkus/gizmo2/creator/BlockCreator.java
@@ -369,63 +369,63 @@ public sealed interface BlockCreator extends SimpleTyped permits BlockCreatorImp
     /**
      * Create a new, empty array of the given type.
      *
-     * @param elemType the element type (must not be {@code null})
+     * @param componentType the component type (must not be {@code null})
      * @param size the size of the array (must not be {@code null})
      * @return the expression for the new array (not {@code null})
      */
-    Expr newEmptyArray(ClassDesc elemType, Expr size);
+    Expr newEmptyArray(ClassDesc componentType, Expr size);
 
     /**
      * Create a new, empty array of the given type.
      *
-     * @param elemType the element type (must not be {@code null})
+     * @param componentType the component type (must not be {@code null})
      * @param size the size of the array (must not be {@code null})
      * @return the expression for the new array (not {@code null})
      */
-    default Expr newEmptyArray(Class<?> elemType, Expr size) {
-        return newEmptyArray(Util.classDesc(elemType), size);
+    default Expr newEmptyArray(Class<?> componentType, Expr size) {
+        return newEmptyArray(Util.classDesc(componentType), size);
     }
 
     /**
      * Create a new array with the given type, initialized with the given values.
      *
-     * @param elementType the element type (must not be {@code null})
+     * @param componentType the component type (must not be {@code null})
      * @param values the values to assign into the array (must not be {@code null})
      * @return the expression for the new array (not {@code null})
      */
-    Expr newArray(ClassDesc elementType, List<Expr> values);
+    Expr newArray(ClassDesc componentType, List<Expr> values);
 
     /**
      * Create a new array with the given type, initialized with the given values.
      *
-     * @param elementType the element type (must not be {@code null})
+     * @param componentType the component type (must not be {@code null})
      * @param values the values to assign into the array (must not be {@code null})
      * @return the expression for the new array (not {@code null})
      */
-    default Expr newArray(ClassDesc elementType, Expr... values) {
-        return newArray(elementType, List.of(values));
+    default Expr newArray(ClassDesc componentType, Expr... values) {
+        return newArray(componentType, List.of(values));
     }
 
     /**
      * Create a new array with the given type, initialized with the given values.
      *
-     * @param elementType the element type (must not be {@code null})
+     * @param componentType the component type (must not be {@code null})
      * @param values the values to assign into the array (must not be {@code null})
      * @return the expression for the new array (not {@code null})
      */
-    default Expr newArray(Class<?> elementType, List<Expr> values) {
-        return newArray(Util.classDesc(elementType), values);
+    default Expr newArray(Class<?> componentType, List<Expr> values) {
+        return newArray(Util.classDesc(componentType), values);
     }
 
     /**
      * Create a new array with the given type, initialized with the given values.
      *
-     * @param elementType the element type (must not be {@code null})
+     * @param componentType the component type (must not be {@code null})
      * @param values the values to assign into the array (must not be {@code null})
      * @return the expression for the new array (not {@code null})
      */
-    default Expr newArray(Class<?> elementType, Expr... values) {
-        return newArray(elementType, List.of(values));
+    default Expr newArray(Class<?> componentType, Expr... values) {
+        return newArray(componentType, List.of(values));
     }
 
     // relational ops
@@ -2593,7 +2593,7 @@ public sealed interface BlockCreator extends SimpleTyped permits BlockCreatorImp
     default SetOps withSet(Expr receiver) {
         return new SetOps(this, receiver);
     }
-    
+
     /**
      * {@return a convenience wrapper for accessing instance methods of {@link Map}}
      * 
@@ -2602,7 +2602,7 @@ public sealed interface BlockCreator extends SimpleTyped permits BlockCreatorImp
     default MapOps withMap(Expr receiver) {
         return new MapOps(this, receiver);
     }
-    
+
     /**
      * {@return a convenience wrapper for accessing instance methods of {@link Iterator}}
      * @param receiver the instance to invoke upon (must not be {@code null})
@@ -2618,7 +2618,7 @@ public sealed interface BlockCreator extends SimpleTyped permits BlockCreatorImp
     default OptionalOps withOptional(Expr receiver) {
         return new OptionalOps(this, receiver);
     }
-    
+
     /**
      * Generate a call to {@link Class#forName(String)} which uses the defining class loader of this class.
      *
@@ -2688,23 +2688,23 @@ public sealed interface BlockCreator extends SimpleTyped permits BlockCreatorImp
     }
     
     /**
-     * Generate a call to {@link Optional#of()}.
-     * 
+     * Generate a call to {@link Optional#of(Object)}.
+     *
      * @param value the expression to pass in to the call (must not be {@code null})
      * @return optional expression (not {@code null})
      * @see BlockCreator#withOptional(Expr)
      */
     Expr optionalOf(Expr value);
-    
+
     /**
      * Generate a call to {@link Optional#ofNullable(Object)}.
-     * 
+     *
      * @param value the expression to pass in to the call (must not be {@code null})
      * @return optional expression (not {@code null})
      * @see BlockCreator#withOptional(Expr)
      */
     Expr optionalOfNullable(Expr value);
-    
+
     /**
      * Iterate the given target.
      *

--- a/src/main/java/io/quarkus/gizmo2/impl/ArrayStore.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/ArrayStore.java
@@ -1,18 +1,22 @@
 package io.quarkus.gizmo2.impl;
 
+import java.lang.constant.ClassDesc;
 import java.util.function.BiFunction;
 
 import io.github.dmlloyd.classfile.CodeBuilder;
+import io.github.dmlloyd.classfile.TypeKind;
 
 final class ArrayStore extends Item {
     private final Item arrayExpr;
     private final Item index;
     private final Item value;
+    private final ClassDesc componentType;
 
-    ArrayStore(final Item arrayExpr, final Item index, final Item value) {
+    ArrayStore(final Item arrayExpr, final Item index, final Item value, final ClassDesc componentType) {
         this.arrayExpr = arrayExpr;
         this.index = index;
         this.value = value;
+        this.componentType = componentType;
     }
 
     Item arrayExpr() {
@@ -32,6 +36,6 @@ final class ArrayStore extends Item {
     }
 
     public void writeCode(final CodeBuilder cb, final BlockCreatorImpl block) {
-        cb.arrayStore(arrayExpr.typeKind());
+        cb.arrayStore(TypeKind.from(componentType));
     }
 }

--- a/src/main/java/io/quarkus/gizmo2/impl/BlockCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/BlockCreatorImpl.java
@@ -409,8 +409,8 @@ public final class BlockCreatorImpl extends Item implements BlockCreator {
         ((LValueExprImpl) var).emitDec(this, amount);
     }
 
-    public Expr newEmptyArray(final ClassDesc elemType, final Expr size) {
-        return addItem(new NewEmptyArray(elemType, (Item) size));
+    public Expr newEmptyArray(final ClassDesc componentType, final Expr size) {
+        return addItem(new NewEmptyArray(componentType, (Item) size));
     }
 
     private void insertNewArrayDup(final NewEmptyArray nea, final List<ArrayStore> stores, Node node, List<Item> values, int idx) {
@@ -446,14 +446,14 @@ public final class BlockCreatorImpl extends Item implements BlockCreator {
         }
     }
 
-    public Expr newArray(final ClassDesc elementType, final List<Expr> values) {
+    public Expr newArray(final ClassDesc componentType, final List<Expr> values) {
         checkActive();
         // build the object graph
         int size = values.size();
         List<ArrayStore> stores = new ArrayList<>(size);
-        NewEmptyArray nea = new NewEmptyArray(elementType, ConstantImpl.of(size));
+        NewEmptyArray nea = new NewEmptyArray(componentType, ConstantImpl.of(size));
         for (int i = 0; i < size; i++) {
-            stores.add(new ArrayStore(new Dup(nea), ConstantImpl.of(i), (Item) values.get(i)));
+            stores.add(new ArrayStore(new Dup(nea), ConstantImpl.of(i), (Item) values.get(i), componentType));
         }
         // stitch the object graph into our list
         insertNewArrayNextStore(nea, stores, tail, Util.reinterpretCast(values), values.size());

--- a/src/main/java/io/quarkus/gizmo2/impl/Item.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/Item.java
@@ -226,8 +226,7 @@ public abstract non-sealed class Item implements Expr {
         if (! type().isArray()) {
             throw new IllegalArgumentException("Value type is not array");
         }
-        final ClassDesc type = type().componentType();
-        return new ArrayDeref(type, index);
+        return new ArrayDeref(type().componentType(), index);
     }
 
     public Expr length() {
@@ -365,11 +364,11 @@ public abstract non-sealed class Item implements Expr {
     }
 
     final class ArrayDeref extends LValueExprImpl {
-        private final ClassDesc type;
+        private final ClassDesc componentType;
         private final Item index;
 
-        public ArrayDeref(final ClassDesc type, final Expr index) {
-            this.type = type;
+        public ArrayDeref(final ClassDesc componentType, final Expr index) {
+            this.componentType = componentType;
             this.index = (Item) index;
         }
 
@@ -393,7 +392,7 @@ public abstract non-sealed class Item implements Expr {
                     }
 
                     public ClassDesc type() {
-                        return type;
+                        return componentType;
                     }
 
                     public void writeCode(final CodeBuilder cb, final BlockCreatorImpl block) {
@@ -414,7 +413,7 @@ public abstract non-sealed class Item implements Expr {
 
         Item emitSet(final BlockCreatorImpl block, final Item value, final AccessMode mode) {
             return switch (mode) {
-                case AsDeclared, Plain -> new ArrayStore(Item.this, index, value);
+                case AsDeclared, Plain -> new ArrayStore(Item.this, index, value, componentType);
                 default -> new Item() {
                     public String itemName() {
                         return "ArrayDeref$SetVolatile" + super.itemName();
@@ -436,7 +435,7 @@ public abstract non-sealed class Item implements Expr {
         }
 
         public ClassDesc type() {
-            return type;
+            return componentType;
         }
 
         public boolean bound() {

--- a/src/main/java/io/quarkus/gizmo2/impl/NewEmptyArray.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/NewEmptyArray.java
@@ -12,8 +12,8 @@ final class NewEmptyArray extends Item {
     private final ClassDesc arrayType;
     private final Item size;
 
-    NewEmptyArray(final ClassDesc elemType, final Item size) {
-        arrayType = elemType.arrayType();
+    NewEmptyArray(final ClassDesc componentType, final Item size) {
+        arrayType = componentType.arrayType();
         this.size = size;
     }
 

--- a/src/test/java/io/quarkus/gizmo2/ArraysTest.java
+++ b/src/test/java/io/quarkus/gizmo2/ArraysTest.java
@@ -1,0 +1,213 @@
+package io.quarkus.gizmo2;
+
+import io.quarkus.gizmo2.creator.BlockCreator;
+import io.quarkus.gizmo2.desc.MethodDesc;
+import org.junit.jupiter.api.Test;
+
+import java.lang.constant.ClassDesc;
+import java.lang.constant.ConstantDescs;
+import java.lang.constant.MethodTypeDesc;
+import java.util.Arrays;
+import java.util.function.Function;
+import java.util.function.IntSupplier;
+import java.util.function.Supplier;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class ArraysTest {
+    @Test
+    public void createPrimitiveArray() {
+        testCreateArray(bc -> bc.newArray(boolean.class, Constant.of(true), Constant.of(false)), "[true, false]");
+        testCreateArray(bc -> bc.newArray(byte.class, Constant.of((byte) 1), Constant.of((byte) 2)), "[1, 2]");
+        testCreateArray(bc -> bc.newArray(short.class, Constant.of((short) 3), Constant.of((short) 4)), "[3, 4]");
+        testCreateArray(bc -> bc.newArray(char.class, Constant.of('a'), Constant.of('b')), "[a, b]");
+        testCreateArray(bc -> bc.newArray(int.class, Constant.of(7), Constant.of(8)), "[7, 8]");
+        testCreateArray(bc -> bc.newArray(long.class, Constant.of(9L), Constant.of(10L)), "[9, 10]");
+        testCreateArray(bc -> bc.newArray(float.class, Constant.of(11.0F), Constant.of(12.0F)), "[11.0, 12.0]");
+        testCreateArray(bc -> bc.newArray(double.class, Constant.of(13.0), Constant.of(14.0)), "[13.0, 14.0]");
+    }
+
+    @Test
+    public void createMultiDimensionalPrimitiveArray() {
+        testCreateArray(bc -> {
+            Expr a1 = bc.newArray(boolean.class, Constant.of(true), Constant.of(false));
+            Expr a2 = bc.newArray(boolean.class, Constant.of(false), Constant.of(true));
+            return bc.newArray(boolean[].class, a1, a2);
+        }, "[[true, false], [false, true]]");
+        testCreateArray(bc -> {
+            Expr a1 = bc.newArray(byte.class, Constant.of((byte) 1), Constant.of((byte) 2));
+            Expr a2 = bc.newArray(byte.class, Constant.of((byte) 3), Constant.of((byte) 4));
+            Expr a3 = bc.newArray(byte.class, Constant.of((byte) 5), Constant.of((byte) 6));
+            return bc.newArray(byte[].class, a1, a2, a3);
+        }, "[[1, 2], [3, 4], [5, 6]]");
+        testCreateArray(bc -> {
+            Expr a1 = bc.newArray(short.class, Constant.of((short) 7));
+            Expr a2 = bc.newArray(short.class, Constant.of((short) 8), Constant.of((short) 9));
+            return bc.newArray(short[].class, a1, a2);
+        }, "[[7], [8, 9]]");
+        testCreateArray(bc -> {
+            Expr a1 = bc.newArray(char.class, Constant.of('a'));
+            Expr a2 = bc.newArray(char.class, Constant.of('b'), Constant.of('c'));
+            Expr a3 = bc.newArray(char.class);
+            Expr a4 = bc.newArray(char.class);
+            Expr a5 = bc.newArray(char.class, Constant.of('d'));
+            return bc.newArray(char[].class, a1, a2, a3, a4, a5);
+        }, "[[a], [b, c], [], [], [d]]");
+        testCreateArray(bc -> {
+            Expr a1 = bc.newArray(int.class, Constant.of(10));
+            Expr a2 = bc.newArray(int.class, Constant.of(11), Constant.of(12));
+            Expr a3 = bc.newArray(int.class, Constant.of(13), Constant.of(14), Constant.of(15));
+            return bc.newArray(int[].class, a1, a2, a3);
+        }, "[[10], [11, 12], [13, 14, 15]]");
+        testCreateArray(bc -> {
+            Expr a1 = bc.newArray(long.class, Constant.of(16L));
+            Expr a2 = bc.newArray(long.class);
+            Expr a3 = bc.newArray(long.class, Constant.of(17L));
+            return bc.newArray(long[].class, a1, a2, a3);
+        }, "[[16], [], [17]]");
+        testCreateArray(bc -> {
+            Expr a1 = bc.newArray(float.class, Constant.of(18.0F));
+            Expr a2 = bc.newArray(float.class);
+            Expr a3 = bc.newArray(float[].class, a1, a2);
+            Expr a4 = bc.newArray(float.class, Constant.of(19.0F));
+            Expr a5 = bc.newArray(float.class, Constant.of(20.0F), Constant.of(21.0F));
+            Expr a6 = bc.newArray(float[].class, a4, a5);
+            return bc.newArray(float[][].class, a3, a6);
+        }, "[[[18.0], []], [[19.0], [20.0, 21.0]]]");
+        testCreateArray(bc -> {
+            Expr a1 = bc.newArray(double.class, Constant.of(22.0));
+            Expr a2 = bc.newArray(double.class, Constant.of(23.0), Constant.of(24.0));
+            Expr a3 = bc.newArray(double[].class, a1, a2);
+            Expr a4 = bc.newArray(double.class, Constant.of(25.0), Constant.of(26.0));
+            Expr a5 = bc.newArray(double.class, Constant.of(27.0));
+            Expr a6 = bc.newArray(double[].class, a4, a5);
+            Expr a7 = bc.newArray(double.class, Constant.of(27.0), Constant.of(28.0));
+            Expr a8 = bc.newArray(double.class);
+            Expr a9 = bc.newArray(double[].class, a7, a8);
+            return bc.newArray(double[][].class, a3, a6, a9);
+        }, "[[[22.0], [23.0, 24.0]], [[25.0, 26.0], [27.0]], [[27.0, 28.0], []]]");
+    }
+
+    @Test
+    public void createReferenceArray() {
+        testCreateArray(bc -> bc.newArray(String.class, Constant.of("ab"), Constant.of("cd")),
+                "[ab, cd]");
+        testCreateArray(bc -> {
+            Expr ef = bc.new_(StringBuilder.class, Constant.of("ef"));
+            return bc.newArray(CharSequence.class, ef, Constant.of("gh"));
+        }, "[ef, gh]");
+        testCreateArray(bc -> {
+            Expr num = bc.new_(Integer.class, Constant.of(123));
+            return bc.newArray(Object.class, Constant.of("ij"), num, Constant.of("klm"));
+        }, "[ij, 123, klm]");
+    }
+
+    @Test
+    public void createMultiDimensionalReferenceArrays() {
+        testCreateArray(bc -> {
+            Expr a1 = bc.newArray(String.class, Constant.of("ab"), Constant.of("cd"));
+            Expr a2 = bc.newArray(String.class, Constant.of("ef"), Constant.of("gh"));
+            return bc.newArray(String[].class, a1, a2);
+        }, "[[ab, cd], [ef, gh]]");
+        testCreateArray(bc -> {
+            Expr cs1 = bc.define("cs1", bc.new_(StringBuilder.class, Constant.of("ij")));
+            Expr cs2 = bc.define("cs2", bc.new_(StringBuilder.class, Constant.of("mn")));
+            Expr a1 = bc.newArray(CharSequence.class, cs1, Constant.of("kl"), cs2);
+            Expr a2 = bc.newArray(CharSequence.class);
+            return bc.newArray(CharSequence[].class, a1, a2);
+        }, "[[ij, kl, mn], []]");
+        testCreateArray(bc -> {
+            Expr num1 = bc.define("num1", bc.new_(Integer.class, Constant.of(123)));
+            Expr num2 = bc.define("num2", bc.new_(Integer.class, Constant.of(456)));
+            Expr a1 = bc.newArray(String.class, Constant.of("op"), Constant.of("qr"));
+            Expr a2 = bc.newArray(CharSequence.class);
+            Expr a3 = bc.newArray(Integer.class, num1, num2);
+            return bc.newArray(Object[].class, a1, a2, a3);
+        }, "[[op, qr], [], [123, 456]]");
+    }
+
+    private void testCreateArray(Function<BlockCreator, Expr> bytecode, String expectedResult) {
+        TestClassMaker tcm = new TestClassMaker();
+        Gizmo g = Gizmo.create(tcm);
+        g.class_("io.quarkus.gizmo2.TestCreateArray", cc -> {
+            cc.staticMethod("returnArrayString", mc -> {
+                mc.returning(Object.class); // in fact always `String`
+                mc.body(bc -> {
+                    Expr array = bytecode.apply(bc);
+                    if (array.type().componentType().isArray()) {
+                        Expr toString = bc.invokeStatic(MethodDesc.of(Arrays.class, "deepToString", String.class, Object[].class), array);
+                        bc.return_(toString);
+                    } else {
+                        ClassDesc arrayType = array.type().componentType().isPrimitive()
+                                ? array.type()
+                                : ConstantDescs.CD_Object.arrayType();
+                        MethodTypeDesc toStringType = MethodTypeDesc.of(ConstantDescs.CD_String, arrayType);
+                        Expr toString = bc.invokeStatic(MethodDesc.of(Arrays.class, "toString", toStringType), array);
+                        bc.return_(toString);
+                    }
+                });
+            });
+        });
+        assertEquals(expectedResult, tcm.staticMethod("returnArrayString", Supplier.class).get());
+    }
+
+    @Test
+    public void readPrimitiveArray() {
+        testReadArray(bc -> {
+            Expr arr = bc.define("arr", bc.newArray(boolean.class, Constant.of(true), Constant.of(false)));
+            return bc.add(arr.elem(0), arr.elem(1));
+        }, 1);
+        testReadArray(bc -> {
+            Expr arr = bc.define("arr", bc.newArray(byte.class, Constant.of((byte) 1), Constant.of((byte) 2)));
+            return bc.add(arr.elem(0), arr.elem(1));
+        }, 3);
+        testReadArray(bc -> {
+            Expr arr = bc.define("arr", bc.newArray(short.class, Constant.of((short) 3), Constant.of((short) 4)));
+            return bc.add(arr.elem(0), arr.elem(1));
+        }, 7);
+        testReadArray(bc -> {
+            Expr arr = bc.define("arr", bc.newArray(char.class, Constant.of('a'), Constant.of('b')));
+            return bc.add(arr.elem(0), arr.elem(1));
+        }, 195); // a = 97, b = 98
+        testReadArray(bc -> {
+            Expr arr = bc.define("arr", bc.newArray(int.class, Constant.of(7), Constant.of(8)));
+            return bc.add(arr.elem(0), arr.elem(1));
+        }, 15);
+        testReadArray(bc -> {
+            Expr arr = bc.define("arr", bc.newArray(long.class, Constant.of(9L), Constant.of(10L)));
+            return bc.add(bc.cast(arr.elem(0), int.class), bc.cast(arr.elem(1), int.class));
+        }, 19);
+        testReadArray(bc -> {
+            Expr arr = bc.define("arr", bc.newArray(float.class, Constant.of(11.0F), Constant.of(12.0F)));
+            return bc.add(bc.cast(arr.elem(0), int.class), bc.cast(arr.elem(1), int.class));
+        }, 23);
+        testReadArray(bc -> {
+            Expr arr = bc.define("arr", bc.newArray(double.class, Constant.of(13.0), Constant.of(14.0)));
+            return bc.add(bc.cast(arr.elem(0), int.class), bc.cast(arr.elem(1), int.class));
+        }, 27);
+    }
+
+    @Test
+    public void readReferenceArray() {
+        testReadArray(bc -> {
+            Expr arr = bc.define("arr", bc.newArray(String.class, Constant.of("ab"), Constant.of("cde")));
+            Expr l1 = bc.withString(arr.elem(0)).length();
+            Expr l2 = bc.withString(arr.elem(1)).length();
+            return bc.add(l1, l2);
+        }, 5);
+    }
+
+    private void testReadArray(Function<BlockCreator, Expr> bytecode, int expectedResult) {
+        TestClassMaker tcm = new TestClassMaker();
+        Gizmo g = Gizmo.create(tcm);
+        g.class_("io.quarkus.gizmo2.TestReadArray", cc -> {
+            cc.staticMethod("returnInt", mc -> {
+                mc.returning(int.class);
+                mc.body(bc -> {
+                    bc.return_(bytecode.apply(bc));
+                });
+            });
+        });
+        assertEquals(expectedResult, tcm.staticMethod("returnInt", IntSupplier.class).getAsInt());
+    }
+}


### PR DESCRIPTION
The `ArrayStore` item used to emit an array store instruction based on the type kind of the array, which is always reference. It needs to do that based on the type kind of the _component type_ of the array.

Further, this commit replaces all occurences of "element type" with "component type", because that's what they really are. This doesn't make a difference with single-dimensional arrays, which is the vast majority of arrays, but it does make a difference with multi-dimensional arrays, where component type is the type of the inner array, while the element type is never an array type.

Finally, some tests for arrays are added.