### PR TITLE
add tests for arithmetic operations and fix type check

### DIFF
--- a/src/main/java/io/quarkus/gizmo2/impl/BinOp.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/BinOp.java
@@ -16,10 +16,21 @@ final class BinOp extends Item {
 
     BinOp(final Expr a, final Expr b, final Kind kind) {
         // todo: automatic conversions, unboxing
-        requireSameLoadableTypeKind(a, b);
+        switch (kind.operands) {
+            case SAME -> requireSameLoadableTypeKind(a, b);
+            case SECOND_INT -> {
+                // the first operand is checked later by `isValidFor()`
+                if (b.typeKind().asLoadable() != TypeKind.INT) {
+                    throw new IllegalArgumentException("Second operand must be int, but is " + b.type().displayName());
+                }
+            }
+        }
+
         this.a = (Item) a;
         this.b = (Item) b;
         this.kind = kind;
+        // it is important here that `type()` (to which `typeKind()` delegates) returns the type
+        // of the _first_ operand, at least for operations that use `Operands.SECOND_INT` (see above)
         if (!kind.isValidFor(typeKind())) {
             throw new IllegalArgumentException("Operation is not valid for type kind of " + typeKind());
         }
@@ -38,7 +49,7 @@ final class BinOp extends Item {
     }
 
     public void writeCode(final CodeBuilder cb, final BlockCreatorImpl block) {
-        Op op = kind.opFor(typeKind());
+        Operation op = kind.opFor(typeKind());
         // we validated op above
         assert op != null;
         op.apply(cb);
@@ -48,29 +59,41 @@ final class BinOp extends Item {
         return b.toShortString(a.toShortString(sb).append(kind));
     }
 
+    enum Operands {
+        SAME,
+        SECOND_INT,
+    }
+
+    interface Operation {
+        void apply(CodeBuilder cb);
+    }
+
     enum Kind {
-        ADD(CodeBuilder::iadd, CodeBuilder::ladd, CodeBuilder::fadd, CodeBuilder::dadd, "+"),
-        SUB(CodeBuilder::isub, CodeBuilder::lsub, CodeBuilder::fsub, CodeBuilder::dsub, "-"),
-        MUL(CodeBuilder::imul, CodeBuilder::lmul, CodeBuilder::fmul, CodeBuilder::dmul, "*"),
-        DIV(CodeBuilder::idiv, CodeBuilder::ldiv, CodeBuilder::fdiv, CodeBuilder::ddiv, "/"),
-        REM(CodeBuilder::irem, CodeBuilder::lrem, CodeBuilder::frem, CodeBuilder::drem, "%"),
+        ADD(Operands.SAME, CodeBuilder::iadd, CodeBuilder::ladd, CodeBuilder::fadd, CodeBuilder::dadd, "+"),
+        SUB(Operands.SAME, CodeBuilder::isub, CodeBuilder::lsub, CodeBuilder::fsub, CodeBuilder::dsub, "-"),
+        MUL(Operands.SAME, CodeBuilder::imul, CodeBuilder::lmul, CodeBuilder::fmul, CodeBuilder::dmul, "*"),
+        DIV(Operands.SAME, CodeBuilder::idiv, CodeBuilder::ldiv, CodeBuilder::fdiv, CodeBuilder::ddiv, "/"),
+        REM(Operands.SAME, CodeBuilder::irem, CodeBuilder::lrem, CodeBuilder::frem, CodeBuilder::drem, "%"),
 
-        AND(CodeBuilder::iand, CodeBuilder::land, "&"),
-        OR(CodeBuilder::ior, CodeBuilder::lor, "|"),
-        XOR(CodeBuilder::ixor, CodeBuilder::lxor, "^"),
+        AND(Operands.SAME, CodeBuilder::iand, CodeBuilder::land, "&"),
+        OR(Operands.SAME, CodeBuilder::ior, CodeBuilder::lor, "|"),
+        XOR(Operands.SAME, CodeBuilder::ixor, CodeBuilder::lxor, "^"),
 
-        SHL(CodeBuilder::ishl, CodeBuilder::lshl, "<<"),
-        SHR(CodeBuilder::ishr, CodeBuilder::lshr, ">>"),
-        USHR(CodeBuilder::iushr, CodeBuilder::lushr, ">>>"),
+        SHL(Operands.SECOND_INT, CodeBuilder::ishl, CodeBuilder::lshl, "<<"),
+        SHR(Operands.SECOND_INT, CodeBuilder::ishr, CodeBuilder::lshr, ">>"),
+        USHR(Operands.SECOND_INT, CodeBuilder::iushr, CodeBuilder::lushr, ">>>"),
         ;
 
-        final Op intOp;
-        final Op longOp;
-        final Op floatOp;
-        final Op doubleOp;
+        final Operands operands;
+        final Operation intOp;
+        final Operation longOp;
+        final Operation floatOp;
+        final Operation doubleOp;
         final String symbol;
 
-        Kind(final Op intOp, final Op longOp, final Op floatOp, final Op doubleOp, final String symbol) {
+        Kind(final Operands operands, final Operation intOp, final Operation longOp, final Operation floatOp,
+                final Operation doubleOp, final String symbol) {
+            this.operands = operands;
             this.intOp = intOp;
             this.longOp = longOp;
             this.floatOp = floatOp;
@@ -78,11 +101,11 @@ final class BinOp extends Item {
             this.symbol = symbol;
         }
 
-        Kind(final Op intOp, final Op longOp, final String symbol) {
-            this(intOp, longOp, null, null, symbol);
+        Kind(final Operands operands, final Operation intOp, final Operation longOp, final String symbol) {
+            this(operands, intOp, longOp, null, null, symbol);
         }
 
-        Op opFor(TypeKind tk) {
+        Operation opFor(TypeKind tk) {
             return switch (tk.asLoadable()) {
                 case INT -> intOp;
                 case LONG -> longOp;
@@ -99,9 +122,5 @@ final class BinOp extends Item {
         public String toString() {
             return symbol;
         }
-    }
-
-    interface Op {
-        void apply(CodeBuilder cb);
     }
 }

--- a/src/test/java/io/quarkus/gizmo2/ArithmeticTest.java
+++ b/src/test/java/io/quarkus/gizmo2/ArithmeticTest.java
@@ -1,0 +1,326 @@
+package io.quarkus.gizmo2;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.function.DoubleBinaryOperator;
+import java.util.function.DoubleUnaryOperator;
+import java.util.function.IntBinaryOperator;
+import java.util.function.IntUnaryOperator;
+import java.util.function.LongBinaryOperator;
+import java.util.function.LongUnaryOperator;
+
+import org.junit.jupiter.api.Test;
+
+public class ArithmeticTest {
+    @Test
+    public void intArithmetic() {
+        TestClassMaker tcm = new TestClassMaker();
+        Gizmo g = Gizmo.create(tcm);
+        g.class_("io.quarkus.gizmo2.Int", cc -> {
+            cc.staticMethod("neg", mc -> {
+                mc.returning(int.class);
+                ParamVar a = mc.parameter("a", int.class);
+                mc.body(bc -> {
+                    bc.return_(bc.neg(a));
+                });
+            });
+            cc.staticMethod("add", mc -> {
+                mc.returning(int.class);
+                ParamVar a = mc.parameter("a", int.class);
+                ParamVar b = mc.parameter("b", int.class);
+                mc.body(bc -> {
+                    bc.return_(bc.add(a, b));
+                });
+            });
+            cc.staticMethod("sub", mc -> {
+                mc.returning(int.class);
+                ParamVar a = mc.parameter("a", int.class);
+                ParamVar b = mc.parameter("b", int.class);
+                mc.body(bc -> {
+                    bc.return_(bc.sub(a, b));
+                });
+            });
+            cc.staticMethod("mul", mc -> {
+                mc.returning(int.class);
+                ParamVar a = mc.parameter("a", int.class);
+                ParamVar b = mc.parameter("b", int.class);
+                mc.body(bc -> {
+                    bc.return_(bc.mul(a, b));
+                });
+            });
+            cc.staticMethod("div", mc -> {
+                mc.returning(int.class);
+                ParamVar a = mc.parameter("a", int.class);
+                ParamVar b = mc.parameter("b", int.class);
+                mc.body(bc -> {
+                    bc.return_(bc.div(a, b));
+                });
+            });
+            cc.staticMethod("rem", mc -> {
+                mc.returning(int.class);
+                ParamVar a = mc.parameter("a", int.class);
+                ParamVar b = mc.parameter("b", int.class);
+                mc.body(bc -> {
+                    bc.return_(bc.rem(a, b));
+                });
+            });
+            cc.staticMethod("and", mc -> {
+                mc.returning(int.class);
+                ParamVar a = mc.parameter("a", int.class);
+                ParamVar b = mc.parameter("b", int.class);
+                mc.body(bc -> {
+                    bc.return_(bc.and(a, b));
+                });
+            });
+            cc.staticMethod("or", mc -> {
+                mc.returning(int.class);
+                ParamVar a = mc.parameter("a", int.class);
+                ParamVar b = mc.parameter("b", int.class);
+                mc.body(bc -> {
+                    bc.return_(bc.or(a, b));
+                });
+            });
+            cc.staticMethod("xor", mc -> {
+                mc.returning(int.class);
+                ParamVar a = mc.parameter("a", int.class);
+                ParamVar b = mc.parameter("b", int.class);
+                mc.body(bc -> {
+                    bc.return_(bc.xor(a, b));
+                });
+            });
+            cc.staticMethod("shl", mc -> {
+                mc.returning(int.class);
+                ParamVar a = mc.parameter("a", int.class);
+                ParamVar b = mc.parameter("b", int.class);
+                mc.body(bc -> {
+                    bc.return_(bc.shl(a, b));
+                });
+            });
+            cc.staticMethod("shr", mc -> {
+                mc.returning(int.class);
+                ParamVar a = mc.parameter("a", int.class);
+                ParamVar b = mc.parameter("b", int.class);
+                mc.body(bc -> {
+                    bc.return_(bc.shr(a, b));
+                });
+            });
+            cc.staticMethod("ushr", mc -> {
+                mc.returning(int.class);
+                ParamVar a = mc.parameter("a", int.class);
+                ParamVar b = mc.parameter("b", int.class);
+                mc.body(bc -> {
+                    bc.return_(bc.ushr(a, b));
+                });
+            });
+        });
+        assertEquals(-2, tcm.staticMethod("neg", IntUnaryOperator.class).applyAsInt(2));
+        assertEquals(2, tcm.staticMethod("neg", IntUnaryOperator.class).applyAsInt(-2));
+        assertEquals(2 + 3, tcm.staticMethod("add", IntBinaryOperator.class).applyAsInt(2, 3));
+        assertEquals(2 - 3, tcm.staticMethod("sub", IntBinaryOperator.class).applyAsInt(2, 3));
+        assertEquals(2 * 3, tcm.staticMethod("mul", IntBinaryOperator.class).applyAsInt(2, 3));
+        assertEquals(2 / 3, tcm.staticMethod("div", IntBinaryOperator.class).applyAsInt(2, 3));
+        assertThrows(ArithmeticException.class, () -> {
+            tcm.staticMethod("div", IntBinaryOperator.class).applyAsInt(2, 0);
+        });
+        assertEquals(2 % 3, tcm.staticMethod("rem", IntBinaryOperator.class).applyAsInt(2, 3));
+        assertEquals(2 & 3, tcm.staticMethod("and", IntBinaryOperator.class).applyAsInt(2, 3));
+        assertEquals(2 | 3, tcm.staticMethod("or", IntBinaryOperator.class).applyAsInt(2, 3));
+        assertEquals(2 ^ 3, tcm.staticMethod("xor", IntBinaryOperator.class).applyAsInt(2, 3));
+        assertEquals(2 << 3, tcm.staticMethod("shl", IntBinaryOperator.class).applyAsInt(2, 3));
+        assertEquals(200 >> 3, tcm.staticMethod("shr", IntBinaryOperator.class).applyAsInt(200, 3));
+        assertEquals(-200 >> 3, tcm.staticMethod("shr", IntBinaryOperator.class).applyAsInt(-200, 3));
+        assertEquals(200 >>> 3, tcm.staticMethod("ushr", IntBinaryOperator.class).applyAsInt(200, 3));
+        assertEquals(-200 >>> 3, tcm.staticMethod("ushr", IntBinaryOperator.class).applyAsInt(-200, 3));
+    }
+
+    @Test
+    public void longArithmetic() {
+        TestClassMaker tcm = new TestClassMaker();
+        Gizmo g = Gizmo.create(tcm);
+        g.class_("io.quarkus.gizmo2.Long", cc -> {
+            cc.staticMethod("neg", mc -> {
+                mc.returning(long.class);
+                ParamVar a = mc.parameter("a", long.class);
+                mc.body(bc -> {
+                    bc.return_(bc.neg(a));
+                });
+            });
+            cc.staticMethod("add", mc -> {
+                mc.returning(long.class);
+                ParamVar a = mc.parameter("a", long.class);
+                ParamVar b = mc.parameter("b", long.class);
+                mc.body(bc -> {
+                    bc.return_(bc.add(a, b));
+                });
+            });
+            cc.staticMethod("sub", mc -> {
+                mc.returning(long.class);
+                ParamVar a = mc.parameter("a", long.class);
+                ParamVar b = mc.parameter("b", long.class);
+                mc.body(bc -> {
+                    bc.return_(bc.sub(a, b));
+                });
+            });
+            cc.staticMethod("mul", mc -> {
+                mc.returning(long.class);
+                ParamVar a = mc.parameter("a", long.class);
+                ParamVar b = mc.parameter("b", long.class);
+                mc.body(bc -> {
+                    bc.return_(bc.mul(a, b));
+                });
+            });
+            cc.staticMethod("div", mc -> {
+                mc.returning(long.class);
+                ParamVar a = mc.parameter("a", long.class);
+                ParamVar b = mc.parameter("b", long.class);
+                mc.body(bc -> {
+                    bc.return_(bc.div(a, b));
+                });
+            });
+            cc.staticMethod("rem", mc -> {
+                mc.returning(long.class);
+                ParamVar a = mc.parameter("a", long.class);
+                ParamVar b = mc.parameter("b", long.class);
+                mc.body(bc -> {
+                    bc.return_(bc.rem(a, b));
+                });
+            });
+            cc.staticMethod("and", mc -> {
+                mc.returning(long.class);
+                ParamVar a = mc.parameter("a", long.class);
+                ParamVar b = mc.parameter("b", long.class);
+                mc.body(bc -> {
+                    bc.return_(bc.and(a, b));
+                });
+            });
+            cc.staticMethod("or", mc -> {
+                mc.returning(long.class);
+                ParamVar a = mc.parameter("a", long.class);
+                ParamVar b = mc.parameter("b", long.class);
+                mc.body(bc -> {
+                    bc.return_(bc.or(a, b));
+                });
+            });
+            cc.staticMethod("xor", mc -> {
+                mc.returning(long.class);
+                ParamVar a = mc.parameter("a", long.class);
+                ParamVar b = mc.parameter("b", long.class);
+                mc.body(bc -> {
+                    bc.return_(bc.xor(a, b));
+                });
+            });
+            cc.staticMethod("shl", mc -> {
+                mc.returning(long.class);
+                ParamVar a = mc.parameter("a", long.class);
+                ParamVar b = mc.parameter("b", int.class);
+                mc.body(bc -> {
+                    bc.return_(bc.shl(a, b));
+                });
+            });
+            cc.staticMethod("shr", mc -> {
+                mc.returning(long.class);
+                ParamVar a = mc.parameter("a", long.class);
+                ParamVar b = mc.parameter("b", int.class);
+                mc.body(bc -> {
+                    bc.return_(bc.shr(a, b));
+                });
+            });
+            cc.staticMethod("ushr", mc -> {
+                mc.returning(long.class);
+                ParamVar a = mc.parameter("a", long.class);
+                ParamVar b = mc.parameter("b", int.class);
+                mc.body(bc -> {
+                    bc.return_(bc.ushr(a, b));
+                });
+            });
+        });
+        assertEquals(-2L, tcm.staticMethod("neg", LongUnaryOperator.class).applyAsLong(2L));
+        assertEquals(2L, tcm.staticMethod("neg", LongUnaryOperator.class).applyAsLong(-2L));
+        assertEquals(2L + 3L, tcm.staticMethod("add", LongBinaryOperator.class).applyAsLong(2L, 3L));
+        assertEquals(2L - 3L, tcm.staticMethod("sub", LongBinaryOperator.class).applyAsLong(2L, 3L));
+        assertEquals(2L * 3L, tcm.staticMethod("mul", LongBinaryOperator.class).applyAsLong(2L, 3L));
+        assertEquals(2L / 3L, tcm.staticMethod("div", LongBinaryOperator.class).applyAsLong(2L, 3L));
+        assertThrows(ArithmeticException.class, () -> {
+            tcm.staticMethod("div", LongBinaryOperator.class).applyAsLong(2L, 0L);
+        });
+        assertEquals(2L % 3L, tcm.staticMethod("rem", LongBinaryOperator.class).applyAsLong(2L, 3L));
+        assertEquals(2L & 3L, tcm.staticMethod("and", LongBinaryOperator.class).applyAsLong(2L, 3L));
+        assertEquals(2L | 3L, tcm.staticMethod("or", LongBinaryOperator.class).applyAsLong(2L, 3L));
+        assertEquals(2L ^ 3L, tcm.staticMethod("xor", LongBinaryOperator.class).applyAsLong(2L, 3L));
+        assertEquals(2L << 3L, tcm.staticMethod("shl", LongIntToLongFunction.class).apply(2L, 3));
+        assertEquals(200L >> 3L, tcm.staticMethod("shr", LongIntToLongFunction.class).apply(200L, 3));
+        assertEquals(-200L >> 3L, tcm.staticMethod("shr", LongIntToLongFunction.class).apply(-200L, 3));
+        assertEquals(200L >>> 3L, tcm.staticMethod("ushr", LongIntToLongFunction.class).apply(200L, 3));
+        assertEquals(-200L >>> 3L, tcm.staticMethod("ushr", LongIntToLongFunction.class).apply(-200L, 3));
+    }
+
+    @FunctionalInterface
+    public interface LongIntToLongFunction {
+        long apply(long a, int b);
+    }
+
+    @Test
+    public void doubleArithmetic() {
+        TestClassMaker tcm = new TestClassMaker();
+        Gizmo g = Gizmo.create(tcm);
+        g.class_("io.quarkus.gizmo2.Double", cc -> {
+            cc.staticMethod("neg", mc -> {
+                mc.returning(double.class);
+                ParamVar a = mc.parameter("a", double.class);
+                mc.body(bc -> {
+                    bc.return_(bc.neg(a));
+                });
+            });
+            cc.staticMethod("add", mc -> {
+                mc.returning(double.class);
+                ParamVar a = mc.parameter("a", double.class);
+                ParamVar b = mc.parameter("b", double.class);
+                mc.body(bc -> {
+                    bc.return_(bc.add(a, b));
+                });
+            });
+            cc.staticMethod("sub", mc -> {
+                mc.returning(double.class);
+                ParamVar a = mc.parameter("a", double.class);
+                ParamVar b = mc.parameter("b", double.class);
+                mc.body(bc -> {
+                    bc.return_(bc.sub(a, b));
+                });
+            });
+            cc.staticMethod("mul", mc -> {
+                mc.returning(double.class);
+                ParamVar a = mc.parameter("a", double.class);
+                ParamVar b = mc.parameter("b", double.class);
+                mc.body(bc -> {
+                    bc.return_(bc.mul(a, b));
+                });
+            });
+            cc.staticMethod("div", mc -> {
+                mc.returning(double.class);
+                ParamVar a = mc.parameter("a", double.class);
+                ParamVar b = mc.parameter("b", double.class);
+                mc.body(bc -> {
+                    bc.return_(bc.div(a, b));
+                });
+            });
+            cc.staticMethod("rem", mc -> {
+                mc.returning(double.class);
+                ParamVar a = mc.parameter("a", double.class);
+                ParamVar b = mc.parameter("b", double.class);
+                mc.body(bc -> {
+                    bc.return_(bc.rem(a, b));
+                });
+            });
+        });
+        assertEquals(-2.0, tcm.staticMethod("neg", DoubleUnaryOperator.class).applyAsDouble(2.0));
+        assertEquals(2.0, tcm.staticMethod("neg", DoubleUnaryOperator.class).applyAsDouble(-2.0));
+        assertEquals(2.0 + 3.0, tcm.staticMethod("add", DoubleBinaryOperator.class).applyAsDouble(2.0, 3.0));
+        assertEquals(2.0 - 3.0, tcm.staticMethod("sub", DoubleBinaryOperator.class).applyAsDouble(2.0, 3.0));
+        assertEquals(2.0 * 3.0, tcm.staticMethod("mul", DoubleBinaryOperator.class).applyAsDouble(2.0, 3.0));
+        assertEquals(2.0 / 3.0, tcm.staticMethod("div", DoubleBinaryOperator.class).applyAsDouble(2.0, 3.0));
+        assertEquals(2.0 / 0.0, tcm.staticMethod("div", DoubleBinaryOperator.class).applyAsDouble(2.0, 0.0));
+        assertEquals(-2.0 / 0.0, tcm.staticMethod("div", DoubleBinaryOperator.class).applyAsDouble(-2.0, 0.0));
+        assertEquals(2.0 % 3.0, tcm.staticMethod("rem", DoubleBinaryOperator.class).applyAsDouble(2.0, 3.0));
+    }
+}


### PR DESCRIPTION
The type check in `BinOp` used to assume that all binary operations accept operands of the same type. That is not true: the shifts (shl, shr, ushr) always accept an `int` second operand, even if the first operand is `long`. This issue is fixed now.

Further, this commit adds tests for arithmetic operations on `int`, `long` and `double`.