### PR TITLE
make Var an LValueExpr

### DIFF
--- a/src/main/java/io/quarkus/gizmo2/Expr.java
+++ b/src/main/java/io/quarkus/gizmo2/Expr.java
@@ -9,7 +9,7 @@ import io.quarkus.gizmo2.impl.Item;
 /**
  * An expression.
  */
-public sealed interface Expr extends SimpleTyped permits Constant, LValueExpr, This, Var, Item {
+public sealed interface Expr extends SimpleTyped permits Constant, LValueExpr, This, Item {
     /**
      * {@return the expression type (not {@code null})}
      */

--- a/src/main/java/io/quarkus/gizmo2/FieldVar.java
+++ b/src/main/java/io/quarkus/gizmo2/FieldVar.java
@@ -7,7 +7,7 @@ import io.quarkus.gizmo2.desc.FieldDesc;
 /**
  * A variable corresponding to a field.
  */
-public sealed interface FieldVar extends Var, LValueExpr permits InstanceFieldVar, StaticFieldVar {
+public sealed interface FieldVar extends Var permits InstanceFieldVar, StaticFieldVar {
     default ClassDesc type() {
         return desc().type();
     }

--- a/src/main/java/io/quarkus/gizmo2/LValueExpr.java
+++ b/src/main/java/io/quarkus/gizmo2/LValueExpr.java
@@ -5,6 +5,6 @@ import io.quarkus.gizmo2.impl.LValueExprImpl;
 /**
  * An expression that can be the target of an assignment.
  */
-public sealed interface LValueExpr extends Expr permits FieldVar, LocalVar, ParamVar, LValueExprImpl {
+public sealed interface LValueExpr extends Expr permits Var, LValueExprImpl {
 
 }

--- a/src/main/java/io/quarkus/gizmo2/LocalVar.java
+++ b/src/main/java/io/quarkus/gizmo2/LocalVar.java
@@ -6,7 +6,7 @@ import io.quarkus.gizmo2.impl.LocalVarImpl;
 /**
  * A local variable.
  */
-public sealed interface LocalVar extends Var, LValueExpr permits LocalVarImpl {
+public sealed interface LocalVar extends Var permits LocalVarImpl {
     /**
      * {@return the block that owns this local variable}
      */

--- a/src/main/java/io/quarkus/gizmo2/ParamVar.java
+++ b/src/main/java/io/quarkus/gizmo2/ParamVar.java
@@ -5,7 +5,7 @@ import io.quarkus.gizmo2.impl.ParamVarImpl;
 /**
  * A variable representing a method call parameter.
  */
-public sealed interface ParamVar extends Var, LValueExpr permits ParamVarImpl {
+public sealed interface ParamVar extends Var permits ParamVarImpl {
     /**
      * {@return the parameter index, counting from zero}
      * The index does not include any "{@code this}" variable.

--- a/src/main/java/io/quarkus/gizmo2/Var.java
+++ b/src/main/java/io/quarkus/gizmo2/Var.java
@@ -3,7 +3,7 @@ package io.quarkus.gizmo2;
 /**
  * An lvalue expression that is stored in a variable.
  */
-public sealed interface Var extends Expr permits FieldVar, LocalVar, ParamVar {
+public sealed interface Var extends LValueExpr permits FieldVar, LocalVar, ParamVar {
     /**
      * {@return the variable name}
      */


### PR DESCRIPTION
Now that `This` is no longer a `Var`, it makes sense for `Var` to simply be a subinterface of `LValueExpr`. This improves clarity of the API.

Related to #281