### PR TITLE
Introduce list/set/map constant support

### DIFF
--- a/src/main/java/io/quarkus/gizmo2/creator/BlockCreator.java
+++ b/src/main/java/io/quarkus/gizmo2/creator/BlockCreator.java
@@ -878,6 +878,14 @@ public sealed interface BlockCreator extends SimpleTyped permits BlockCreatorImp
 
     // relational ops
 
+    default Expr isNull(Expr input) {
+        return eq(input, Const.ofNull(input.type()));
+    }
+
+    default Expr isNotNull(Expr input) {
+        return ne(input, Const.ofNull(input.type()));
+    }
+
     /**
      * The equality operator.
      * The arguments must be of the same {@linkplain TypeKind type kind}.
@@ -2866,6 +2874,14 @@ public sealed interface BlockCreator extends SimpleTyped permits BlockCreatorImp
     void autoClose(Expr resource, BiConsumer<BlockCreator, ? super LocalVar> body);
 
     /**
+     * Open a resource and run the given body with the resource, automatically closing it at the end.
+     *
+     * @param resource the resource to automatically close (must not be {@code null})
+     * @param body the creator for the body of the resource operation (must not be {@code null})
+     */
+    void autoClose(LocalVar resource, Consumer<BlockCreator> body);
+
+    /**
      * Create a {@code synchronized} block. When the given {@code body} is executed,
      * the monitor of given {@code monitor} is locked.
      *
@@ -3366,6 +3382,15 @@ public sealed interface BlockCreator extends SimpleTyped permits BlockCreatorImp
     }
 
     /**
+     * Generate a call to {@link Map#entry(Object, Object)}.
+     *
+     * @param key the key for the new entry (must not be {@code null})
+     * @param value the value for the new entry (must not be {@code null})
+     * @return the new map entry (not {@code null})
+     */
+    Expr mapEntry(Expr key, Expr value);
+
+    /**
      * Generate a call to {@link Optional#of(Object)}.
      *
      * @param value the expression to pass in to the call (must not be {@code null})
@@ -3437,5 +3462,4 @@ public sealed interface BlockCreator extends SimpleTyped permits BlockCreatorImp
      * @param message the message to print if the assertion fails (must not be {@code null})
      */
     void assert_(Consumer<BlockCreator> assertion, String message);
-
 }

--- a/src/main/java/io/quarkus/gizmo2/creator/TypeCreator.java
+++ b/src/main/java/io/quarkus/gizmo2/creator/TypeCreator.java
@@ -4,6 +4,8 @@ import java.lang.constant.ClassDesc;
 import java.lang.constant.MethodTypeDesc;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.function.Consumer;
 
 import io.github.dmlloyd.classfile.Signature;
@@ -210,6 +212,42 @@ public sealed interface TypeCreator extends Annotatable, SimpleTyped permits Cla
             sfc.withInitial(value);
         });
     }
+
+    /**
+     * Create a private constant which loads the given list of strings from a generated resource file.
+     * The constant may not be used outside of this class.
+     * Any number of strings may be stored in the constant;
+     * however, for smaller lists, {@link Const#of(List)} is preferred.
+     *
+     * @param name the constant name (must not be {@code null})
+     * @param items the list of strings for the constant (must not be {@code null})
+     * @return the constant (not {@code null})
+     */
+    Const stringListResourceConstant(String name, List<String> items);
+
+    /**
+     * Create a private constant which loads the given set of strings from a generated resource file.
+     * The constant may not be used outside of this class.
+     * Any number of strings may be stored in the constant;
+     * however, for smaller sets, {@link Const#of(Set)} is preferred.
+     *
+     * @param name the constant name (must not be {@code null})
+     * @param items the set of strings for the constant (must not be {@code null})
+     * @return the constant (not {@code null})
+     */
+    Const stringSetResourceConstant(String name, Set<String> items);
+
+    /**
+     * Create a private constant which loads the given map of strings from a generated resource file.
+     * The constant may not be used outside of this class.
+     * Any number of strings may be stored in the constant;
+     * however, for smaller maps, {@link Const#of(Map)} is preferred.
+     *
+     * @param name the constant name (must not be {@code null})
+     * @param items the map of strings for the constant (must not be {@code null})
+     * @return the constant (not {@code null})
+     */
+    Const stringMapResourceConstant(String name, Map<String, String> items);
 
     /**
      * {@return the {@code this} expression}

--- a/src/main/java/io/quarkus/gizmo2/creator/ops/StringBuilderOps.java
+++ b/src/main/java/io/quarkus/gizmo2/creator/ops/StringBuilderOps.java
@@ -56,7 +56,7 @@ public final class StringBuilderOps extends ObjectOps implements ComparableOps {
      * @return this instance
      */
     public StringBuilderOps append(final Expr expr) {
-        switch (expr.type().descriptorString()) {
+        return new StringBuilderOps(bc, switch (expr.type().descriptorString()) {
             case "Z" -> invokeInstance(StringBuilder.class, "append", boolean.class, expr);
             case "B", "S", "I" -> invokeInstance(StringBuilder.class, "append", int.class, expr);
             case "J" -> invokeInstance(StringBuilder.class, "append", long.class, expr);
@@ -67,8 +67,7 @@ public final class StringBuilderOps extends ObjectOps implements ComparableOps {
             case "Ljava/lang/String;" -> invokeInstance(StringBuilder.class, "append", String.class, expr);
             case "Ljava/lang/CharSequence;" -> invokeInstance(StringBuilder.class, "append", CharSequence.class, expr);
             default -> invokeInstance(StringBuilder.class, "append", Object.class, expr);
-        }
-        return this;
+        });
     }
 
     /**
@@ -89,6 +88,44 @@ public final class StringBuilderOps extends ObjectOps implements ComparableOps {
      */
     public StringBuilderOps append(final String constant) {
         return append(Const.of(constant));
+    }
+
+    /**
+     * Appends the given code point to this {@code StringBuilder}.
+     *
+     * @param codePoint the value to append (must not be {@code null})
+     * @return a valid wrapper for this instance (not {@code null})
+     */
+    public StringBuilderOps appendCodePoint(final Expr codePoint) {
+        return new StringBuilderOps(bc, invokeInstance(StringBuilder.class, "appendCodePoint", int.class, codePoint));
+    }
+
+    /**
+     * Appends the given code point to this {@code StringBuilder}.
+     *
+     * @param codePoint the value to append
+     * @return a valid wrapper for this instance (not {@code null})
+     */
+    public StringBuilderOps appendCodePoint(final int codePoint) {
+        return appendCodePoint(Const.of(codePoint));
+    }
+
+    /**
+     * Set the length of this {@code StringBuilder}.
+     *
+     * @param length the length expression (must not be {@code null})
+     */
+    public void setLength(Expr length) {
+        invokeInstance(void.class, "setLength", int.class, length);
+    }
+
+    /**
+     * Set the length of this {@code StringBuilder}.
+     *
+     * @param length the constant length
+     */
+    public void setLength(int length) {
+        setLength(Const.of(length));
     }
 
     @Override

--- a/src/main/java/io/quarkus/gizmo2/impl/ClassSwitchCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/ClassSwitchCreatorImpl.java
@@ -34,8 +34,7 @@ public final class ClassSwitchCreatorImpl extends HashSwitchCreatorImpl<ClassCon
         } else if (desc.isPrimitive()) {
             return desc.displayName().hashCode();
         } else {
-            String ds = desc.descriptorString();
-            return ds.substring(1, ds.length() - 1).replace('/', '.').hashCode();
+            return Util.binaryName(desc).hashCode();
         }
     }
 

--- a/src/main/java/io/quarkus/gizmo2/impl/Rel.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/Rel.java
@@ -58,7 +58,7 @@ final class Rel extends Item {
     public void writeCode(final CodeBuilder cb, final BlockCreatorImpl block) {
         Label true_ = cb.newLabel();
         Label end = cb.newLabel();
-        switch (typeKind().asLoadable()) {
+        switch (a.typeKind().asLoadable()) {
             case INT -> kind.if_icmp.accept(cb, true_);
             case REFERENCE -> kind.if_acmp.accept(cb, true_);
             default -> throw impossibleSwitchCase(typeKind().asLoadable());

--- a/src/main/java/io/quarkus/gizmo2/impl/RelZero.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/RelZero.java
@@ -47,7 +47,7 @@ final class RelZero extends Item {
     public void writeCode(final CodeBuilder cb, final BlockCreatorImpl block) {
         Label true_ = cb.newLabel();
         Label end = cb.newLabel();
-        switch (typeKind().asLoadable()) {
+        switch (a.typeKind().asLoadable()) {
             case INT -> kind.if_.accept(cb, true_);
             case REFERENCE -> kind.if_acmpnull.accept(cb, true_);
             case LONG -> {

--- a/src/main/java/io/quarkus/gizmo2/impl/Util.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/Util.java
@@ -215,4 +215,17 @@ public final class Util {
     public static MethodDesc findSam(final Class<?> type) {
         return samCache.get(type);
     }
+
+    public static String internalName(final ClassDesc desc) {
+        if (desc.isClassOrInterface()) {
+            String ds = desc.descriptorString();
+            return ds.substring(1, ds.length() - 1);
+        } else {
+            return desc.descriptorString();
+        }
+    }
+
+    public static String binaryName(final ClassDesc desc) {
+        return internalName(desc).replace('/', '.');
+    }
 }

--- a/src/main/java/io/quarkus/gizmo2/impl/constant/ConstImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/constant/ConstImpl.java
@@ -296,10 +296,8 @@ public abstract non-sealed class ConstImpl extends Item implements Const {
         };
     }
 
-    @SuppressWarnings({ "unchecked", "rawtypes" })
     public static InvokeConst ofInvoke(Const handle, List<Const> args) {
-        // we could theoretically use a stream to cast the list properly, but instead let's cheat and save some CPU
-        return new InvokeConst((MethodHandleConst) handle, (List<ConstImpl>) (List) args);
+        return new InvokeConst((MethodHandleConst) handle, Util.reinterpretCast(args));
     }
 
     public static MethodHandleConst of(MethodHandleDesc desc) {

--- a/src/main/java/io/quarkus/gizmo2/impl/constant/InvokeConst.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/constant/InvokeConst.java
@@ -6,6 +6,7 @@ import java.lang.constant.DynamicConstantDesc;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Stream;
 
 public final class InvokeConst extends ConstImpl {
     private final MethodHandleConst handleConstant;
@@ -32,7 +33,10 @@ public final class InvokeConst extends ConstImpl {
     public ConstantDesc desc() {
         return DynamicConstantDesc.of(
                 ConstantDescs.BSM_INVOKE,
-                args.stream().map(ConstImpl::describeConstable).map(Optional::orElseThrow).toArray(ConstantDesc[]::new));
+                Stream.concat(
+                        Stream.of(handleConstant.desc()),
+                        args.stream().map(ConstImpl::describeConstable).map(Optional::orElseThrow))
+                        .toArray(ConstantDesc[]::new));
     }
 
     public Optional<? extends ConstantDesc> describeConstable() {

--- a/src/test/java/io/quarkus/gizmo2/TestCollectionsConstants.java
+++ b/src/test/java/io/quarkus/gizmo2/TestCollectionsConstants.java
@@ -1,0 +1,362 @@
+package io.quarkus.gizmo2;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.lang.constant.ClassDesc;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collector;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+
+public final class TestCollectionsConstants {
+    @Test
+    public void testConstantStringList() {
+        TestClassMaker tcm = new TestClassMaker();
+        Gizmo g = Gizmo.create(tcm);
+        ClassDesc desc = ClassDesc.of("io.quarkus.gizmo2.TestSmallList");
+        List<Object> emptyList = List.of();
+        List<String> threeList = List.of("Foo", "Bar", "Baz");
+        List<String> elevenList = List.of("Foo", "Bar", "Baz", "Zap", "Quux", "Thud", "Gorp", "Fom", "Zop", "Zork", "Gork");
+        g.class_(desc, zc -> {
+            zc.sourceFile(file());
+            // case: empty
+            zc.staticMethod("test0", mc -> {
+                mc.returning(List.class);
+                mc.body(b0 -> {
+                    b0.line(nextLine());
+                    b0.return_(Const.of(emptyList));
+                });
+            });
+            // case: small number of args
+            zc.staticMethod("test1", mc -> {
+                mc.returning(List.class);
+                mc.body(b0 -> {
+                    b0.line(nextLine());
+                    b0.return_(Const.of(threeList));
+                });
+            });
+            // case: big enough to force varargs
+            zc.staticMethod("test2", mc -> {
+                mc.returning(List.class);
+                mc.body(b0 -> {
+                    b0.line(nextLine());
+                    b0.return_(Const.of(elevenList));
+                });
+            });
+        });
+        assertEquals(emptyList, tcm.staticMethod("test0", StringListTest.class).get());
+        assertEquals(threeList, tcm.staticMethod("test1", StringListTest.class).get());
+        assertEquals(elevenList, tcm.staticMethod("test2", StringListTest.class).get());
+    }
+
+    @Test
+    public void testConstantClassList() {
+        TestClassMaker tcm = new TestClassMaker();
+        Gizmo g = Gizmo.create(tcm);
+        ClassDesc desc = ClassDesc.of("io.quarkus.gizmo2.TestSmallList");
+        List<Class<?>> threeList = List.of(Object.class, String.class, Class.class);
+        List<Class<?>> elevenList = List.of(Object.class, String.class, Class.class, Integer.class,
+                Byte.class, Float.class, List.class, Throwable.class, Long.class, Double.class, Void.class);
+        g.class_(desc, zc -> {
+            zc.sourceFile(file());
+            // case: small number of args
+            zc.staticMethod("test0", mc -> {
+                mc.returning(List.class);
+                mc.body(b0 -> {
+                    b0.line(nextLine());
+                    b0.return_(Const.of(threeList));
+                });
+            });
+            // case: big enough to force varargs
+            zc.staticMethod("test1", mc -> {
+                mc.returning(List.class);
+                mc.body(b0 -> {
+                    b0.line(nextLine());
+                    b0.return_(Const.of(elevenList));
+                });
+            });
+        });
+        assertEquals(threeList, tcm.staticMethod("test0", ClassListTest.class).get());
+        assertEquals(elevenList, tcm.staticMethod("test1", ClassListTest.class).get());
+    }
+
+    @Test
+    public void testConstantStringSet() {
+        TestClassMaker tcm = new TestClassMaker();
+        Gizmo g = Gizmo.create(tcm);
+        ClassDesc desc = ClassDesc.of("io.quarkus.gizmo2.TestSmallSet");
+        Set<Object> emptySet = Set.of();
+        Set<String> threeSet = Set.of("Foo", "Bar", "Baz");
+        Set<String> elevenSet = Set.of("Foo", "Bar", "Baz", "Zap", "Quux", "Thud", "Gorp", "Fom", "Zop", "Zork", "Gork");
+        g.class_(desc, zc -> {
+            zc.sourceFile(file());
+            // case: empty
+            zc.staticMethod("test0", mc -> {
+                mc.returning(Set.class);
+                mc.body(b0 -> {
+                    b0.line(nextLine());
+                    b0.return_(Const.of(emptySet));
+                });
+            });
+            // case: small number of args
+            zc.staticMethod("test1", mc -> {
+                mc.returning(Set.class);
+                mc.body(b0 -> {
+                    b0.line(nextLine());
+                    b0.return_(Const.of(threeSet));
+                });
+            });
+            // case: big enough to force varargs
+            zc.staticMethod("test2", mc -> {
+                mc.returning(Set.class);
+                mc.body(b0 -> {
+                    b0.line(nextLine());
+                    b0.return_(Const.of(elevenSet));
+                });
+            });
+        });
+        assertEquals(emptySet, tcm.staticMethod("test0", StringSetTest.class).get());
+        assertEquals(threeSet, tcm.staticMethod("test1", StringSetTest.class).get());
+        assertEquals(elevenSet, tcm.staticMethod("test2", StringSetTest.class).get());
+    }
+
+    @Test
+    public void testConstantClassSet() {
+        TestClassMaker tcm = new TestClassMaker();
+        Gizmo g = Gizmo.create(tcm);
+        ClassDesc desc = ClassDesc.of("io.quarkus.gizmo2.TestSmallSet");
+        Set<Class<?>> threeSet = Set.of(Object.class, String.class, Class.class);
+        Set<Class<?>> elevenSet = Set.of(Object.class, String.class, Class.class, Integer.class,
+                Byte.class, Float.class, Set.class, Throwable.class, Long.class, Double.class, Void.class);
+        g.class_(desc, zc -> {
+            zc.sourceFile(file());
+            // case: small number of args
+            zc.staticMethod("test0", mc -> {
+                mc.returning(Set.class);
+                mc.body(b0 -> {
+                    b0.line(nextLine());
+                    b0.return_(Const.of(threeSet));
+                });
+            });
+            // case: big enough to force varargs
+            zc.staticMethod("test1", mc -> {
+                mc.returning(Set.class);
+                mc.body(b0 -> {
+                    b0.line(nextLine());
+                    b0.return_(Const.of(elevenSet));
+                });
+            });
+        });
+        assertEquals(threeSet, tcm.staticMethod("test0", ClassSetTest.class).get());
+        assertEquals(elevenSet, tcm.staticMethod("test1", ClassSetTest.class).get());
+    }
+
+    @Test
+    public void testConstantStringMap() {
+        TestClassMaker tcm = new TestClassMaker();
+        Gizmo g = Gizmo.create(tcm);
+        ClassDesc desc = ClassDesc.of("io.quarkus.gizmo2.TestSmallMap");
+        Map<String, String> emptyMap = Map.of();
+        Collector<String, ?, Map<String, String>> collector = Collectors.toMap(Function.identity(), Function.identity());
+        Map<String, String> threeMap = Stream.of("Foo", "Bar", "Baz").collect(collector);
+        Map<String, String> elevenMap = Stream
+                .of("Foo", "Bar", "Baz", "Zap", "Quux", "Thud", "Gorp", "Fom", "Zop", "Zork", "Gork").collect(collector);
+        g.class_(desc, zc -> {
+            zc.sourceFile(file());
+            // case: empty
+            zc.staticMethod("test0", mc -> {
+                mc.returning(Map.class);
+                mc.body(b0 -> {
+                    b0.line(nextLine());
+                    b0.return_(Const.of(emptyMap));
+                });
+            });
+            // case: small number of args
+            zc.staticMethod("test1", mc -> {
+                mc.returning(Map.class);
+                mc.body(b0 -> {
+                    b0.line(nextLine());
+                    b0.return_(Const.of(threeMap));
+                });
+            });
+            // case: big enough to force varargs
+            zc.staticMethod("test2", mc -> {
+                mc.returning(Map.class);
+                mc.body(b0 -> {
+                    b0.line(nextLine());
+                    b0.return_(Const.of(elevenMap));
+                });
+            });
+        });
+        assertEquals(emptyMap, tcm.staticMethod("test0", StringMapTest.class).get());
+        assertEquals(threeMap, tcm.staticMethod("test1", StringMapTest.class).get());
+        assertEquals(elevenMap, tcm.staticMethod("test2", StringMapTest.class).get());
+    }
+
+    @Test
+    public void testConstantClassMap() {
+        TestClassMaker tcm = new TestClassMaker();
+        Gizmo g = Gizmo.create(tcm);
+        ClassDesc desc = ClassDesc.of("io.quarkus.gizmo2.TestSmallMap");
+        Collector<Class<?>, ?, Map<String, Class<?>>> collector = Collectors.toMap(Class::getName, Function.identity());
+        Map<String, Class<?>> threeMap = Stream.of(Object.class, String.class, Class.class).collect(collector);
+        Map<String, Class<?>> elevenMap = Stream.of(Object.class, String.class, Class.class, Integer.class,
+                Byte.class, Float.class, Map.class, Throwable.class, Long.class, Double.class, Void.class).collect(collector);
+        g.class_(desc, zc -> {
+            zc.sourceFile(file());
+            // case: small number of args
+            zc.staticMethod("test0", mc -> {
+                mc.returning(Map.class);
+                mc.body(b0 -> {
+                    b0.line(nextLine());
+                    b0.return_(Const.of(threeMap));
+                });
+            });
+            // case: big enough to force varargs
+            zc.staticMethod("test1", mc -> {
+                mc.returning(Map.class);
+                mc.body(b0 -> {
+                    b0.line(nextLine());
+                    b0.return_(Const.of(elevenMap));
+                });
+            });
+        });
+        assertEquals(threeMap, tcm.staticMethod("test0", ClassMapTest.class).get());
+        assertEquals(elevenMap, tcm.staticMethod("test1", ClassMapTest.class).get());
+    }
+
+    @SuppressWarnings("SpellCheckingInspection")
+    @Test
+    public void testResourceStringList() {
+        TestClassMaker tcm = new TestClassMaker();
+        Gizmo g = Gizmo.create(tcm);
+        ClassDesc desc = ClassDesc.of("io.quarkus.gizmo2.TestSmallList");
+        List<String> big1 = List.of(
+                "Lorem ipsum dolor sit amet,",
+                "consectetur adipiscing elit,",
+                "sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
+                "Ut enim ad minim veniam,",
+                "quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.",
+                "Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.",
+                "Excepteur sint occaecat cupidatat non proident,",
+                "sunt in culpa qui officia deserunt mollit anim id est laborum.",
+                "Lorem ipsum dolor sit amet,",
+                "consectetur adipiscing elit,",
+                "sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
+                "Ut enim ad minim veniam,",
+                "quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.",
+                "Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.",
+                "Excepteur sint occaecat cupidatat non proident,",
+                "sunt in culpa qui officia deserunt mollit anim id est laborum.");
+        g.class_(desc, zc -> {
+            zc.sourceFile(file());
+            zc.staticMethod("test0", mc -> {
+                mc.returning(List.class);
+                mc.body(b0 -> {
+                    b0.line(nextLine());
+                    b0.return_(zc.stringListResourceConstant("big1", big1));
+                });
+            });
+        });
+        assertEquals(big1, tcm.staticMethod("test0", StringListTest.class).get());
+    }
+
+    @SuppressWarnings("SpellCheckingInspection")
+    @Test
+    public void testResourceStringSet() {
+        TestClassMaker tcm = new TestClassMaker();
+        Gizmo g = Gizmo.create(tcm);
+        ClassDesc desc = ClassDesc.of("io.quarkus.gizmo2.TestSmallSet");
+        Set<String> big1 = Set.of(
+                "Lorem ipsum dolor sit amet,",
+                "consectetur adipiscing elit,",
+                "sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
+                "Ut enim ad minim veniam,",
+                "quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.",
+                "Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.",
+                "Excepteur sint occaecat cupidatat non proident,",
+                "sunt in culpa qui officia deserunt mollit anim id est laborum.");
+        g.class_(desc, zc -> {
+            zc.sourceFile(file());
+            zc.staticMethod("test0", mc -> {
+                mc.returning(Set.class);
+                mc.body(b0 -> {
+                    b0.line(nextLine());
+                    b0.return_(zc.stringSetResourceConstant("big1", big1));
+                });
+            });
+        });
+        assertEquals(big1, tcm.staticMethod("test0", StringSetTest.class).get());
+    }
+
+    @SuppressWarnings("SpellCheckingInspection")
+    @Test
+    public void testResourceStringMap() {
+        TestClassMaker tcm = new TestClassMaker();
+        Gizmo g = Gizmo.create(tcm);
+        ClassDesc desc = ClassDesc.of("io.quarkus.gizmo2.TestSmallMap");
+        Map<String, String> big1 = Stream.of(
+                "Lorem ipsum dolor sit amet,",
+                "consectetur adipiscing elit,",
+                "sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
+                "Ut enim ad minim veniam,",
+                "quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.",
+                "Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.",
+                "Excepteur sint occaecat cupidatat non proident,",
+                "sunt in culpa qui officia deserunt mollit anim id est laborum.").collect(
+                        Collectors.toMap(
+                                Function.identity(), Function.identity()));
+        g.class_(desc, zc -> {
+            zc.sourceFile(file());
+            zc.staticMethod("test0", mc -> {
+                mc.returning(Map.class);
+                mc.body(b0 -> {
+                    b0.line(nextLine());
+                    b0.return_(zc.stringMapResourceConstant("big1", big1));
+                });
+            });
+        });
+        assertEquals(big1, tcm.staticMethod("test0", StringMapTest.class).get());
+    }
+
+    public interface StringListTest {
+        List<String> get();
+    }
+
+    public interface StringSetTest {
+        Set<String> get();
+    }
+
+    public interface StringMapTest {
+        Map<String, String> get();
+    }
+
+    public interface ClassListTest {
+        List<Class<?>> get();
+    }
+
+    public interface ClassSetTest {
+        Set<Class<?>> get();
+    }
+
+    public interface ClassMapTest {
+        Map<String, Class<?>> get();
+    }
+
+    private static final StackWalker SW = StackWalker.getInstance();
+
+    // get the line # after the call to this method
+    private static int nextLine() {
+        return SW.walk(s -> s.skip(1).findFirst().orElseThrow()).getLineNumber() + 1;
+    }
+
+    // get my source file name
+    private static String file() {
+        return SW.walk(s -> s.skip(1).findFirst().orElseThrow()).getFileName();
+    }
+}


### PR DESCRIPTION
Introduce two features:

* `List`/`Set`/`Map` plain constants (good for less than ~30 elements)
* External resource-backed constants for `List`/`Set`/`Map` of `String` specifically (no other constant types)

The constants are implemented in terms of condy.

The plain constants are a bit greedy with the constant pool. The amount of slots will amortize towards one slot per entry if enough are used, but for smaller collections it could be 2-3 slots per entry. Nevertheless these could be quite handy in certain circumstances where you have a small fixed set of, say, classes that you only use in one or two places and you don't want to go through the ceremony of setting up a field for it.

The resource-backed collections are unbounded in maximum size, however they will take up several constant pool slots (amortizing to 1 per collection if enough are used in one file).
