### PR TITLE
improvements

### DIFF
--- a/src/main/java/io/quarkus/gizmo2/creator/BlockCreator.java
+++ b/src/main/java/io/quarkus/gizmo2/creator/BlockCreator.java
@@ -1802,8 +1802,7 @@ public sealed interface BlockCreator extends SimpleTyped permits BlockCreatorImp
     Expr newAnonymousClass(ConstructorDesc superCtor, List<? extends Expr> args, Consumer<AnonymousClassCreator> builder);
 
     /**
-     * Create a new anonymous class instance
-     * which implements an interface.
+     * Create a new anonymous class instance which implements the given interface.
      * The type of the returned instance is the anonymous class type.
      *
      * @param interface_ the interface to implement (must not be {@code null})
@@ -1821,11 +1820,11 @@ public sealed interface BlockCreator extends SimpleTyped permits BlockCreatorImp
     }
 
     /**
-     * Create a new anonymous class instance
-     * which implements a single class or interface.
+     * Create a new anonymous class instance which extends the given class or implements the given interface.
+     * If the given supertype is a class, it has to have a zero-parameter constructor.
      * The type of the returned instance is the anonymous class type.
      *
-     * @param supertype the supertype to implement (must not be {@code null})
+     * @param supertype the supertype to extend or implement (must not be {@code null})
      * @param builder the builder for the anonymous class (must not be {@code null})
      * @return the anonymous class instance (not {@code null})
      */

--- a/src/main/java/io/quarkus/gizmo2/creator/BlockCreator.java
+++ b/src/main/java/io/quarkus/gizmo2/creator/BlockCreator.java
@@ -429,7 +429,7 @@ public sealed interface BlockCreator extends SimpleTyped permits BlockCreatorImp
      * @param values the values to assign into the array (must not be {@code null})
      * @return the expression for the new array (not {@code null})
      */
-    Expr newArray(ClassDesc componentType, List<Expr> values);
+    Expr newArray(ClassDesc componentType, List<? extends Expr> values);
 
     /**
      * Create a new array with the given type, initialized with the given values.
@@ -449,7 +449,7 @@ public sealed interface BlockCreator extends SimpleTyped permits BlockCreatorImp
      * @param values the values to assign into the array (must not be {@code null})
      * @return the expression for the new array (not {@code null})
      */
-    default Expr newArray(Class<?> componentType, List<Expr> values) {
+    default Expr newArray(Class<?> componentType, List<? extends Expr> values) {
         return newArray(Util.classDesc(componentType), values);
     }
 
@@ -1799,7 +1799,7 @@ public sealed interface BlockCreator extends SimpleTyped permits BlockCreatorImp
      * @param builder the builder for the anonymous class (must not be {@code null})
      * @return the anonymous class instance (not {@code null})
      */
-    Expr newAnonymousClass(ConstructorDesc superCtor, List<Expr> args, Consumer<AnonymousClassCreator> builder);
+    Expr newAnonymousClass(ConstructorDesc superCtor, List<? extends Expr> args, Consumer<AnonymousClassCreator> builder);
 
     /**
      * Create a new anonymous class instance
@@ -1939,7 +1939,7 @@ public sealed interface BlockCreator extends SimpleTyped permits BlockCreatorImp
      * @param args the arguments to pass to the constructor (must not be {@code null})
      * @return the new object (not {@code null})
      */
-    Expr new_(ConstructorDesc ctor, List<Expr> args);
+    Expr new_(ConstructorDesc ctor, List<? extends Expr> args);
 
     /**
      * Construct a new instance.
@@ -1959,7 +1959,7 @@ public sealed interface BlockCreator extends SimpleTyped permits BlockCreatorImp
      * @param args the arguments to pass to the constructor (must not be {@code null})
      * @return the new object (not {@code null})
      */
-    default Expr new_(ClassDesc type, List<Expr> args) {
+    default Expr new_(ClassDesc type, List<? extends Expr> args) {
         return new_(ConstructorDesc.of(type, args.stream().map(Expr::type).toList()), args);
     }
 
@@ -1981,7 +1981,7 @@ public sealed interface BlockCreator extends SimpleTyped permits BlockCreatorImp
      * @param args the arguments to pass to the constructor (must not be {@code null})
      * @return the new object (not {@code null})
      */
-    default Expr new_(Class<?> type, List<Expr> args) {
+    default Expr new_(Class<?> type, List<? extends Expr> args) {
         return new_(Util.classDesc(type), args);
     }
 
@@ -2005,7 +2005,7 @@ public sealed interface BlockCreator extends SimpleTyped permits BlockCreatorImp
      * @param args the arguments to pass to the method (must not be {@code null})
      * @return the method call result (not {@code null})
      */
-    Expr invokeStatic(MethodDesc method, List<Expr> args);
+    Expr invokeStatic(MethodDesc method, List<? extends Expr> args);
 
     /**
      * Invoke a static method.
@@ -2026,7 +2026,7 @@ public sealed interface BlockCreator extends SimpleTyped permits BlockCreatorImp
      * @param args the arguments to pass to the method (must not be {@code null})
      * @return the method call result (not {@code null})
      */
-    Expr invokeVirtual(MethodDesc method, Expr instance, List<Expr> args);
+    Expr invokeVirtual(MethodDesc method, Expr instance, List<? extends Expr> args);
 
     /**
      * Invoke a virtual method.
@@ -2048,7 +2048,7 @@ public sealed interface BlockCreator extends SimpleTyped permits BlockCreatorImp
      * @param args the arguments to pass to the method (must not be {@code null})
      * @return the method call result (not {@code null})
      */
-    Expr invokeSpecial(MethodDesc method, Expr instance, List<Expr> args);
+    Expr invokeSpecial(MethodDesc method, Expr instance, List<? extends Expr> args);
 
     /**
      * Invoke a method using "special" semantics.
@@ -2070,7 +2070,7 @@ public sealed interface BlockCreator extends SimpleTyped permits BlockCreatorImp
      * @param args the arguments to pass to the constructor (must not be {@code null})
      * @return the constructor call result (not {@code null}, usually {@link Constant#ofVoid()})
      */
-    Expr invokeSpecial(ConstructorDesc ctor, Expr instance, List<Expr> args);
+    Expr invokeSpecial(ConstructorDesc ctor, Expr instance, List<? extends Expr> args);
 
     /**
      * Invoke a constructor using "special" semantics.
@@ -2092,7 +2092,7 @@ public sealed interface BlockCreator extends SimpleTyped permits BlockCreatorImp
      * @param args the arguments to pass to the method (must not be {@code null})
      * @return the method call result (not {@code null})
      */
-    Expr invokeInterface(MethodDesc method, Expr instance, List<Expr> args);
+    Expr invokeInterface(MethodDesc method, Expr instance, List<? extends Expr> args);
 
     /**
      * Invoke an interface method.
@@ -2106,7 +2106,7 @@ public sealed interface BlockCreator extends SimpleTyped permits BlockCreatorImp
         return invokeInterface(method, instance, List.of(args));
     }
 
-    Expr invokeDynamic(DynamicCallSiteDesc callSiteDesc, List<Expr> args);
+    Expr invokeDynamic(DynamicCallSiteDesc callSiteDesc, List<? extends Expr> args);
 
     default Expr invokeDynamic(DynamicCallSiteDesc callSiteDesc, Expr... args) {
         return invokeDynamic(callSiteDesc, List.of(args));
@@ -2898,7 +2898,7 @@ public sealed interface BlockCreator extends SimpleTyped permits BlockCreatorImp
      * @return the list expression (not {@code null})
      * @see #withList(Expr)
      */
-    Expr listOf(List<Expr> items);
+    Expr listOf(List<? extends Expr> items);
 
     /**
      * Generate a call to {@link List#of()} or one of its variants, based on the number of arguments.
@@ -2918,7 +2918,7 @@ public sealed interface BlockCreator extends SimpleTyped permits BlockCreatorImp
      * @return the list expression (not {@code null})
      * @see #withSet(Expr)
      */
-    Expr setOf(List<Expr> items);
+    Expr setOf(List<? extends Expr> items);
 
     /**
      * Generate a call to {@link Set#of()} or one of its variants, based on the number of arguments.
@@ -2938,7 +2938,7 @@ public sealed interface BlockCreator extends SimpleTyped permits BlockCreatorImp
      * @return map expression (not {@code null})
      * @see BlockCreator#withMap(Expr)
      */
-    Expr mapOf(List<Expr> items);
+    Expr mapOf(List<? extends Expr> items);
 
     /**
      * Generate a call to {@link Map#of()} or one of its variants, based on the number of arguments.
@@ -3004,7 +3004,7 @@ public sealed interface BlockCreator extends SimpleTyped permits BlockCreatorImp
      * @param format the format string (must not be {@code null})
      * @param values the value expression(s) (must not be {@code null})
      */
-    void printf(String format, List<Expr> values);
+    void printf(String format, List<? extends Expr> values);
 
     /**
      * Insert a {@code printf} statement.

--- a/src/main/java/io/quarkus/gizmo2/creator/LambdaCreator.java
+++ b/src/main/java/io/quarkus/gizmo2/creator/LambdaCreator.java
@@ -4,11 +4,12 @@ import java.lang.constant.ClassDesc;
 import java.util.function.Consumer;
 
 import io.quarkus.gizmo2.ParamVar;
+import io.quarkus.gizmo2.impl.LambdaCreatorImpl;
 
 /**
  * A creator for a lambda instance.
  */
-public sealed interface LambdaCreator extends BodyCreator, CapturingCreator permits io.quarkus.gizmo2.impl.LambdaCreatorImpl {
+public sealed interface LambdaCreator extends BodyCreator, CapturingCreator permits LambdaCreatorImpl {
     /**
      * {@return the descriptor of the lambda functional interface}
      */

--- a/src/main/java/io/quarkus/gizmo2/creator/ops/ObjectOps.java
+++ b/src/main/java/io/quarkus/gizmo2/creator/ops/ObjectOps.java
@@ -1,8 +1,9 @@
 package io.quarkus.gizmo2.creator.ops;
 
+import static io.smallrye.common.constraint.Assert.checkNotNullParam;
+
 import java.lang.constant.ClassDesc;
 import java.util.List;
-import java.util.Objects;
 
 import io.quarkus.gizmo2.Expr;
 import io.quarkus.gizmo2.creator.BlockCreator;
@@ -36,9 +37,9 @@ public class ObjectOps {
      * @param obj the receiver object (must not be {@code null})
      */
     protected ObjectOps(final Class<?> receiverType, final BlockCreator bc, final Expr obj) {
-        Objects.requireNonNull(receiverType, "receiverType");
-        Objects.requireNonNull(bc, "bc");
-        Objects.requireNonNull(obj, "obj");
+        checkNotNullParam("receiverType", receiverType);
+        checkNotNullParam("bc", bc);
+        checkNotNullParam("obj", obj);
         this.receiverType = receiverType;
         receiverTypeDesc = Util.classDesc(receiverType);
         this.bc = bc;

--- a/src/main/java/io/quarkus/gizmo2/desc/FieldDesc.java
+++ b/src/main/java/io/quarkus/gizmo2/desc/FieldDesc.java
@@ -30,6 +30,19 @@ public sealed interface FieldDesc extends MemberDesc, SimpleTyped permits FieldD
     /**
      * Construct a new instance.
      *
+     * @param owner the descriptor of the class which contains the field (must not be {@code null})
+     * @param name the name of the field (must not be {@code null})
+     * @param type the field type (must not be {@code null})
+     * @return the field descriptor (not {@code null})
+     */
+    static FieldDesc of(ClassDesc owner, String name, Class<?> type) {
+        checkNotNullParam("type", type);
+        return of(owner, name, Util.classDesc(type));
+    }
+
+    /**
+     * Construct a new instance.
+     *
      * @param owner the class which contains the field (must not be {@code null})
      * @param name the name of the field (must not be {@code null})
      * @return the field descriptor (not {@code null})

--- a/src/main/java/io/quarkus/gizmo2/desc/FieldDesc.java
+++ b/src/main/java/io/quarkus/gizmo2/desc/FieldDesc.java
@@ -1,7 +1,8 @@
 package io.quarkus.gizmo2.desc;
 
+import static io.smallrye.common.constraint.Assert.checkNotNullParam;
+
 import java.lang.constant.ClassDesc;
-import java.util.Objects;
 
 import io.quarkus.gizmo2.SimpleTyped;
 import io.quarkus.gizmo2.impl.FieldDescImpl;
@@ -20,6 +21,9 @@ public sealed interface FieldDesc extends MemberDesc, SimpleTyped permits FieldD
      * @return the field descriptor (not {@code null})
      */
     static FieldDesc of(ClassDesc owner, String name, ClassDesc type) {
+        checkNotNullParam("owner", owner);
+        checkNotNullParam("name", name);
+        checkNotNullParam("type", type);
         return new FieldDescImpl(owner, name, type);
     }
 
@@ -31,8 +35,8 @@ public sealed interface FieldDesc extends MemberDesc, SimpleTyped permits FieldD
      * @return the field descriptor (not {@code null})
      */
     static FieldDesc of(Class<?> owner, String name) {
-        Objects.requireNonNull(owner, "owner");
-        Objects.requireNonNull(name, "name");
+        checkNotNullParam("owner", owner);
+        checkNotNullParam("name", name);
         try {
             return of(Util.classDesc(owner), name, Util.classDesc(owner.getDeclaredField(name).getType()));
         } catch (NoSuchFieldException e) {

--- a/src/main/java/io/quarkus/gizmo2/impl/BlockCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/BlockCreatorImpl.java
@@ -425,7 +425,7 @@ public final class BlockCreatorImpl extends Item implements BlockCreator {
         }
     }
 
-    public Expr newArray(final ClassDesc componentType, final List<Expr> values) {
+    public Expr newArray(final ClassDesc componentType, final List<? extends Expr> values) {
         checkActive();
         // build the object graph
         int size = values.size();
@@ -627,7 +627,7 @@ public final class BlockCreatorImpl extends Item implements BlockCreator {
                 ctorType), captureExprs);
     }
 
-    public Expr newAnonymousClass(final ConstructorDesc superCtor, final List<Expr> args,
+    public Expr newAnonymousClass(final ConstructorDesc superCtor, final List<? extends Expr> args,
             final Consumer<AnonymousClassCreator> builder) {
         ClassDesc ownerDesc = owner.type();
         int idx = ++anonClassCount;
@@ -693,7 +693,7 @@ public final class BlockCreatorImpl extends Item implements BlockCreator {
         return addItem(new InstanceOf(obj, type));
     }
 
-    public Expr new_(final ConstructorDesc ctor, final List<Expr> args) {
+    public Expr new_(final ConstructorDesc ctor, final List<? extends Expr> args) {
         checkActive();
         New new_ = new New(ctor.owner());
         Dup dup_ = new Dup(new_);
@@ -713,19 +713,19 @@ public final class BlockCreatorImpl extends Item implements BlockCreator {
         return new_;
     }
 
-    public Expr invokeStatic(final MethodDesc method, final List<Expr> args) {
+    public Expr invokeStatic(final MethodDesc method, final List<? extends Expr> args) {
         return addItem(new Invoke(Opcode.INVOKESTATIC, method, null, args));
     }
 
-    public Expr invokeVirtual(final MethodDesc method, final Expr instance, final List<Expr> args) {
+    public Expr invokeVirtual(final MethodDesc method, final Expr instance, final List<? extends Expr> args) {
         return addItem(new Invoke(Opcode.INVOKEVIRTUAL, method, instance, args));
     }
 
-    public Expr invokeSpecial(final MethodDesc method, final Expr instance, final List<Expr> args) {
+    public Expr invokeSpecial(final MethodDesc method, final Expr instance, final List<? extends Expr> args) {
         return addItem(new Invoke(Opcode.INVOKESPECIAL, method, instance, args));
     }
 
-    public Expr invokeSpecial(final ConstructorDesc ctor, final Expr instance, final List<Expr> args) {
+    public Expr invokeSpecial(final ConstructorDesc ctor, final Expr instance, final List<? extends Expr> args) {
         Invoke invoke = new Invoke(ctor, instance, args);
         addItem(invoke);
         if (instance instanceof ThisExpr) {
@@ -737,11 +737,11 @@ public final class BlockCreatorImpl extends Item implements BlockCreator {
         return invoke;
     }
 
-    public Expr invokeInterface(final MethodDesc method, final Expr instance, final List<Expr> args) {
+    public Expr invokeInterface(final MethodDesc method, final Expr instance, final List<? extends Expr> args) {
         return addItem(new Invoke(Opcode.INVOKEINTERFACE, method, instance, args));
     }
 
-    public Expr invokeDynamic(final DynamicCallSiteDesc callSiteDesc, final List<Expr> args) {
+    public Expr invokeDynamic(final DynamicCallSiteDesc callSiteDesc, final List<? extends Expr> args) {
         return addItem(new Item() {
             protected Node forEachDependency(Node node, final BiFunction<Item, Node, Node> op) {
                 node = node.prev();
@@ -1201,7 +1201,7 @@ public final class BlockCreatorImpl extends Item implements BlockCreator {
         return invokeStatic(MethodDesc.of(Class.class, "forName", Class.class, String.class), className);
     }
 
-    public Expr listOf(final List<Expr> items) {
+    public Expr listOf(final List<? extends Expr> items) {
         int size = items.size();
         if (size <= 10) {
             return invokeStatic(MethodDesc.of(List.class, "of", List.class, nCopies(size, Object.class)), items);
@@ -1210,7 +1210,7 @@ public final class BlockCreatorImpl extends Item implements BlockCreator {
         }
     }
 
-    public Expr setOf(final List<Expr> items) {
+    public Expr setOf(final List<? extends Expr> items) {
         int size = items.size();
         if (size <= 10) {
             return invokeStatic(MethodDesc.of(Set.class, "of", Set.class, nCopies(size, Object.class)), items);
@@ -1220,7 +1220,7 @@ public final class BlockCreatorImpl extends Item implements BlockCreator {
     }
 
     @Override
-    public Expr mapOf(List<Expr> items) {
+    public Expr mapOf(List<? extends Expr> items) {
         items = List.copyOf(items);
         int size = items.size();
         if (size % 2 != 0) {
@@ -1251,7 +1251,7 @@ public final class BlockCreatorImpl extends Item implements BlockCreator {
         });
     }
 
-    public void printf(final String format, final List<Expr> values) {
+    public void printf(final String format, final List<? extends Expr> values) {
         invokeVirtual(
                 MethodDesc.of(PrintStream.class, "printf", PrintStream.class, String.class, Object[].class),
                 Expr.staticField(FieldDesc.of(System.class, "out")),

--- a/src/main/java/io/quarkus/gizmo2/impl/BlockCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/BlockCreatorImpl.java
@@ -1260,13 +1260,9 @@ public final class BlockCreatorImpl extends Item implements BlockCreator {
     }
 
     public void assert_(final Consumer<BlockCreator> assertion, final String message) {
-        if_(logicalAnd(
-                Constant.ofInvoke(
-                        Constant.ofMethodHandle(InvokeKind.VIRTUAL,
-                                MethodDesc.of(Class.class, "desiredAssertionStatus", boolean.class))),
-                assertion), __ -> {
-                    throw_(AssertionError.class, message);
-                });
+        if_(logicalAnd(Constant.ofInvoke(Constant.ofMethodHandle(InvokeKind.VIRTUAL,
+                MethodDesc.of(Class.class, "desiredAssertionStatus", boolean.class))), assertion),
+                __ -> throw_(AssertionError.class, message));
     }
 
     protected Node forEachDependency(final Node node, final BiFunction<Item, Node, Node> op) {

--- a/src/main/java/io/quarkus/gizmo2/impl/ClassCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/ClassCreatorImpl.java
@@ -1,8 +1,9 @@
 package io.quarkus.gizmo2.impl;
 
+import static io.smallrye.common.constraint.Assert.checkNotNullParam;
+
 import java.lang.constant.ClassDesc;
 import java.lang.constant.MethodTypeDesc;
-import java.util.Objects;
 import java.util.function.Consumer;
 
 import io.github.dmlloyd.classfile.ClassBuilder;
@@ -48,8 +49,8 @@ public sealed class ClassCreatorImpl extends TypeCreatorImpl implements ClassCre
     }
 
     public FieldDesc field(final String name, final Consumer<InstanceFieldCreator> builder) {
-        Objects.requireNonNull(name, "name");
-        Objects.requireNonNull(builder, "builder");
+        checkNotNullParam("name", name);
+        checkNotNullParam("builder", builder);
         var fc = new InstanceFieldCreatorImpl(this, type(), name);
         fc.accept(builder);
         FieldDesc desc = fc.desc();
@@ -60,8 +61,8 @@ public sealed class ClassCreatorImpl extends TypeCreatorImpl implements ClassCre
     }
 
     public MethodDesc method(final String name, final Consumer<InstanceMethodCreator> builder) {
-        Objects.requireNonNull(name, "name");
-        Objects.requireNonNull(builder, "builder");
+        checkNotNullParam("name", name);
+        checkNotNullParam("builder", builder);
         var mc = new InstanceMethodCreatorImpl(this, name);
         mc.accept(builder);
         MethodDesc desc = mc.desc();
@@ -72,8 +73,8 @@ public sealed class ClassCreatorImpl extends TypeCreatorImpl implements ClassCre
     }
 
     public MethodDesc abstractMethod(final String name, final Consumer<AbstractMethodCreator> builder) {
-        Objects.requireNonNull(name, "name");
-        Objects.requireNonNull(builder, "builder");
+        checkNotNullParam("name", name);
+        checkNotNullParam("builder", builder);
         var mc = new AbstractMethodCreatorImpl(this, name);
         mc.accept(builder);
         MethodDesc desc = mc.desc();
@@ -84,8 +85,8 @@ public sealed class ClassCreatorImpl extends TypeCreatorImpl implements ClassCre
     }
 
     public MethodDesc nativeMethod(final String name, final Consumer<AbstractMethodCreator> builder) {
-        Objects.requireNonNull(name, "name");
-        Objects.requireNonNull(builder, "builder");
+        checkNotNullParam("name", name);
+        checkNotNullParam("builder", builder);
         var mc = new NativeMethodCreatorImpl(this, name);
         mc.accept(builder);
         MethodDesc desc = mc.desc();
@@ -96,8 +97,8 @@ public sealed class ClassCreatorImpl extends TypeCreatorImpl implements ClassCre
     }
 
     public MethodDesc staticNativeMethod(final String name, final Consumer<AbstractMethodCreator> builder) {
-        Objects.requireNonNull(name, "name");
-        Objects.requireNonNull(builder, "builder");
+        checkNotNullParam("name", name);
+        checkNotNullParam("builder", builder);
         var mc = new StaticNativeMethodCreatorImpl(this, name);
         mc.accept(builder);
         MethodDesc desc = mc.desc();
@@ -108,7 +109,7 @@ public sealed class ClassCreatorImpl extends TypeCreatorImpl implements ClassCre
     }
 
     public ConstructorDesc constructor(final Consumer<ConstructorCreator> builder) {
-        Objects.requireNonNull(builder, "builder");
+        checkNotNullParam("builder", builder);
         var mc = new ConstructorCreatorImpl(this, preInits, postInits);
         mc.accept(builder);
         ConstructorDesc desc = mc.desc();

--- a/src/main/java/io/quarkus/gizmo2/impl/ExecutableCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/ExecutableCreatorImpl.java
@@ -1,5 +1,6 @@
 package io.quarkus.gizmo2.impl;
 
+import static io.smallrye.common.constraint.Assert.checkNotNullParam;
 import static java.lang.constant.ConstantDescs.CD_void;
 
 import java.lang.constant.ClassDesc;
@@ -8,7 +9,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.BitSet;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
@@ -29,7 +29,6 @@ import io.quarkus.gizmo2.ParamVar;
 import io.quarkus.gizmo2.creator.BlockCreator;
 import io.quarkus.gizmo2.creator.ExecutableCreator;
 import io.quarkus.gizmo2.creator.ParamCreator;
-import io.smallrye.common.constraint.Assert;
 
 public sealed abstract class ExecutableCreatorImpl extends AnnotatableCreatorImpl implements ExecutableCreator
         permits ConstructorCreatorImpl, MethodCreatorImpl {
@@ -144,7 +143,7 @@ public sealed abstract class ExecutableCreatorImpl extends AnnotatableCreatorImp
     }
 
     void returning(final ClassDesc type) {
-        Objects.requireNonNull(type, "type");
+        checkNotNullParam("type", type);
         if (state >= ST_BODY) {
             throw new IllegalStateException("Return type may no longer be changed");
         }
@@ -285,7 +284,7 @@ public sealed abstract class ExecutableCreatorImpl extends AnnotatableCreatorImp
     }
 
     public void throws_(final ClassDesc throwableType) {
-        Assert.checkNotNullParam("throwableType", throwableType);
+        checkNotNullParam("throwableType", throwableType);
         if (state >= ST_BODY) {
             throw new IllegalStateException("Exception throws may no longer be established");
         }

--- a/src/main/java/io/quarkus/gizmo2/impl/FieldCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/FieldCreatorImpl.java
@@ -1,11 +1,11 @@
 package io.quarkus.gizmo2.impl;
 
+import static io.smallrye.common.constraint.Assert.checkNotNullParam;
 import static java.lang.constant.ConstantDescs.CD_int;
 import static java.lang.constant.ConstantDescs.CD_void;
 
 import java.lang.annotation.ElementType;
 import java.lang.constant.ClassDesc;
-import java.util.Objects;
 import java.util.Set;
 
 import io.github.dmlloyd.classfile.Signature;
@@ -47,13 +47,13 @@ public abstract sealed class FieldCreatorImpl extends AnnotatableCreatorImpl imp
     }
 
     public void withTypeSignature(final Signature type) {
-        Objects.requireNonNull(type, "type");
+        checkNotNullParam("type", type);
         withType(Util.erased(type));
         genericType = type;
     }
 
     public void withType(final ClassDesc type) {
-        this.type = Objects.requireNonNull(type, "type");
+        this.type = checkNotNullParam("type", type);
         if (type.equals(CD_void)) {
             throw new IllegalArgumentException("Fields cannot have void type");
         }

--- a/src/main/java/io/quarkus/gizmo2/impl/InterfaceCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/InterfaceCreatorImpl.java
@@ -1,8 +1,9 @@
 package io.quarkus.gizmo2.impl;
 
+import static io.smallrye.common.constraint.Assert.checkNotNullParam;
+
 import java.lang.constant.ClassDesc;
 import java.lang.constant.MethodTypeDesc;
-import java.util.Objects;
 import java.util.function.Consumer;
 
 import io.github.dmlloyd.classfile.ClassBuilder;
@@ -35,8 +36,8 @@ public final class InterfaceCreatorImpl extends TypeCreatorImpl implements Inter
     }
 
     public MethodDesc defaultMethod(final String name, final Consumer<InstanceMethodCreator> builder) {
-        Objects.requireNonNull(name, "name");
-        Objects.requireNonNull(builder, "builder");
+        checkNotNullParam("name", name);
+        checkNotNullParam("builder", builder);
         var mc = new DefaultMethodCreatorImpl(this, name);
         mc.accept(builder);
         MethodDesc desc = mc.desc();
@@ -47,8 +48,8 @@ public final class InterfaceCreatorImpl extends TypeCreatorImpl implements Inter
     }
 
     public MethodDesc privateMethod(final String name, final Consumer<InstanceMethodCreator> builder) {
-        Objects.requireNonNull(name, "name");
-        Objects.requireNonNull(builder, "builder");
+        checkNotNullParam("name", name);
+        checkNotNullParam("builder", builder);
         var mc = new PrivateInterfaceMethodCreatorImpl(this, name);
         mc.accept(builder);
         MethodDesc desc = mc.desc();
@@ -59,8 +60,8 @@ public final class InterfaceCreatorImpl extends TypeCreatorImpl implements Inter
     }
 
     public MethodDesc method(final String name, final Consumer<AbstractMethodCreator> builder) {
-        Objects.requireNonNull(name, "name");
-        Objects.requireNonNull(builder, "builder");
+        checkNotNullParam("name", name);
+        checkNotNullParam("builder", builder);
         var mc = new InterfaceMethodCreatorImpl(this, name);
         mc.accept(builder);
         MethodDesc desc = mc.desc();

--- a/src/main/java/io/quarkus/gizmo2/impl/Invoke.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/Invoke.java
@@ -22,12 +22,12 @@ final class Invoke extends Item {
     private final Opcode opcode;
     private final boolean isInterface;
 
-    Invoke(final Opcode opcode, final MethodDesc desc, Expr instance, List<Expr> args) {
+    Invoke(final Opcode opcode, final MethodDesc desc, Expr instance, List<? extends Expr> args) {
         this(desc.owner(), desc.name(), desc.type(), opcode, desc instanceof InterfaceMethodDesc, (Item) instance,
                 Util.reinterpretCast(args));
     }
 
-    Invoke(final ConstructorDesc desc, Expr instance, List<Expr> args) {
+    Invoke(final ConstructorDesc desc, Expr instance, List<? extends Expr> args) {
         this(desc.owner(), "<init>", desc.type(), Opcode.INVOKESPECIAL, false, (Item) instance, Util.reinterpretCast(args));
     }
 

--- a/src/main/java/io/quarkus/gizmo2/impl/Item.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/Item.java
@@ -18,7 +18,7 @@ import io.quarkus.gizmo2.desc.FieldDesc;
 import io.quarkus.gizmo2.impl.constant.ConstantImpl;
 
 public abstract non-sealed class Item implements Expr {
-    private final String creationSite = Util.trackCreationSite();
+    private final String creationSite = Util.trackCaller();
 
     public String itemName() {
         return getClass().getSimpleName();
@@ -176,8 +176,7 @@ public abstract non-sealed class Item implements Expr {
     private IllegalStateException missing() {
         if (creationSite == null) {
             return new IllegalStateException("Item " + this + " is not at its expected location (declare a LocalVar"
-                    + " to store values which are used away from their creation site)\nTo track Item creation sites"
-                    + " and get an improved exception message, add the system property `gizmo.trackCreations`");
+                    + " to store values which are used away from their creation site)" + Util.trackingMessage);
         } else {
             return new IllegalStateException("Item " + this + " created at " + creationSite + " is not at its expected"
                     + " location (declare a LocalVar to store values which are used away from their creation site)");

--- a/src/main/java/io/quarkus/gizmo2/impl/Item.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/Item.java
@@ -1,12 +1,12 @@
 package io.quarkus.gizmo2.impl;
 
+import static io.smallrye.common.constraint.Assert.checkNotNullParam;
 import static java.lang.constant.ConstantDescs.CD_VarHandle;
 import static java.lang.constant.ConstantDescs.CD_int;
 
 import java.lang.constant.ClassDesc;
 import java.lang.constant.ConstantDescs;
 import java.lang.constant.MethodTypeDesc;
-import java.util.Objects;
 import java.util.function.BiFunction;
 
 import io.github.dmlloyd.classfile.CodeBuilder;
@@ -238,7 +238,8 @@ public abstract non-sealed class Item implements Expr {
     }
 
     public InstanceFieldVar field(final FieldDesc desc) {
-        return new FieldDeref(Objects.requireNonNull(desc, "desc"));
+        checkNotNullParam("desc", desc);
+        return new FieldDeref(desc);
     }
 
     Item asBound() {

--- a/src/main/java/io/quarkus/gizmo2/impl/Node.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/Node.java
@@ -1,6 +1,7 @@
 package io.quarkus.gizmo2.impl;
 
-import java.util.Objects;
+import static io.smallrye.common.constraint.Assert.checkNotNullParam;
+
 import java.util.function.BiFunction;
 
 /**
@@ -25,8 +26,10 @@ public final class Node {
      * @return the head node in the new list (not {@code null})
      */
     public static Node newList(Item head, Item tail) {
-        Node a = new Node(null, null, Objects.requireNonNull(head, "head"));
-        Node b = new Node(null, null, Objects.requireNonNull(tail, "tail"));
+        checkNotNullParam("head", head);
+        checkNotNullParam("tail", tail);
+        Node a = new Node(null, null, head);
+        Node b = new Node(null, null, tail);
         a.next = b;
         b.prev = a;
         return a;

--- a/src/main/java/io/quarkus/gizmo2/impl/ParamCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/ParamCreatorImpl.java
@@ -1,10 +1,11 @@
 package io.quarkus.gizmo2.impl;
 
+import static io.smallrye.common.constraint.Assert.checkNotNullParam;
+
 import java.lang.annotation.ElementType;
 import java.lang.constant.ClassDesc;
 import java.lang.constant.ConstantDescs;
 import java.util.List;
-import java.util.Objects;
 import java.util.function.Consumer;
 
 import io.github.dmlloyd.classfile.extras.reflect.AccessFlag;
@@ -41,7 +42,7 @@ public final class ParamCreatorImpl extends AnnotatableCreatorImpl implements Pa
     }
 
     public void withType(final ClassDesc type) {
-        Objects.requireNonNull(type, "type");
+        checkNotNullParam("type", type);
         if (type.equals(ConstantDescs.CD_void)) {
             throw new IllegalArgumentException("Bad type for parameter: " + type);
         }

--- a/src/main/java/io/quarkus/gizmo2/impl/TypeCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/TypeCreatorImpl.java
@@ -17,7 +17,6 @@ import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 import java.util.function.Consumer;
 
@@ -102,7 +101,7 @@ public abstract sealed class TypeCreatorImpl extends AnnotatableCreatorImpl impl
     }
 
     public void withTypeParam(final Signature.TypeParam param) {
-        Objects.requireNonNull(param, "param");
+        checkNotNullParam("param", param);
         if (typeParams.isEmpty()) {
             typeParams = new ArrayList<>(4);
         }
@@ -202,7 +201,7 @@ public abstract sealed class TypeCreatorImpl extends AnnotatableCreatorImpl impl
     }
 
     public MethodDesc staticMethod(final String name, final Consumer<StaticMethodCreator> builder) {
-        Objects.requireNonNull(builder, "builder");
+        checkNotNullParam("builder", builder);
         MethodDesc desc;
         boolean isInterface = (flags & AccessFlag.INTERFACE.mask()) == AccessFlag.INTERFACE.mask();
         if (isInterface) {
@@ -221,8 +220,8 @@ public abstract sealed class TypeCreatorImpl extends AnnotatableCreatorImpl impl
     }
 
     public StaticFieldVar staticField(final String name, final Consumer<StaticFieldCreator> builder) {
-        Objects.requireNonNull(name, "name");
-        Objects.requireNonNull(builder, "builder");
+        checkNotNullParam("name", name);
+        checkNotNullParam("builder", builder);
         boolean isInterface = (flags & AccessFlag.INTERFACE.mask()) == AccessFlag.INTERFACE.mask();
         var fc = new StaticFieldCreatorImpl(this, type(), name, isInterface);
         fc.accept(builder);

--- a/src/main/java/io/quarkus/gizmo2/impl/Util.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/Util.java
@@ -29,7 +29,9 @@ public final class Util {
     public static final ClassDesc[] NO_DESCS = new ClassDesc[0];
 
     // set system property means enabled, even with an empty value, except if the value is `false`
-    private static final boolean trackCreations = !"false".equals(System.getProperty("gizmo.trackCreations", "false"));
+    private static final boolean trackingEnabled = !"false".equals(System.getProperty("gizmo.enableTracking", "false"));
+
+    public static final String trackingMessage = "\nTo track callers and get an improved exception message, add the system property `gizmo.enableTracking`";
 
     private Util() {
     }
@@ -112,13 +114,13 @@ public final class Util {
         return b.toString();
     }
 
-    public static String trackCreationSite() {
-        return trackCreations ? callerOutsideGizmo() : null;
+    public static String trackCaller() {
+        return trackingEnabled ? callerOutsideGizmo() : null;
     }
 
     private static String callerOutsideGizmo() {
         return SW.walk(stream -> stream
-                .filter(it -> !it.getClassName().startsWith("io.quarkus.gizmo2"))
+                .filter(it -> !it.getClassName().startsWith("io.quarkus.gizmo2") || it.getClassName().endsWith("Test"))
                 .findFirst()
                 .map(it -> it.getClassName() + "." + it.getMethodName() + "():" + it.getLineNumber())
                 .orElseThrow(IllegalStateException::new));

--- a/src/main/java/io/quarkus/gizmo2/impl/constant/ConstantImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/constant/ConstantImpl.java
@@ -1,5 +1,7 @@
 package io.quarkus.gizmo2.impl.constant;
 
+import static io.smallrye.common.constraint.Assert.checkNotNullParam;
+
 import java.lang.constant.ClassDesc;
 import java.lang.constant.Constable;
 import java.lang.constant.ConstantDesc;
@@ -9,7 +11,6 @@ import java.lang.constant.MethodHandleDesc;
 import java.lang.constant.MethodTypeDesc;
 import java.lang.invoke.VarHandle;
 import java.util.List;
-import java.util.Objects;
 
 import io.github.dmlloyd.classfile.CodeBuilder;
 import io.quarkus.gizmo2.Constant;
@@ -34,7 +35,7 @@ public abstract non-sealed class ConstantImpl extends Item implements Constant {
     }
 
     public static ConstantImpl of(Constable constable) {
-        Objects.requireNonNull(constable, "constable");
+        checkNotNullParam("constable", constable);
         if (constable instanceof ConstantImpl con) {
             return con;
         } else if (constable instanceof Boolean val) {
@@ -51,7 +52,7 @@ public abstract non-sealed class ConstantImpl extends Item implements Constant {
     }
 
     public static ConstantImpl of(ConstantDesc constantDesc) {
-        Objects.requireNonNull(constantDesc, "constantDesc");
+        checkNotNullParam("constantDesc", constantDesc);
         if (constantDesc instanceof Integer val) {
             return of(val);
         } else if (constantDesc instanceof Long val) {


### PR DESCRIPTION
- track callers on more places: In addition to tracking where `Item`s are created, we also track where blocks become inactive (either by being finished, or by creating nested blocks).
- replace `Objects.requireNonNull()` in parameter checking with `Assert.checkNotNullParam()`
- add `FieldDesc.of()` overload that takes `ClassDesc` owner and `Class` type
- replace `List<Expr>` by `List<? extends Expr>` in `BlockCreator` methods
- tiny javadoc and code improvements