### PR TITLE
Make static field initializers more robust

### DIFF
--- a/src/main/java/io/quarkus/gizmo2/creator/StaticFieldCreator.java
+++ b/src/main/java/io/quarkus/gizmo2/creator/StaticFieldCreator.java
@@ -11,7 +11,6 @@ import io.quarkus.gizmo2.impl.StaticFieldCreatorImpl;
 public sealed interface StaticFieldCreator extends FieldCreator permits StaticFieldCreatorImpl {
     /**
      * Provide an initial constant value for this field.
-     * An initial constant value must be only one of the types permitted by the JVMS.
      *
      * @param initial the initial value (must not be {@code null})
      */


### PR DESCRIPTION
Allow any kind of constant to be assigned to a static field, and automatically move it to an initializer if needed.