### PR TITLE
add BlockCreator.if[Not]InstanceOf[OrElse] overloads that take a Class

### DIFF
--- a/src/main/java/io/quarkus/gizmo2/creator/BlockCreator.java
+++ b/src/main/java/io/quarkus/gizmo2/creator/BlockCreator.java
@@ -2099,6 +2099,17 @@ public sealed interface BlockCreator extends SimpleTyped permits BlockCreatorImp
      * @param type the type to check for (must not be {@code null})
      * @param ifTrue the builder for a block to run if the type was successfully narrowed (must not be {@code null})
      */
+    default void ifInstanceOf(Expr obj, Class<?> type, BiConsumer<BlockCreator, ? super LocalVar> ifTrue) {
+        ifInstanceOf(obj, Util.classDesc(type), ifTrue);
+    }
+
+    /**
+     * If the given object is an instance of the given type, then execute the block with the narrowed object.
+     *
+     * @param obj the object to test (must not be {@code null})
+     * @param type the type to check for (must not be {@code null})
+     * @param ifTrue the builder for a block to run if the type was successfully narrowed (must not be {@code null})
+     */
     void ifInstanceOf(Expr obj, ClassDesc type, BiConsumer<BlockCreator, ? super LocalVar> ifTrue);
 
     /**
@@ -2108,7 +2119,32 @@ public sealed interface BlockCreator extends SimpleTyped permits BlockCreatorImp
      * @param type the type to check for (must not be {@code null})
      * @param ifFalse the builder for a block to run if the type did not match (must not be {@code null})
      */
+    default void ifNotInstanceOf(Expr obj, Class<?> type, Consumer<BlockCreator> ifFalse) {
+        ifNotInstanceOf(obj, Util.classDesc(type), ifFalse);
+    }
+
+    /**
+     * If the given object is <em>not</em> an instance of the given type, then execute the given block.
+     *
+     * @param obj the object to test (must not be {@code null})
+     * @param type the type to check for (must not be {@code null})
+     * @param ifFalse the builder for a block to run if the type did not match (must not be {@code null})
+     */
     void ifNotInstanceOf(Expr obj, ClassDesc type, Consumer<BlockCreator> ifFalse);
+
+    /**
+     * If the given object is an instance of the given type, then execute the first block with the narrowed object,
+     * otherwise execute the other block.
+     *
+     * @param obj the object to test (must not be {@code null})
+     * @param type the type to check for (must not be {@code null})
+     * @param ifTrue the builder for a block to run if the type was successfully narrowed (must not be {@code null})
+     * @param ifFalse the builder for a block to run if the type did not match (must not be {@code null})
+     */
+    default void ifInstanceOfElse(Expr obj, Class<?> type, BiConsumer<BlockCreator, ? super LocalVar> ifTrue,
+            Consumer<BlockCreator> ifFalse) {
+        ifInstanceOfElse(obj, Util.classDesc(type), ifTrue, ifFalse);
+    }
 
     /**
      * If the given object is an instance of the given type, then execute the first block with the narrowed object,

--- a/src/main/java/io/quarkus/gizmo2/creator/ClassCreator.java
+++ b/src/main/java/io/quarkus/gizmo2/creator/ClassCreator.java
@@ -328,7 +328,7 @@ public sealed interface ClassCreator extends TypeCreator, SimpleTyped permits An
      * <li>At the end, the result is returned.</li>
      * </ol>
      * <p>
-     * is thrown. If one of the fields doesn't belong to this class, an exception is thrown.
+     * If one of the fields doesn't belong to this class, an exception is thrown.
      *
      * @param fields fields to consider in the {@code equals} and {@code hashCode} methods (must not be {@code null})
      */

--- a/src/main/java/io/quarkus/gizmo2/impl/TypeCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/TypeCreatorImpl.java
@@ -381,22 +381,22 @@ public abstract sealed class TypeCreatorImpl extends AnnotatableCreatorImpl impl
 
     @Override
     public List<FieldDesc> staticFields() {
-        return fields.entrySet().stream().filter(e -> e.getValue().booleanValue()).map(Map.Entry::getKey).toList();
+        return fields.entrySet().stream().filter(Map.Entry::getValue).map(Map.Entry::getKey).toList();
     }
 
     @Override
     public List<FieldDesc> instanceFields() {
-        return fields.entrySet().stream().filter(e -> !e.getValue().booleanValue()).map(Map.Entry::getKey).toList();
+        return fields.entrySet().stream().filter(e -> !e.getValue()).map(Map.Entry::getKey).toList();
     }
 
     @Override
     public List<MethodDesc> staticMethods() {
-        return methods.entrySet().stream().filter(e -> e.getValue().booleanValue()).map(Map.Entry::getKey).toList();
+        return methods.entrySet().stream().filter(Map.Entry::getValue).map(Map.Entry::getKey).toList();
     }
 
     @Override
     public List<MethodDesc> instanceMethods() {
-        return methods.entrySet().stream().filter(e -> !e.getValue().booleanValue()).map(Map.Entry::getKey).toList();
+        return methods.entrySet().stream().filter(e -> !e.getValue()).map(Map.Entry::getKey).toList();
     }
 
     @Override


### PR DESCRIPTION
It is fairly common to emit the `instanceof` instruction to test against a class that's known during code generation. Therefore, this commit adds a few overloads that accept `Class` and delegate to the corresponding overload that accept `ClassDesc`.

Additionally, this commit does some tiny cleanup.