### PR TITLE
improve parameter-related javadocs

### DIFF
--- a/src/main/java/io/quarkus/gizmo2/creator/ops/ObjectOps.java
+++ b/src/main/java/io/quarkus/gizmo2/creator/ops/ObjectOps.java
@@ -67,61 +67,61 @@ public class ObjectOps {
     }
 
     /**
-     * Perform an instance invocation.
+     * Perform an instance invocation of a method with 3 parameters.
      *
      * @param returnType the return type (must not be {@code null})
      * @param name the method name (must not be {@code null})
-     * @param arg0Type the first argument type (must not be {@code null})
-     * @param arg1Type the second argument type (must not be {@code null})
-     * @param arg2Type the third argument type (must not be {@code null})
+     * @param param0Type the first parameter type (must not be {@code null})
+     * @param param1Type the second parameter type (must not be {@code null})
+     * @param param2Type the third parameter type (must not be {@code null})
      * @param arg0 the first argument value (must not be {@code null})
      * @param arg1 the second argument value (must not be {@code null})
      * @param arg2 the third argument value (must not be {@code null})
      * @return the invocation result expression (not {@code null})
      */
-    protected Expr invokeInstance(Class<?> returnType, String name, Class<?> arg0Type, Class<?> arg1Type, Class<?> arg2Type,
-            Expr arg0, Expr arg1, Expr arg2) {
-        MethodDesc md = MethodDesc.of(receiverType, name, returnType, List.of(arg0Type, arg1Type, arg2Type));
+    protected Expr invokeInstance(Class<?> returnType, String name, Class<?> param0Type, Class<?> param1Type,
+            Class<?> param2Type, Expr arg0, Expr arg1, Expr arg2) {
+        MethodDesc md = MethodDesc.of(receiverType, name, returnType, List.of(param0Type, param1Type, param2Type));
         return receiverType.isInterface()
                 ? bc.invokeInterface(md, obj, List.of(arg0, arg1, arg2))
                 : bc.invokeVirtual(md, obj, List.of(arg0, arg1, arg2));
     }
 
     /**
-     * Perform an instance invocation.
+     * Perform an instance invocation of a method with 2 parameters.
      *
      * @param returnType the return type (must not be {@code null})
      * @param name the method name (must not be {@code null})
-     * @param arg0Type the first argument type (must not be {@code null})
-     * @param arg1Type the second argument type (must not be {@code null})
+     * @param param0Type the first parameter type (must not be {@code null})
+     * @param param1Type the second parameter type (must not be {@code null})
      * @param arg0 the first argument value (must not be {@code null})
      * @param arg1 the second argument value (must not be {@code null})
      * @return the invocation result expression (not {@code null})
      */
-    protected Expr invokeInstance(Class<?> returnType, String name, Class<?> arg0Type, Class<?> arg1Type, Expr arg0,
+    protected Expr invokeInstance(Class<?> returnType, String name, Class<?> param0Type, Class<?> param1Type, Expr arg0,
             Expr arg1) {
-        MethodDesc md = MethodDesc.of(receiverType, name, returnType, List.of(arg0Type, arg1Type));
+        MethodDesc md = MethodDesc.of(receiverType, name, returnType, List.of(param0Type, param1Type));
         return receiverType.isInterface()
                 ? bc.invokeInterface(md, obj, List.of(arg0, arg1))
                 : bc.invokeVirtual(md, obj, List.of(arg0, arg1));
     }
 
     /**
-     * Perform an instance invocation.
+     * Perform an instance invocation of a method with 1 parameter.
      *
      * @param returnType the return type (must not be {@code null})
      * @param name the method name (must not be {@code null})
-     * @param argType the argument type (must not be {@code null})
+     * @param paramType the parameter type (must not be {@code null})
      * @param arg the argument value (must not be {@code null})
      * @return the invocation result expression (not {@code null})
      */
-    protected Expr invokeInstance(Class<?> returnType, String name, Class<?> argType, Expr arg) {
-        MethodDesc md = MethodDesc.of(receiverType, name, returnType, List.of(argType));
+    protected Expr invokeInstance(Class<?> returnType, String name, Class<?> paramType, Expr arg) {
+        MethodDesc md = MethodDesc.of(receiverType, name, returnType, List.of(paramType));
         return receiverType.isInterface() ? bc.invokeInterface(md, obj, List.of(arg)) : bc.invokeVirtual(md, obj, List.of(arg));
     }
 
     /**
-     * Perform an instance invocation.
+     * Perform an instance invocation of a method with no parameter.
      *
      * @param returnType the return type (must not be {@code null})
      * @param name the method name (must not be {@code null})
@@ -133,7 +133,7 @@ public class ObjectOps {
     }
 
     /**
-     * Perform a {@code void} instance invocation on the receiver type.
+     * Perform an instance invocation of a method with no parameter that returns {@code void}.
      *
      * @param name the method name (must not be {@code null})
      */

--- a/src/main/java/io/quarkus/gizmo2/desc/ConstructorDesc.java
+++ b/src/main/java/io/quarkus/gizmo2/desc/ConstructorDesc.java
@@ -25,7 +25,7 @@ public sealed interface ConstructorDesc extends MemberDesc permits ConstructorDe
     }
 
     /**
-     * Construct a new instance for a no-arguments constructor.
+     * Construct a new instance for a zero-parameter constructor.
      *
      * @param owner the descriptor of the class which contains the member (must not be {@code null})
      * @return the constructor descriptor (not {@code null})
@@ -38,11 +38,11 @@ public sealed interface ConstructorDesc extends MemberDesc permits ConstructorDe
      * Construct a new instance.
      *
      * @param owner the descriptor of the class which contains the member (must not be {@code null})
-     * @param argTypes a list of descriptors corresponding to the argument types (must not be {@code null})
+     * @param paramTypes a list of descriptors corresponding to the parameter types (must not be {@code null})
      * @return the constructor descriptor (not {@code null})
      */
-    static ConstructorDesc of(ClassDesc owner, List<ClassDesc> argTypes) {
-        return of(owner, MethodTypeDesc.of(ConstantDescs.CD_void, argTypes.toArray(ClassDesc[]::new)));
+    static ConstructorDesc of(ClassDesc owner, List<ClassDesc> paramTypes) {
+        return of(owner, MethodTypeDesc.of(ConstantDescs.CD_void, paramTypes.toArray(ClassDesc[]::new)));
     }
 
     /**
@@ -71,22 +71,22 @@ public sealed interface ConstructorDesc extends MemberDesc permits ConstructorDe
      * Construct a new instance.
      *
      * @param owner the class which contains the member (must not be {@code null})
-     * @param argTypes a list of argument types (must not be {@code null})
+     * @param paramTypes a list of parameter types (must not be {@code null})
      * @return the constructor descriptor (not {@code null})
      */
-    static ConstructorDesc of(Class<?> owner, Class<?>... argTypes) {
-        return of(owner, MethodType.methodType(void.class, argTypes));
+    static ConstructorDesc of(Class<?> owner, Class<?>... paramTypes) {
+        return of(owner, MethodType.methodType(void.class, paramTypes));
     }
 
     /**
      * Construct a new instance.
      *
      * @param owner the class which contains the member (must not be {@code null})
-     * @param argTypes a list of argument types (must not be {@code null})
+     * @param paramTypes a list of parameter types (must not be {@code null})
      * @return the constructor descriptor (not {@code null})
      */
-    static ConstructorDesc of(Class<?> owner, List<Class<?>> argTypes) {
-        return of(owner, MethodType.methodType(void.class, argTypes));
+    static ConstructorDesc of(Class<?> owner, List<Class<?>> paramTypes) {
+        return of(owner, MethodType.methodType(void.class, paramTypes));
     }
 
     /**

--- a/src/main/java/io/quarkus/gizmo2/desc/MethodDesc.java
+++ b/src/main/java/io/quarkus/gizmo2/desc/MethodDesc.java
@@ -44,12 +44,12 @@ public sealed interface MethodDesc extends MemberDesc, MethodTyped
      *
      * @param owner the class which contains the method (must not be {@code null})
      * @param name the name of the method (must not be {@code null})
-     * @param returning the class of the method return type (must not be {@code null})
-     * @param argTypes the classes of the argument types (must not be {@code null})
+     * @param returnType the class of the return type (must not be {@code null})
+     * @param paramTypes the classes of the parameter types (must not be {@code null})
      * @return the method descriptor (must not be {@code null})
      */
-    static MethodDesc of(Class<?> owner, String name, Class<?> returning, Class<?>... argTypes) {
-        return of(owner, name, MethodType.methodType(returning, argTypes));
+    static MethodDesc of(Class<?> owner, String name, Class<?> returnType, Class<?>... paramTypes) {
+        return of(owner, name, MethodType.methodType(returnType, paramTypes));
     }
 
     /**
@@ -57,11 +57,11 @@ public sealed interface MethodDesc extends MemberDesc, MethodTyped
      *
      * @param owner the class which contains the method (must not be {@code null})
      * @param name the name of the method (must not be {@code null})
-     * @param returning the class of the method return type (must not be {@code null})
-     * @param argTypes the classes of the argument types (must not be {@code null})
+     * @param returnType the class of the return type (must not be {@code null})
+     * @param paramTypes the classes of the parameter types (must not be {@code null})
      * @return the method descriptor (must not be {@code null})
      */
-    static MethodDesc of(Class<?> owner, String name, Class<?> returning, List<Class<?>> argTypes) {
-        return of(owner, name, MethodType.methodType(returning, argTypes));
+    static MethodDesc of(Class<?> owner, String name, Class<?> returnType, List<Class<?>> paramTypes) {
+        return of(owner, name, MethodType.methodType(returnType, paramTypes));
     }
 }


### PR DESCRIPTION
Certain methods used to refer to parameters as arguments in their javadoc. This is especially confusing in case of `ObjectOps` which has methods with parameters that refer to both parameters and arguments.