### PR TITLE
small improvements

### DIFF
--- a/src/main/java/io/quarkus/gizmo2/MethodTyped.java
+++ b/src/main/java/io/quarkus/gizmo2/MethodTyped.java
@@ -53,6 +53,13 @@ public sealed interface MethodTyped extends Typed permits MethodDesc, Executable
     }
 
     /**
+     * {@return the number of parameters}
+     */
+    default int parameterCount() {
+        return type().parameterCount();
+    }
+
+    /**
      * {@return the type of the parameter with the given index}
      *
      * @param idx the parameter index

--- a/src/main/java/io/quarkus/gizmo2/creator/BlockCreator.java
+++ b/src/main/java/io/quarkus/gizmo2/creator/BlockCreator.java
@@ -381,7 +381,7 @@ public sealed interface BlockCreator extends SimpleTyped permits BlockCreatorImp
     // arrays
 
     /**
-     * Create a new, empty array of the given type.
+     * Create a new, empty array of the given type with given size.
      *
      * @param componentType the component type (must not be {@code null})
      * @param size the size of the array (must not be {@code null})
@@ -390,7 +390,18 @@ public sealed interface BlockCreator extends SimpleTyped permits BlockCreatorImp
     Expr newEmptyArray(ClassDesc componentType, Expr size);
 
     /**
-     * Create a new, empty array of the given type.
+     * Create a new, empty array of the given type with given size.
+     *
+     * @param componentType the component type (must not be {@code null})
+     * @param size the size of the array
+     * @return the expression for the new array (not {@code null})
+     */
+    default Expr newEmptyArray(ClassDesc componentType, int size) {
+        return newEmptyArray(componentType, Constant.of(size));
+    }
+
+    /**
+     * Create a new, empty array of the given type with given size.
      *
      * @param componentType the component type (must not be {@code null})
      * @param size the size of the array (must not be {@code null})
@@ -398,6 +409,17 @@ public sealed interface BlockCreator extends SimpleTyped permits BlockCreatorImp
      */
     default Expr newEmptyArray(Class<?> componentType, Expr size) {
         return newEmptyArray(Util.classDesc(componentType), size);
+    }
+
+    /**
+     * Create a new, empty array of the given type with given size.
+     *
+     * @param componentType the component type (must not be {@code null})
+     * @param size the size of the array
+     * @return the expression for the new array (not {@code null})
+     */
+    default Expr newEmptyArray(Class<?> componentType, int size) {
+        return newEmptyArray(Util.classDesc(componentType), Constant.of(size));
     }
 
     /**

--- a/src/main/java/io/quarkus/gizmo2/creator/BlockCreator.java
+++ b/src/main/java/io/quarkus/gizmo2/creator/BlockCreator.java
@@ -2536,7 +2536,7 @@ public sealed interface BlockCreator extends SimpleTyped permits BlockCreatorImp
      * @param type the exception type (must not be {@code null})
      */
     default void throw_(ClassDesc type) {
-        throw_(new_(type, List.of()));
+        throw_(new_(type));
     }
 
     /**
@@ -2546,7 +2546,17 @@ public sealed interface BlockCreator extends SimpleTyped permits BlockCreatorImp
      * @param message the message (must not be {@code null})
      */
     default void throw_(ClassDesc type, String message) {
-        throw_(new_(type, List.of(Constant.of(message))));
+        throw_(new_(type, Constant.of(message)));
+    }
+
+    /**
+     * Throw a new exception of the given type with a message.
+     *
+     * @param type the exception type (must not be {@code null})
+     * @param message the message (must not be {@code null})
+     */
+    default void throw_(ClassDesc type, Expr message) {
+        throw_(new_(type, message));
     }
 
     /**
@@ -2562,9 +2572,23 @@ public sealed interface BlockCreator extends SimpleTyped permits BlockCreatorImp
      * Throw a new exception of the given type with a message.
      *
      * @param type the exception type (must not be {@code null})
-     * @param message the message (must not be {@code null})
+     * @param message the message
      */
     default void throw_(Class<? extends Throwable> type, String message) {
+        if (message == null) {
+            throw_(type);
+        } else {
+            throw_(Util.classDesc(type), message);
+        }
+    }
+
+    /**
+     * Throw a new exception of the given type with a message.
+     *
+     * @param type the exception type (must not be {@code null})
+     * @param message the message
+     */
+    default void throw_(Class<? extends Throwable> type, Expr message) {
         if (message == null) {
             throw_(type);
         } else {

--- a/src/main/java/io/quarkus/gizmo2/desc/ConstructorDesc.java
+++ b/src/main/java/io/quarkus/gizmo2/desc/ConstructorDesc.java
@@ -5,6 +5,7 @@ import java.lang.constant.ConstantDescs;
 import java.lang.constant.MethodTypeDesc;
 import java.lang.invoke.MethodType;
 import java.util.List;
+import java.util.stream.Stream;
 
 import io.quarkus.gizmo2.impl.ConstructorDescImpl;
 import io.quarkus.gizmo2.impl.Util;
@@ -16,7 +17,7 @@ public sealed interface ConstructorDesc extends MemberDesc permits ConstructorDe
     /**
      * Construct a new instance.
      *
-     * @param owner the descriptor of the class which contains the member (must not be {@code null})
+     * @param owner the descriptor of the class which contains the constructor (must not be {@code null})
      * @param type the descriptor of the type of the constructor (must not be {@code null})
      * @return the constructor descriptor (not {@code null})
      */
@@ -27,7 +28,7 @@ public sealed interface ConstructorDesc extends MemberDesc permits ConstructorDe
     /**
      * Construct a new instance for a zero-parameter constructor.
      *
-     * @param owner the descriptor of the class which contains the member (must not be {@code null})
+     * @param owner the descriptor of the class which contains the constructor (must not be {@code null})
      * @return the constructor descriptor (not {@code null})
      */
     static ConstructorDesc of(ClassDesc owner) {
@@ -37,7 +38,30 @@ public sealed interface ConstructorDesc extends MemberDesc permits ConstructorDe
     /**
      * Construct a new instance.
      *
-     * @param owner the descriptor of the class which contains the member (must not be {@code null})
+     * @param owner the descriptor of the class which contains the constructor (must not be {@code null})
+     * @param paramTypes a list of parameter types (must not be {@code null})
+     * @return the constructor descriptor (not {@code null})
+     */
+    static ConstructorDesc of(ClassDesc owner, Class<?>... paramTypes) {
+        ClassDesc[] params = Stream.of(paramTypes).map(Util::classDesc).toArray(ClassDesc[]::new);
+        return of(owner, MethodTypeDesc.of(ConstantDescs.CD_void, params));
+    }
+
+    /**
+     * Construct a new instance.
+     *
+     * @param owner the descriptor of the class which contains the constructor (must not be {@code null})
+     * @param paramTypes a list of descriptors corresponding to the parameter types (must not be {@code null})
+     * @return the constructor descriptor (not {@code null})
+     */
+    static ConstructorDesc of(ClassDesc owner, ClassDesc... paramTypes) {
+        return of(owner, MethodTypeDesc.of(ConstantDescs.CD_void, paramTypes));
+    }
+
+    /**
+     * Construct a new instance.
+     *
+     * @param owner the descriptor of the class which contains the constructor (must not be {@code null})
      * @param paramTypes a list of descriptors corresponding to the parameter types (must not be {@code null})
      * @return the constructor descriptor (not {@code null})
      */
@@ -48,7 +72,7 @@ public sealed interface ConstructorDesc extends MemberDesc permits ConstructorDe
     /**
      * Construct a new instance.
      *
-     * @param owner the class which contains the member (must not be {@code null})
+     * @param owner the class which contains the constructor (must not be {@code null})
      * @param type the descriptor of the type of the constructor (must not be {@code null})
      * @return the constructor descriptor (not {@code null})
      */
@@ -59,7 +83,7 @@ public sealed interface ConstructorDesc extends MemberDesc permits ConstructorDe
     /**
      * Construct a new instance.
      *
-     * @param owner the class which contains the member (must not be {@code null})
+     * @param owner the class which contains the constructor (must not be {@code null})
      * @param type the type of the constructor (must not be {@code null})
      * @return the constructor descriptor (not {@code null})
      */
@@ -70,7 +94,7 @@ public sealed interface ConstructorDesc extends MemberDesc permits ConstructorDe
     /**
      * Construct a new instance.
      *
-     * @param owner the class which contains the member (must not be {@code null})
+     * @param owner the class which contains the constructor (must not be {@code null})
      * @param paramTypes a list of parameter types (must not be {@code null})
      * @return the constructor descriptor (not {@code null})
      */
@@ -81,7 +105,7 @@ public sealed interface ConstructorDesc extends MemberDesc permits ConstructorDe
     /**
      * Construct a new instance.
      *
-     * @param owner the class which contains the member (must not be {@code null})
+     * @param owner the class which contains the constructor (must not be {@code null})
      * @param paramTypes a list of parameter types (must not be {@code null})
      * @return the constructor descriptor (not {@code null})
      */

--- a/src/main/java/io/quarkus/gizmo2/impl/ConstructorDescImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/ConstructorDescImpl.java
@@ -1,6 +1,7 @@
 package io.quarkus.gizmo2.impl;
 
 import java.lang.constant.ClassDesc;
+import java.lang.constant.ConstantDescs;
 import java.lang.constant.MethodTypeDesc;
 import java.util.Objects;
 
@@ -12,6 +13,9 @@ public final class ConstructorDescImpl implements ConstructorDesc {
     private final int hashCode;
 
     public ConstructorDescImpl(final ClassDesc owner, final MethodTypeDesc type) {
+        if (!ConstantDescs.CD_void.equals(type.returnType())) {
+            throw new IllegalArgumentException("Constructor descriptor must have a return type of void");
+        }
         this.owner = owner;
         this.type = type;
         hashCode = Objects.hash(owner, "<init>", type);

--- a/src/main/java/io/quarkus/gizmo2/impl/Util.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/Util.java
@@ -30,6 +30,9 @@ public final class Util {
      */
     public static final ClassDesc[] NO_DESCS = new ClassDesc[0];
 
+    // set system property means enabled, even with an empty value, except if the value is `false`
+    private static final boolean trackCreations = !"false".equals(System.getProperty("gizmo.trackCreations", "false"));
+
     private Util() {
     }
 
@@ -134,6 +137,18 @@ public final class Util {
             return null;
         });
         return b.toString();
+    }
+
+    public static String trackCreationSite() {
+        return trackCreations ? callerOutsideGizmo() : null;
+    }
+
+    private static String callerOutsideGizmo() {
+        return SW.walk(stream -> stream
+                .filter(it -> !it.getClassName().startsWith("io.quarkus.gizmo2"))
+                .findFirst()
+                .map(it -> it.getClassName() + "." + it.getMethodName() + "():" + it.getLineNumber())
+                .orElseThrow(IllegalStateException::new));
     }
 
     // TODO: move to using smallrye-common-search


### PR DESCRIPTION
- add `MethodTyped.parameterCount()`
- add `BlockCreator.newEmptyArray()` overloads that take an `int` size
- add `BlockCreator.throw_()` overloads that take an `Expr` message
- add `ConstructorDesc.of()` overloads that accept vararg parameter types
- validate the return type on creation of `ConstructorDesc`
- add `TestClassMaker.loadClass()`
- improve the exception message when an `Item` is used on an unexpected place
