### PR TITLE
add StringBuilderOps

### DIFF
--- a/src/main/java/io/quarkus/gizmo2/creator/BlockCreator.java
+++ b/src/main/java/io/quarkus/gizmo2/creator/BlockCreator.java
@@ -32,6 +32,7 @@ import io.quarkus.gizmo2.creator.ops.MapOps;
 import io.quarkus.gizmo2.creator.ops.ObjectOps;
 import io.quarkus.gizmo2.creator.ops.OptionalOps;
 import io.quarkus.gizmo2.creator.ops.SetOps;
+import io.quarkus.gizmo2.creator.ops.StringBuilderOps;
 import io.quarkus.gizmo2.creator.ops.StringOps;
 import io.quarkus.gizmo2.desc.ConstructorDesc;
 import io.quarkus.gizmo2.desc.MethodDesc;
@@ -2619,6 +2620,115 @@ public sealed interface BlockCreator extends SimpleTyped permits BlockCreatorImp
         return new OptionalOps(this, receiver);
     }
 
+    /**
+     * Creates a {@code StringBuilder} generator that helps to generate a chain of
+     * {@code append} calls and a final {@code toString} call.
+     *
+     * <pre>
+     * StringBuilderOps str = bc.withNewStringBuilder();
+     * str.append("constant");
+     * str.append(someExpr);
+     * Expr result = str.objToString();
+     * </pre>
+     *
+     * The {@code append} method mimics the regular {@code StringBuilder.append}, so
+     * it accepts {@code Expr}s of all types for which {@code StringBuilder}
+     * has an overload:
+     * <ul>
+     * <li>primitive types</li>
+     * <li>{@code char[]}</li>
+     * <li>{@code java.lang.String}</li>
+     * <li>{@code java.lang.CharSequence}</li>
+     * <li>{@code java.lang.Object}</li>
+     * </ul>
+     *
+     * Notably, arrays except of {@code char[]} are appended using {@code Object.toString}
+     * and if {@code Arrays.toString} should be used, it must be generated manually.
+     * <p>
+     * Methods for appending only a part of {@code char[]} or {@code CharSequence} are not
+     * provided. Other {@code StringBuilder} methods are not provided either. This is just
+     * a simple utility for generating code that concatenates strings, e.g. for implementing
+     * the {@code toString} method.
+     *
+     * @return a convenience wrapper for accessing instance methods of a newly created {@link StringBuilder}
+     */
+    default StringBuilderOps withNewStringBuilder() {
+        return new StringBuilderOps(this);
+    }
+
+    /**
+     * Creates a {@code StringBuilder} generator that helps to generate a chain of
+     * {@code append} calls and a final {@code toString} call.
+     *
+     * <pre>
+     * StringBuilderOps str = bc.withNewStringBuilder(16);
+     * str.append("constant");
+     * str.append(someExpr);
+     * Expr result = str.objToString();
+     * </pre>
+     *
+     * The {@code append} method mimics the regular {@code StringBuilder.append}, so
+     * it accepts {@code Expr}s of all types for which {@code StringBuilder}
+     * has an overload:
+     * <ul>
+     * <li>primitive types</li>
+     * <li>{@code char[]}</li>
+     * <li>{@code java.lang.String}</li>
+     * <li>{@code java.lang.CharSequence}</li>
+     * <li>{@code java.lang.Object}</li>
+     * </ul>
+     *
+     * Notably, arrays except of {@code char[]} are appended using {@code Object.toString}
+     * and if {@code Arrays.toString} should be used, it must be generated manually.
+     * <p>
+     * Methods for appending only a part of {@code char[]} or {@code CharSequence} are not
+     * provided. Other {@code StringBuilder} methods are not provided either. This is just
+     * a simple utility for generating code that concatenates strings, e.g. for implementing
+     * the {@code toString} method.
+     *
+     * @param capacity the capacity of the newly created {@link StringBuilder}
+     * @return a convenience wrapper for accessing instance methods of a newly created {@link StringBuilder}
+     */
+    default StringBuilderOps withNewStringBuilder(int capacity) {
+        return new StringBuilderOps(this, capacity);
+    }
+
+    /**
+     * Creates a {@code StringBuilder} generator that helps to generate a chain of
+     * {@code append} calls and a final {@code toString} call.
+     *
+     * <pre>
+     * StringBuilderOps str = bc.withStringBuilder(theStringBuilder);
+     * str.append("constant");
+     * str.append(someExpr);
+     * Expr result = str.objToString();
+     * </pre>
+     *
+     * The {@code append} method mimics the regular {@code StringBuilder.append}, so
+     * it accepts {@code Expr}s of all types for which {@code StringBuilder}
+     * has an overload:
+     * <ul>
+     * <li>primitive types</li>
+     * <li>{@code char[]}</li>
+     * <li>{@code java.lang.String}</li>
+     * <li>{@code java.lang.CharSequence}</li>
+     * <li>{@code java.lang.Object}</li>
+     * </ul>
+     *
+     * Notably, arrays except of {@code char[]} are appended using {@code Object.toString}
+     * and if {@code Arrays.toString} should be used, it must be generated manually.
+     * <p>
+     * Methods for appending only a part of {@code char[]} or {@code CharSequence} are not
+     * provided. Other {@code StringBuilder} methods are not provided either. This is just
+     * a simple utility for generating code that concatenates strings, e.g. for implementing
+     * the {@code toString} method.
+     *
+     * @param receiver the {@link StringBuilder}
+     * @return a convenience wrapper for accessing instance methods of the given {@link StringBuilder}
+     */
+    default StringBuilderOps withStringBuilder(Expr receiver) {
+        return new StringBuilderOps(this, receiver);
+    }
     /**
      * Generate a call to {@link Class#forName(String)} which uses the defining class loader of this class.
      *

--- a/src/main/java/io/quarkus/gizmo2/creator/ops/StringBuilderOps.java
+++ b/src/main/java/io/quarkus/gizmo2/creator/ops/StringBuilderOps.java
@@ -1,0 +1,98 @@
+package io.quarkus.gizmo2.creator.ops;
+
+import io.quarkus.gizmo2.Constant;
+import io.quarkus.gizmo2.Expr;
+import io.quarkus.gizmo2.creator.BlockCreator;
+
+/**
+ * Operations on {@link StringBuilder}. The expected usage pattern is:
+ * <ol>
+ * <li>Create an instance using {@link BlockCreator#withNewStringBuilder()}</li>
+ * <li>Append to it using {@link #append(Expr)}</li>
+ * <li>Create the final string using {@link #objToString()}</li>
+ * </ol>
+ * If you need to perform other operations on the {@code StringBuilder}
+ * that this class doesn't provide, you should create an instance
+ * using {@link BlockCreator#withStringBuilder(Expr)}, which allows
+ * you to pass an already created {@code StringBuilder}. This class
+ * itself doesn't provide access to the underlying object.
+ */
+public final class StringBuilderOps extends ObjectOps implements ComparableOps {
+
+    /**
+     * Construct a new instance on an existing {@link StringBuilder}.
+     *
+     * @param bc the block creator (must not be {@code null})
+     * @param obj the receiver string builder (must not be {@code null})
+     */
+    public StringBuilderOps(final BlockCreator bc, final Expr obj) {
+        super(StringBuilder.class, bc, obj);
+    }
+
+    /**
+     * Construct a new instance on a newly created {@link StringBuilder}.
+     *
+     * @param bc the block creator (must not be {@code null})
+     */
+    public StringBuilderOps(final BlockCreator bc) {
+        super(StringBuilder.class, bc, bc.define("stringBuilder", bc.new_(StringBuilder.class)));
+    }
+
+    /**
+     * Construct a new instance on a newly created {@link StringBuilder}
+     * with given {@code capacity}.
+     *
+     * @param bc the block creator (must not be {@code null})
+     * @param capacity the capacity of the newly created {@link StringBuilder}
+     */
+    public StringBuilderOps(final BlockCreator bc, final int capacity) {
+        super(StringBuilder.class, bc, bc.new_(StringBuilder.class, Constant.of(capacity)));
+    }
+
+    /**
+     * Appends the string value of given {@code expr} to this {@code StringBuilder}.
+     *
+     * @param expr the value to append
+     * @return this instance
+     */
+    public StringBuilderOps append(final Expr expr) {
+        switch (expr.type().descriptorString()) {
+            case "Z" -> invokeInstance(StringBuilder.class, "append", boolean.class, expr);
+            case "B", "S", "I" -> invokeInstance(StringBuilder.class, "append", int.class, expr);
+            case "J" -> invokeInstance(StringBuilder.class, "append", long.class, expr);
+            case "F" -> invokeInstance(StringBuilder.class, "append", float.class, expr);
+            case "D" -> invokeInstance(StringBuilder.class, "append", double.class, expr);
+            case "C" -> invokeInstance(StringBuilder.class, "append", char.class, expr);
+            case "[C" -> invokeInstance(StringBuilder.class, "append", char[].class, expr);
+            case "Ljava/lang/String;" -> invokeInstance(StringBuilder.class, "append", String.class, expr);
+            case "Ljava/lang/CharSequence;" -> invokeInstance(StringBuilder.class, "append", CharSequence.class, expr);
+            default -> invokeInstance(StringBuilder.class, "append", Object.class, expr);
+        }
+        return this;
+    }
+
+    /**
+     * Appends the given {@code char} constant to this {@code StringBuilder}.
+     *
+     * @param constant the value to append
+     * @return this instance
+     */
+    public StringBuilderOps append(final char constant) {
+        return append(Constant.of(constant));
+    }
+
+    /**
+     * Appends the given {@code String} constant to this {@code StringBuilder}.
+     *
+     * @param constant the value to append
+     * @return this instance
+     */
+    public StringBuilderOps append(final String constant) {
+        return append(Constant.of(constant));
+    }
+
+    @Override
+    public Expr compareTo(Expr other) {
+        return invokeInstance(int.class, "compareTo", StringBuilder.class, other);
+    }
+}

--- a/src/test/java/io/quarkus/gizmo2/ops/ListOpsTest.java
+++ b/src/test/java/io/quarkus/gizmo2/ops/ListOpsTest.java
@@ -1,4 +1,4 @@
-package io.quarkus.gizmo2;
+package io.quarkus.gizmo2.ops;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -7,6 +7,10 @@ import java.util.function.Function;
 
 import org.junit.jupiter.api.Test;
 
+import io.quarkus.gizmo2.Constant;
+import io.quarkus.gizmo2.Gizmo;
+import io.quarkus.gizmo2.ParamVar;
+import io.quarkus.gizmo2.TestClassMaker;
 import io.quarkus.gizmo2.creator.ops.ListOps;
 
 public class ListOpsTest {

--- a/src/test/java/io/quarkus/gizmo2/ops/MapOpsTest.java
+++ b/src/test/java/io/quarkus/gizmo2/ops/MapOpsTest.java
@@ -1,4 +1,4 @@
-package io.quarkus.gizmo2;
+package io.quarkus.gizmo2.ops;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -8,6 +8,9 @@ import java.util.function.IntSupplier;
 
 import org.junit.jupiter.api.Test;
 
+import io.quarkus.gizmo2.Constant;
+import io.quarkus.gizmo2.Gizmo;
+import io.quarkus.gizmo2.TestClassMaker;
 import io.quarkus.gizmo2.creator.ops.MapOps;
 
 public class MapOpsTest {

--- a/src/test/java/io/quarkus/gizmo2/ops/OptionalOpsTest.java
+++ b/src/test/java/io/quarkus/gizmo2/ops/OptionalOpsTest.java
@@ -1,9 +1,12 @@
-package io.quarkus.gizmo2;
+package io.quarkus.gizmo2.ops;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.function.IntSupplier;
 
+import io.quarkus.gizmo2.Constant;
+import io.quarkus.gizmo2.Gizmo;
+import io.quarkus.gizmo2.TestClassMaker;
 import org.junit.jupiter.api.Test;
 
 public class OptionalOpsTest {

--- a/src/test/java/io/quarkus/gizmo2/ops/StringBuilderOpsTest.java
+++ b/src/test/java/io/quarkus/gizmo2/ops/StringBuilderOpsTest.java
@@ -1,0 +1,64 @@
+package io.quarkus.gizmo2.ops;
+
+import io.quarkus.gizmo2.Constant;
+import io.quarkus.gizmo2.Expr;
+import io.quarkus.gizmo2.Gizmo;
+import io.quarkus.gizmo2.LocalVar;
+import io.quarkus.gizmo2.TestClassMaker;
+import io.quarkus.gizmo2.creator.ops.StringBuilderOps;
+import io.quarkus.gizmo2.desc.MethodDesc;
+import org.junit.jupiter.api.Test;
+
+import java.util.function.Supplier;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class StringBuilderOpsTest {
+    @Test
+    public void testStringBuilder() {
+        TestClassMaker tcm = new TestClassMaker();
+        Gizmo g = Gizmo.create(tcm);
+        g.class_("io.quarkus.gizmo2.TestStringBuilder", cc -> {
+            MethodDesc charSeq = cc.staticMethod("createCharSequence", mc -> {
+                mc.returning(CharSequence.class);
+                mc.body(bc -> {
+                    LocalVar strBuilder = bc.define("stringBuilder", bc.new_(StringBuilder.class));
+                    bc.withStringBuilder(strBuilder).append("ghi");
+                    bc.return_(strBuilder);
+                });
+            });
+
+            cc.staticMethod("createString", mc -> {
+                mc.returning(Object.class); // in fact always `String`
+                mc.body(bc -> {
+                    StringBuilderOps strBuilder = bc.withNewStringBuilder();
+                    strBuilder.append(Constant.of(true));
+                    strBuilder.append(Constant.of((byte) 1));
+                    strBuilder.append(Constant.of((short) 2));
+                    strBuilder.append(Constant.of(3));
+                    strBuilder.append(Constant.of(4L));
+                    strBuilder.append(Constant.of(5.0F));
+                    strBuilder.append(Constant.of(6.0));
+                    strBuilder.append(Constant.of('a'));
+                    Expr charArray = bc.newArray(char.class, Constant.of('b'), Constant.of('c'));
+                    strBuilder.append(charArray);
+                    strBuilder.append(Constant.of("def"));
+                    strBuilder.append(bc.invokeStatic(charSeq));
+                    strBuilder.append(bc.new_(MyObject.class));
+                    strBuilder.append(Constant.ofNull(Object.class));
+                    strBuilder.append("...");
+                    strBuilder.append('!');
+                    bc.return_(strBuilder.objToString());
+                });
+            });
+        });
+        assertEquals("true12345.06.0abcdefghijklmnull...!", tcm.staticMethod("createString", Supplier.class).get());
+    }
+
+    public static class MyObject {
+        @Override
+        public String toString() {
+            return "jklm";
+        }
+    }
+}


### PR DESCRIPTION
This is an equivalent of `StringBuilderGenerator` from Gizmo 1.x.

This commit also moves tests for existing `*Ops` classes to the `ops` package, similarly to `StringBuilderOpsTest`.

Resolves #257