### PR TITLE
fix static field with an initializer

### DIFF
--- a/src/main/java/io/quarkus/gizmo2/impl/BlockCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/BlockCreatorImpl.java
@@ -805,7 +805,7 @@ public final class BlockCreatorImpl extends Item implements BlockCreator {
         block.accept(nested);
         state = ST_ACTIVE;
         // inline it
-        if (block.tail.item() instanceof Yield yield) {
+        if (block.tail.item() instanceof Yield yield && yield.value().isVoid()) {
             // block should be safe to inline
             Node node = block.head.next();
             while (node.item() != yield) {

--- a/src/main/java/io/quarkus/gizmo2/impl/BlockCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/BlockCreatorImpl.java
@@ -796,7 +796,6 @@ public final class BlockCreatorImpl extends Item implements BlockCreator {
         block.accept(nested);
         state = ST_ACTIVE;
         addItem(block);
-        return;
     }
 
     public Expr blockExpr(final ClassDesc type, final Consumer<BlockCreator> nested) {

--- a/src/main/java/io/quarkus/gizmo2/impl/StaticFieldCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/StaticFieldCreatorImpl.java
@@ -31,7 +31,7 @@ public final class StaticFieldCreatorImpl extends FieldCreatorImpl implements St
         if (initial.type().isPrimitive() || initial.type().equals(CD_String)) {
             this.initial = initial;
         } else {
-            initializer = (bc -> bc.setStaticField(desc(), initial));
+            initializer = bc -> bc.setStaticField(desc(), initial);
         }
     }
 

--- a/src/main/java/io/quarkus/gizmo2/impl/TypeCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/TypeCreatorImpl.java
@@ -264,8 +264,10 @@ public abstract sealed class TypeCreatorImpl extends AnnotatableCreatorImpl impl
                     bc.accept(b0 -> {
                         for (Consumer<BlockCreator> init : staticInits) {
                             b0.block(init);
+                            b0.writeCode(cb, b0);
                         }
                     });
+                    cb.return_();
                 });
             });
         }

--- a/src/main/java/io/quarkus/gizmo2/impl/TypeCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/TypeCreatorImpl.java
@@ -264,9 +264,9 @@ public abstract sealed class TypeCreatorImpl extends AnnotatableCreatorImpl impl
                     bc.accept(b0 -> {
                         for (Consumer<BlockCreator> init : staticInits) {
                             b0.block(init);
-                            b0.writeCode(cb, b0);
                         }
                     });
+                    bc.writeCode(cb, bc);
                     cb.return_();
                 });
             });


### PR DESCRIPTION
In case a `static` field was provided with an initializer (that is, either a block of code or a constant that cannot be represented in the constant pool), the code of that initializer was never emitted. This commit fixes that.