### PR TITLE
`unsafeCast` -> `uncheckedCast`

### DIFF
--- a/src/main/java/io/quarkus/gizmo2/creator/BlockCreator.java
+++ b/src/main/java/io/quarkus/gizmo2/creator/BlockCreator.java
@@ -1879,7 +1879,7 @@ public sealed interface BlockCreator extends SimpleTyped permits BlockCreatorImp
      * @return the cast value (not {@code null})
      * @see #cast(Expr, ClassDesc)
      */
-    Expr unsafeCast(Expr a, ClassDesc toType);
+    Expr uncheckedCast(Expr a, ClassDesc toType);
 
     /**
      * Cast an object value to the given type without a type check.
@@ -1890,8 +1890,8 @@ public sealed interface BlockCreator extends SimpleTyped permits BlockCreatorImp
      * @return the cast value (not {@code null})
      * @see #cast(Expr, Class)
      */
-    default Expr unsafeCast(Expr a, Class<?> toType) {
-        return unsafeCast(a, Util.classDesc(toType));
+    default Expr uncheckedCast(Expr a, Class<?> toType) {
+        return uncheckedCast(a, Util.classDesc(toType));
     }
 
     /**

--- a/src/main/java/io/quarkus/gizmo2/impl/BlockCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/BlockCreatorImpl.java
@@ -674,7 +674,7 @@ public final class BlockCreatorImpl extends Item implements BlockCreator {
         }
     }
 
-    public Expr unsafeCast(final Expr a, final ClassDesc toType) {
+    public Expr uncheckedCast(final Expr a, final ClassDesc toType) {
         if (a.type().isPrimitive()) {
             throw new IllegalArgumentException("Only object types may be unsafely cast");
         }

--- a/src/test/java/io/quarkus/gizmo2/CastTest.java
+++ b/src/test/java/io/quarkus/gizmo2/CastTest.java
@@ -36,7 +36,7 @@ public final class CastTest {
                 smc.returning(Object.class);
                 ParamVar input = smc.parameter("input", String.class);
                 smc.body(b0 -> {
-                    b0.return_(b0.unsafeCast(input, Object.class));
+                    b0.return_(b0.uncheckedCast(input, Object.class));
                 });
             });
         });


### PR DESCRIPTION
On further thought I've decided that `uncheckedCast` is a better name. Everyone knows what "unchecked" means - it means the cast isn't checked. The cast is not "unsafe" in any way - if the cast is valid, it's safe, and if it's invalid, it will fail verification. It also intuitively complements the `CHECKCAST` instruction.