### PR TITLE
Fix StaticFieldVarImpl#emitSet(), add access methods to toBlockCreator

### DIFF
--- a/src/main/java/io/quarkus/gizmo2/creator/BlockCreator.java
+++ b/src/main/java/io/quarkus/gizmo2/creator/BlockCreator.java
@@ -35,6 +35,7 @@ import io.quarkus.gizmo2.creator.ops.SetOps;
 import io.quarkus.gizmo2.creator.ops.StringBuilderOps;
 import io.quarkus.gizmo2.creator.ops.StringOps;
 import io.quarkus.gizmo2.desc.ConstructorDesc;
+import io.quarkus.gizmo2.desc.FieldDesc;
 import io.quarkus.gizmo2.desc.MethodDesc;
 import io.quarkus.gizmo2.impl.BlockCreatorImpl;
 import io.quarkus.gizmo2.impl.Util;
@@ -2159,6 +2160,26 @@ public sealed interface BlockCreator extends SimpleTyped permits BlockCreatorImp
     void ifElse(Expr cond, Consumer<BlockCreator> whenTrue, Consumer<BlockCreator> whenFalse);
 
     /**
+     * An {@code if (obj == null)} conditional.
+     *
+     * @param obj the object reference to test (must not be {@code null})
+     * @param whenTrue the builder for a block to execute if the object reference is null (must not be {@code null})
+     */
+    default void ifNull(Expr obj, Consumer<BlockCreator> whenTrue) {
+        if_(eq(obj, Constant.ofNull(obj.type())), whenTrue);
+    }
+
+    /**
+     * An {@code if (obj != null)} conditional.
+     *
+     * @param obj the object reference to test (must not be {@code null})
+     * @param whenTrue the builder for a block to execute if the object reference is not null (must not be {@code null})
+     */
+    default void ifNotNull(Expr obj, Consumer<BlockCreator> whenTrue) {
+        if_(ne(obj, Constant.ofNull(obj.type())), whenTrue);
+    }
+    
+    /**
      * Construct a {@code switch} statement for {@code enum} constants.
      *
      * @param val the value to switch on (must not be {@code null})
@@ -2900,5 +2921,26 @@ public sealed interface BlockCreator extends SimpleTyped permits BlockCreatorImp
      * @param message the message to print if the assertion fails (must not be {@code null})
      */
     void assert_(Consumer<BlockCreator> assertion, String message);
+    
+    /**
+     * Read the value from a static field.
+     * 
+     * @param desc the field descriptor (must not be {@code null})
+     * @return the memory value (not {@code null})
+     */
+    default Expr getStaticField(FieldDesc desc) {
+        return get(Expr.staticField(desc));
+    }
+    
+    /**
+     * Write the value to a static field.
+     * 
+     * @param desc the field descriptor (must not be {@code null})
+     * @param value the value to write
+     * @return the memory value (not {@code null})
+     */
+    default void setStaticField(FieldDesc desc, Expr value) {
+        set(Expr.staticField(desc), value);
+    }
+    
 }
-

--- a/src/main/java/io/quarkus/gizmo2/impl/BlockCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/BlockCreatorImpl.java
@@ -3,7 +3,6 @@ package io.quarkus.gizmo2.impl;
 import static io.quarkus.gizmo2.impl.Preconditions.requireArray;
 import static io.quarkus.gizmo2.impl.Preconditions.requireSameLoadableTypeKind;
 import static io.quarkus.gizmo2.impl.Preconditions.requireSameTypeKind;
-import static io.smallrye.common.constraint.Assert.impossibleSwitchCase;
 import static java.lang.constant.ConstantDescs.*;
 import static java.util.Collections.*;
 
@@ -902,7 +901,7 @@ public final class BlockCreatorImpl extends Item implements BlockCreator {
         }
         doIfInsn(CD_void, cond, wt, wf);
     }
-
+    
     public Expr selectExpr(final ClassDesc type, final Expr cond, final Consumer<BlockCreator> whenTrue, final Consumer<BlockCreator> whenFalse) {
         BlockCreatorImpl wt = new BlockCreatorImpl(this, type);
         BlockCreatorImpl wf = new BlockCreatorImpl(this, type);

--- a/src/main/java/io/quarkus/gizmo2/impl/StaticFieldVarImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/StaticFieldVarImpl.java
@@ -66,17 +66,18 @@ public final class StaticFieldVarImpl extends LValueExprImpl implements StaticFi
     Item emitSet(final BlockCreatorImpl block, final Item value, final AccessMode mode) {
         return new Item() {
             protected Node forEachDependency(Node node, final BiFunction<Item, Node, Node> op) {
-                node = value.process(node, op);
                 if (mode != AccessMode.AsDeclared) {
                     node = ConstantImpl.ofStaticFieldVarHandle(desc).process(node.prev(), op);
+                } else {
+                    node = value.process(node.prev(), op);
                 }
                 return node;
             }
-
+            
             public void writeCode(final CodeBuilder cb, final BlockCreatorImpl block) {
                 switch (mode) {
                     case AsDeclared -> {
-                        cb.putstatic(owner(), name(), type());
+                        cb.putstatic(owner(), name(), desc().type());
                     }
                     default -> {
                         cb.invokevirtual(CD_VarHandle, switch (mode) {

--- a/src/test/java/io/quarkus/gizmo2/TestClassMaker.java
+++ b/src/test/java/io/quarkus/gizmo2/TestClassMaker.java
@@ -9,8 +9,8 @@ import java.lang.invoke.MethodType;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Arrays;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.BiConsumer;
 
@@ -31,7 +31,9 @@ public class TestClassMaker implements BiConsumer<ClassDesc, byte[]> {
         }
         if (System.getProperty("dumpClass") != null) {
             try {
-                Files.write(Paths.get(classDesc.displayName() + ".class"), bytes);
+                Path path = Paths.get(classDesc.displayName() + ".class");
+                System.out.println("Dump class to: " + path.toAbsolutePath().toString());
+                Files.write(path, bytes);
             } catch (IOException e) {
                 throw new UncheckedIOException(e);
             }


### PR DESCRIPTION
- add BlockCreator#readStaticField() and BlockCreator#writeStaticField()
- also add BlockCreator#ifNull() and BlockCreator#ifNotNull()

I'd like to add an `if-null-else`/`if-not-null-else` variants but I don't like the current way we handle the `Else` case (i.e. another method with a `whenFalse` param). Something like this would be more convenient IMO:
```java
bc.ifNull(input, bc1 -> {
   // null case
}).else_(bc2 -> {
   // non-null case
});
```

In Gizmo1 we have a [special construct for `if-then-else`](https://github.com/quarkusio/gizmo/blob/main/USAGE.adoc#if-statements) so maybe we could try to do something similar...