### PR TITLE
add missing toString() methods

### DIFF
--- a/src/main/java/io/quarkus/gizmo2/impl/ConstructorDescImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/ConstructorDescImpl.java
@@ -49,4 +49,8 @@ public final class ConstructorDescImpl implements ConstructorDesc {
         b.append(type.descriptorString());
         return b.append(']');
     }
+
+    public String toString() {
+        return toString(new StringBuilder()).toString();
+    }
 }

--- a/src/main/java/io/quarkus/gizmo2/impl/MethodDescImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/MethodDescImpl.java
@@ -43,4 +43,8 @@ public sealed abstract class MethodDescImpl implements MethodDesc permits ClassM
     public int hashCode() {
         return hashCode;
     }
+
+    public String toString() {
+        return toString(new StringBuilder()).toString();
+    }
 }


### PR DESCRIPTION
I just found that a few `MemberDesc` implementation classes do have the `toString(StringBuilder)` method, but they lack the common `toString()` method, so they inherit the one from `Object`. This commit fixes that.