### PR TITLE
Non capturing lambdas should be singleton

### DIFF
--- a/src/main/java/io/quarkus/gizmo2/impl/BlockCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/BlockCreatorImpl.java
@@ -880,11 +880,21 @@ public final class BlockCreatorImpl extends Item implements BlockCreator {
             if (prevItem == cond) {
                 if (cond instanceof Rel rel) {
                     IfRel ifRel = new IfRel(type, rel.kind(), wt, wf, rel.left(), rel.right());
-                    rel.replace(tail.prev(), ifRel);
+                    if (ifRel.mayFallThrough()) {
+                        rel.replace(tail.prev(), ifRel);
+                    } else {
+                        rel.remove(tail.prev());
+                        replaceLastItem(ifRel);
+                    }
                     return ifRel;
                 } else if (cond instanceof RelZero rz) {
                     IfZero ifZero = new IfZero(type, rz.kind(), wt, wf, rz.input());
-                    rz.replace(tail.prev(), ifZero);
+                    if (ifZero.mayFallThrough()) {
+                        rz.replace(tail.prev(), ifZero);
+                    } else {
+                        rz.remove(tail.prev());
+                        replaceLastItem(ifZero);
+                    }
                     return ifZero;
                 }
             }

--- a/src/main/java/io/quarkus/gizmo2/impl/Item.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/Item.java
@@ -119,14 +119,23 @@ public abstract non-sealed class Item implements Expr {
 
     /**
      * Replace this item with the given replacement.
-     * This item must be the previous item in the iterator.
      *
-     * @param node        the list iterator (must not be {@code null})
+     * @param node the item's node (must not be {@code null})
      * @param replacement the replacement item (must not be {@code null})
      */
     protected void replace(Node node, Item replacement) {
         assert this == node.item();
         node.set(replacement);
+    }
+
+    /**
+     * Delete this item from the list.
+     *
+     * @param node the item's node (must not be {@code null})
+     */
+    protected void remove(Node node) {
+        assert this == node.item();
+        node.remove();
     }
 
     /**


### PR DESCRIPTION
The existing tests already cover capturing and non-capturing cases. Also fixes a bug where a relational- or compare-to-zero-if statement at the end of a block is still considered to possibly fall through even if none of its branches fall through.

Fixes #266