### PR TITLE
Abstracted generics+annotation support

### DIFF
--- a/src/main/java/io/quarkus/gizmo2/AnnotatableCreator.java
+++ b/src/main/java/io/quarkus/gizmo2/AnnotatableCreator.java
@@ -1,13 +1,18 @@
 package io.quarkus.gizmo2;
 
-import static io.smallrye.common.constraint.Assert.checkNotNullParam;
+import static io.smallrye.common.constraint.Assert.*;
 
 import java.lang.annotation.Annotation;
 import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 import java.lang.constant.ClassDesc;
+import java.lang.reflect.AnnotatedElement;
+import java.util.Objects;
+import java.util.Set;
 import java.util.function.Consumer;
+import java.util.stream.Stream;
 
 import io.quarkus.gizmo2.creator.AnnotationCreator;
 import io.quarkus.gizmo2.creator.MemberCreator;
@@ -18,7 +23,34 @@ import io.quarkus.gizmo2.impl.AnnotatableCreatorImpl;
 /**
  * An element that can be annotated.
  */
-public sealed interface Annotatable permits MemberCreator, ParamCreator, TypeCreator, AnnotatableCreatorImpl {
+public sealed interface AnnotatableCreator
+        permits TypeVariableCreator, MemberCreator, ParamCreator, TypeCreator, AnnotatableCreatorImpl {
+    /**
+     * Copy all of the annotations from the given annotated element.
+     *
+     * @param element the annotated element (must not be {@code null})
+     * @return a consumer which copies the annotations (not {@code null})
+     */
+    static Consumer<AnnotatableCreator> from(AnnotatedElement element) {
+        return ac -> Stream.of(element.getAnnotations())
+                .filter(a -> Set.of(Objects.requireNonNull(a.annotationType().getAnnotation(Target.class)).value())
+                        .contains(((AnnotatableCreatorImpl) ac).annotationTargetType()))
+                .forEach(ac::withAnnotation);
+    }
+
+    /**
+     * Add the given annotation object to this creator.
+     *
+     * @param annotation the annotation object (must not be {@code null})
+     * @param <A> the annotation type
+     */
+    default <A extends Annotation> void withAnnotation(A annotation) {
+        checkNotNullParam("annotation", annotation);
+        @SuppressWarnings("unchecked")
+        Class<A> annotationType = (Class<A>) annotation.annotationType();
+        withAnnotation(annotationType, AnnotationCreator.from(annotation));
+    }
+
     /**
      * Add an annotation with no elements. If {@code annotationClass} has no {@link Retention}
      * annotation, {@link RetentionPolicy#RUNTIME} is assumed. This is the most commonly used

--- a/src/main/java/io/quarkus/gizmo2/Expr.java
+++ b/src/main/java/io/quarkus/gizmo2/Expr.java
@@ -16,6 +16,13 @@ public sealed interface Expr extends SimpleTyped permits Const, Assignable, This
     ClassDesc type();
 
     /**
+     * {@return the generic expression type (not {@code null})}
+     */
+    default GenericType genericType() {
+        return GenericType.of(type());
+    }
+
+    /**
      * {@return {@code true} if the expression is bound to a single point in the instruction list, or {@code false} otherwise}
      * Bound expressions may not be used again.
      */

--- a/src/main/java/io/quarkus/gizmo2/GenericType.java
+++ b/src/main/java/io/quarkus/gizmo2/GenericType.java
@@ -108,12 +108,36 @@ public abstract class GenericType {
     /**
      * {@return a generic type for the given class or interface type}
      *
+     * @param desc the descriptor for the class or interface (must not be {@code null})
+     * @throws IllegalArgumentException if the given type class object does not represent a class or interface
+     */
+    public static GenericType.OfClass ofClass(ClassDesc desc) {
+        if (!desc.isClassOrInterface()) {
+            throw new IllegalArgumentException("Type %s does not represent a class or interface".formatted(desc));
+        }
+        return (OfClass) of(desc);
+    }
+
+    /**
+     * {@return a generic type for the given class or interface type}
+     *
      * @param type the class object for the class or interface (must not be {@code null})
      * @param typeArguments the type arguments for the type (must not be {@code null})
      * @throws IllegalArgumentException if the given type class object does not represent a class or interface
      */
     public static GenericType.OfClass ofClass(Class<?> type, List<TypeArgument> typeArguments) {
         return ofClass(type).withArguments(typeArguments);
+    }
+
+    /**
+     * {@return a generic type for the given class or interface type}
+     *
+     * @param desc the descriptor for the class or interface (must not be {@code null})
+     * @param typeArguments the type arguments for the type (must not be {@code null})
+     * @throws IllegalArgumentException if the given type class object does not represent a class or interface
+     */
+    public static GenericType.OfClass ofClass(ClassDesc desc, List<TypeArgument> typeArguments) {
+        return ofClass(desc).withArguments(typeArguments);
     }
 
     /**

--- a/src/main/java/io/quarkus/gizmo2/GenericType.java
+++ b/src/main/java/io/quarkus/gizmo2/GenericType.java
@@ -232,6 +232,11 @@ public abstract class GenericType {
         return copy(tac.visible(), tac.invisible());
     }
 
+    public final <A extends java.lang.annotation.Annotation> GenericType withAnnotation(Class<A> annotationType) {
+        return withAnnotation(annotationType, ac -> {
+        });
+    }
+
     public final <A extends java.lang.annotation.Annotation> GenericType withAnnotation(Class<A> annotationType,
             Consumer<AnnotationCreator<A>> builder) {
         return withAnnotations(ac -> ac.withAnnotation(annotationType, builder));
@@ -252,7 +257,7 @@ public abstract class GenericType {
     }
 
     public boolean hasInvisibleAnnotations() {
-        return !visible.isEmpty();
+        return !invisible.isEmpty();
     }
 
     public final boolean hasAnnotations() {
@@ -471,7 +476,7 @@ public abstract class GenericType {
         }
 
         public boolean hasInvisibleAnnotations() {
-            return super.hasVisibleAnnotations() || typeArguments.stream().anyMatch(TypeArgument::hasInvisibleAnnotations);
+            return super.hasInvisibleAnnotations() || typeArguments.stream().anyMatch(TypeArgument::hasInvisibleAnnotations);
         }
 
         public OfClass withArguments(List<TypeArgument> newArguments) {

--- a/src/main/java/io/quarkus/gizmo2/GenericType.java
+++ b/src/main/java/io/quarkus/gizmo2/GenericType.java
@@ -1,0 +1,630 @@
+package io.quarkus.gizmo2;
+
+import static java.lang.constant.ConstantDescs.*;
+
+import java.lang.annotation.RetentionPolicy;
+import java.lang.constant.ClassDesc;
+import java.lang.reflect.AnnotatedArrayType;
+import java.lang.reflect.AnnotatedParameterizedType;
+import java.lang.reflect.AnnotatedType;
+import java.lang.reflect.AnnotatedTypeVariable;
+import java.lang.reflect.AnnotatedWildcardType;
+import java.lang.reflect.GenericArrayType;
+import java.lang.reflect.Modifier;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import io.github.dmlloyd.classfile.Annotation;
+import io.github.dmlloyd.classfile.Signature;
+import io.github.dmlloyd.classfile.TypeAnnotation;
+import io.quarkus.gizmo2.impl.TypeAnnotatableCreatorImpl;
+import io.quarkus.gizmo2.impl.Util;
+import io.smallrye.common.constraint.Assert;
+
+/**
+ * A generic Java type, which may include type arguments as well as type annotations.
+ * <p>
+ * This class models types for the purpose of code generation, and is not generally suitable
+ * for usage in any kind of type-checking system.
+ */
+public abstract class GenericType {
+    /*
+     *
+     * JavaTypeSignature
+     * +- ReferenceTypeSignature
+     * | +- ThrowsSignature
+     * | | +- ClassTypeSignature :: [PackageSpec] {Identifier [TypeArguments] [{Nested}]}
+     * | | +- TypeVariableSignature :: Identifier
+     * | +- ArrayTypeSignature :: JavaTypeSignature
+     * +- BaseType (primitive)
+     *
+     * TypeArguments
+     * +- [WildCard == +/-] ReferenceTypeSignature
+     * +- `*`
+     *
+     * Annotations:
+     *
+     * - Type parameters (class or method) (top level or method info)
+     * - Supertype (class or interface) (top level)
+     * - Type parameter bound type (class or method) (top level or method info)
+     * - Type of field (or record component) (field info, record component info)
+     * - Method return type or ctor output type (OK weird) (method info)
+     * - Receiver type (method or ctor) (method info)
+     * - Throws clause type (method into)
+     *
+     * - Local variable `@xyz Foo foo;` (Code attr)
+     * - Resource variable `try (@xyz Foo foo = bar()) {}` (Code attr)
+     * - Catch parameter `catch (Foo | @xyz Bar e)` (special target) (Code attr)
+     * - Instanceof `instanceof @xyz Foo` (bytecode offset) (Code attr)
+     * - Type of `new @xyz Foo()` expr (bytecode offset) (Code attr)
+     * - Type of `(@xyz Abc)::new` (bytecode offset) (Code attr)
+     * - Type of `(@xyz Abc)::identifier` (bytecode offset) (Code attr)
+     * - Cast type (Code attr)
+     * - Generic type argument for `new` invocation e.g. `new <@xyz Foo> Bar()`
+     * - Generic type argument for method invocation `<@xyz Foo> bar()`
+     * - Generic type argument for `::<@xyz Foo>new`
+     * - Generic type argument for `::<@xyz Foo>identifier`
+     *
+     *
+     * GenericType
+     * +- OfReference
+     * | +- OfThrows
+     * | | +- OfClass :: enclosing (outer) OfThrows
+     * | | +- OfTypeVariable
+     * | +- OfArray
+     * +- OfPrimitive
+     */
+
+    final List<Annotation> visible;
+    final List<Annotation> invisible;
+    OfArray arrayType;
+
+    GenericType(final List<Annotation> visible, final List<Annotation> invisible) {
+        this.visible = visible;
+        this.invisible = invisible;
+    }
+
+    /**
+     * {@return the given type as an erased generic type (not {@code null})}
+     *
+     * @param type the type (must not be {@code null})
+     */
+    public static GenericType of(Class<?> type) {
+        return of(type, List.of());
+    }
+
+    public static OfClass of(Class<?> type, List<TypeArgument> typeArguments) {
+        int tpCount = type.getTypeParameters().length;
+        int taSize = typeArguments.size();
+        if (tpCount != taSize && taSize != 0) {
+            throw new IllegalArgumentException("Invalid number of type arguments (expected %d but got %d)"
+                    .formatted(Integer.valueOf(tpCount), Integer.valueOf(taSize)));
+        }
+        if (type.isMemberClass()) {
+            Class<?> enclosingClass = type.getEnclosingClass();
+            if (Modifier.isStatic(type.getModifiers())) {
+                return (OfClass) of(Util.classDesc(type), typeArguments);
+            } else {
+                return ofInnerClass((OfClass) of(enclosingClass), type.getSimpleName()).withArguments(typeArguments);
+            }
+        } else {
+            return (OfClass) of(Util.classDesc(type), typeArguments);
+        }
+    }
+
+    /**
+     * {@return the given type as an erased generic type (not {@code null})}
+     *
+     * @param desc the type descriptor
+     */
+    public static GenericType of(ClassDesc desc) {
+        if (desc.isClassOrInterface()) {
+            return new OfRootClass(List.of(), List.of(), desc, List.of());
+        }
+        if (desc.isPrimitive()) {
+            return OfPrimitive.baseItems.get(desc);
+        }
+        assert desc.isArray();
+        return new OfArray(List.of(), List.of(), of(desc.componentType()));
+    }
+
+    public static GenericType of(ClassDesc desc, List<TypeArgument> typeArguments) {
+        GenericType genericType = of(desc);
+        if (typeArguments.isEmpty()) {
+            return genericType;
+        } else if (genericType instanceof OfRootClass oc) {
+            return oc.withArguments(typeArguments);
+        } else {
+            throw new IllegalArgumentException("Type %s cannot have type arguments".formatted(desc));
+        }
+    }
+
+    public static OfTypeVariable ofTypeVariable(TypeVariable typeVariable) {
+        OfTypeVariable type = typeVariable.genericType;
+        if (type == null) {
+            type = typeVariable.genericType = new OfTypeVariable(List.of(), List.of(), typeVariable);
+        }
+        return type;
+    }
+
+    public static OfInnerClass ofInnerClass(OfClass outerClass, String name) {
+        return new OfInnerClass(List.of(), List.of(),
+                Assert.checkNotNullParam("outerClass", outerClass),
+                Assert.checkNotNullParam("name", name),
+                List.of());
+    }
+
+    public static GenericType of(Type type) {
+        if (type instanceof Class<?> c) {
+            return of(c);
+        } else if (type instanceof GenericArrayType gat) {
+            return of(gat);
+        } else if (type instanceof ParameterizedType pt) {
+            return of(pt);
+        } else if (type instanceof java.lang.reflect.TypeVariable<?> tv) {
+            return of(tv);
+        } else {
+            throw new IllegalArgumentException("Invalid type " + type.getClass());
+        }
+    }
+
+    public static OfArray of(GenericArrayType type) {
+        return of(type.getGenericComponentType()).arrayType();
+    }
+
+    public static OfTypeVariable of(java.lang.reflect.TypeVariable<?> type) {
+        return TypeVariable.of(type).genericType();
+    }
+
+    public static OfClass of(ParameterizedType type) {
+        return ((OfClass) of(type.getRawType())).withArguments(
+                Stream.of(type.getActualTypeArguments()).map(TypeArgument::of).toList());
+    }
+
+    public static GenericType of(AnnotatedType type) {
+        if (type instanceof AnnotatedArrayType aat) {
+            return of(aat);
+        } else if (type instanceof AnnotatedParameterizedType apt) {
+            return of(apt);
+        } else if (type instanceof AnnotatedTypeVariable atv) {
+            return of(atv);
+        } else if (type instanceof AnnotatedWildcardType) {
+            throw new IllegalArgumentException("Wildcard types cannot be used here (see `TypeArgument.of(AnnotatedType)`)");
+        } else {
+            // annotated plain type
+            return of(type.getType()).withAnnotations(AnnotatableCreator.from(type));
+        }
+    }
+
+    public static OfArray of(AnnotatedArrayType type) {
+        return of(type.getAnnotatedGenericComponentType()).arrayType().withAnnotations(AnnotatableCreator.from(type));
+    }
+
+    public static OfClass of(AnnotatedParameterizedType type) {
+        List<TypeArgument> typeArgs = Stream.of(type.getAnnotatedActualTypeArguments()).map(TypeArgument::of).toList();
+        ParameterizedType pt = (ParameterizedType) type.getType();
+        return of((Class<?>) pt.getRawType(), typeArgs).withAnnotations(AnnotatableCreator.from(type));
+    }
+
+    public static OfTypeVariable of(AnnotatedTypeVariable type) {
+        TypeVariable tv = TypeVariable.of((java.lang.reflect.TypeVariable<?>) type.getType());
+        return tv.genericType().withAnnotations(AnnotatableCreator.from(type));
+    }
+
+    abstract GenericType copy(List<Annotation> visible, List<Annotation> invisible);
+
+    public GenericType withAnnotations(Consumer<AnnotatableCreator> builder) {
+        TypeAnnotatableCreatorImpl tac = new TypeAnnotatableCreatorImpl(visible, invisible);
+        builder.accept(tac);
+        if (visible.equals(tac.visible()) && invisible.equals(tac.invisible())) {
+            // no annotations added
+            return this;
+        }
+        return copy(tac.visible(), tac.invisible());
+    }
+
+    public OfArray arrayType() {
+        OfArray arrayType = this.arrayType;
+        if (arrayType == null) {
+            arrayType = this.arrayType = new OfArray(List.of(), List.of(), this);
+        }
+        return arrayType;
+    }
+
+    public abstract ClassDesc desc();
+
+    /**
+     * Append a string representation of this type to the given string builder.
+     *
+     * @param b the string builder (must not be {@code null})
+     * @return the string builder that was passed in (not {@code null})
+     */
+    public StringBuilder toString(StringBuilder b) {
+        for (Annotation annotation : visible) {
+            Util.appendAnnotation(b, annotation).append(' ');
+        }
+        for (Annotation annotation : invisible) {
+            Util.appendAnnotation(b, annotation).append(' ');
+        }
+        return b;
+    }
+
+    /**
+     * {@return a string representation of this type}
+     */
+    public final String toString() {
+        return toString(new StringBuilder()).toString();
+    }
+
+    public final boolean equals(final Object obj) {
+        return obj instanceof GenericType gt && equals(gt);
+    }
+
+    public boolean equals(GenericType gt) {
+        return this == gt || visible.equals(gt.visible) && invisible.equals(gt.invisible);
+    }
+
+    public int hashCode() {
+        return visible.hashCode() * 19 + invisible.hashCode();
+    }
+
+    List<TypeAnnotation> computeAnnotations(RetentionPolicy retention, TypeAnnotation.TargetInfo targetInfo,
+            ArrayList<TypeAnnotation> list, ArrayDeque<TypeAnnotation.TypePathComponent> path) {
+        List<TypeAnnotation.TypePathComponent> pathSnapshot = List.copyOf(path);
+        for (Annotation annotation : switch (retention) {
+            case RUNTIME -> visible;
+            case CLASS -> invisible;
+            default -> throw Assert.impossibleSwitchCase(retention);
+        }) {
+            list.add(TypeAnnotation.of(targetInfo, pathSnapshot, annotation));
+        }
+        return list;
+    }
+
+    abstract Signature computeSignature();
+
+    public static final class OfTypeVariable extends OfThrows {
+        private final TypeVariable typeParameter;
+
+        OfTypeVariable(final List<Annotation> visible, final List<Annotation> invisible, final TypeVariable typeParameter) {
+            super(visible, invisible);
+            this.typeParameter = typeParameter;
+        }
+
+        public ClassDesc desc() {
+            return typeParameter.erasure();
+        }
+
+        public StringBuilder toString(final StringBuilder b) {
+            return super.toString(b).append(typeParameter);
+        }
+
+        TypeVariable typeParameter() {
+            return typeParameter;
+        }
+
+        public OfTypeVariable withAnnotations(final Consumer<AnnotatableCreator> builder) {
+            return (OfTypeVariable) super.withAnnotations(builder);
+        }
+
+        OfTypeVariable copy(final List<Annotation> visible, final List<Annotation> invisible) {
+            return new OfTypeVariable(visible, invisible, typeParameter);
+        }
+
+        public boolean equals(final GenericType gt) {
+            return gt instanceof OfTypeVariable tv && equals(tv);
+        }
+
+        public boolean equals(final OfTypeVariable tvt) {
+            return this == tvt || super.equals(tvt) && typeParameter().equals(tvt.typeParameter());
+        }
+
+        public int hashCode() {
+            return super.hashCode() * 19 + typeParameter().hashCode();
+        }
+
+        Signature.TypeVarSig computeSignature() {
+            return Signature.TypeVarSig.of(typeParameter.name());
+        }
+    }
+
+    public static abstract class OfReference extends GenericType {
+        TypeArgument.OfExact exactArg;
+        TypeArgument.OfExtends extendsArg;
+        TypeArgument.OfSuper superArg;
+
+        OfReference(final List<Annotation> visible, final List<Annotation> invisible) {
+            super(visible, invisible);
+        }
+
+        abstract Signature.RefTypeSig computeSignature();
+    }
+
+    public static abstract class OfThrows extends OfReference {
+        OfThrows(final List<Annotation> visible, final List<Annotation> invisible) {
+            super(visible, invisible);
+        }
+    }
+
+    public static final class OfArray extends OfReference {
+        private final GenericType componentType;
+        private ClassDesc desc;
+
+        OfArray(final List<Annotation> visible, final List<Annotation> invisible, final GenericType componentType) {
+            super(visible, invisible);
+            this.componentType = componentType;
+        }
+
+        public GenericType componentType() {
+            return componentType;
+        }
+
+        List<TypeAnnotation> computeAnnotations(final RetentionPolicy retention, final TypeAnnotation.TargetInfo targetInfo,
+                final ArrayList<TypeAnnotation> list, final ArrayDeque<TypeAnnotation.TypePathComponent> path) {
+            componentType.computeAnnotations(retention, targetInfo, list, path);
+            path.addLast(TypeAnnotation.TypePathComponent.ARRAY);
+            super.computeAnnotations(retention, targetInfo, list, path);
+            path.removeLast();
+            return list;
+        }
+
+        OfArray copy(final List<Annotation> visible, final List<Annotation> invisible) {
+            return new OfArray(visible, invisible, componentType);
+        }
+
+        public OfArray withAnnotations(final Consumer<AnnotatableCreator> builder) {
+            return (OfArray) super.withAnnotations(builder);
+        }
+
+        public ClassDesc desc() {
+            ClassDesc desc = this.desc;
+            if (desc == null) {
+                desc = this.desc = componentType.desc().arrayType();
+            }
+            return desc;
+        }
+
+        public StringBuilder toString(final StringBuilder b) {
+            // supertype annotations []
+            return super.toString(componentType.toString(b)).append("[]");
+        }
+
+        Signature.ArrayTypeSig computeSignature() {
+            return Signature.ArrayTypeSig.of(1, componentType.computeSignature());
+        }
+    }
+
+    public static abstract class OfClass extends OfThrows {
+        final List<TypeArgument> typeArguments;
+
+        OfClass(final List<Annotation> visible, final List<Annotation> invisible, final List<TypeArgument> typeArguments) {
+            super(visible, invisible);
+            this.typeArguments = typeArguments;
+        }
+
+        public abstract ClassDesc desc();
+
+        public OfClass withAnnotations(final Consumer<AnnotatableCreator> builder) {
+            return (OfClass) super.withAnnotations(builder);
+        }
+
+        public OfClass withArguments(List<TypeArgument> newArguments) {
+            if (typeArguments.equals(newArguments)) {
+                return this;
+            }
+            int taSize = typeArguments.size();
+            int naSize = newArguments.size();
+            if (taSize == 0 || naSize == 0 || taSize == naSize) {
+                return copy(visible, invisible, newArguments);
+            } else {
+                throw new IllegalArgumentException("Invalid number of type arguments (expected %d but got %d)"
+                        .formatted(Integer.valueOf(naSize), Integer.valueOf(taSize)));
+            }
+        }
+
+        abstract OfClass copy(final List<Annotation> visible, final List<Annotation> invisible,
+                final List<TypeArgument> typeArguments);
+
+        List<TypeAnnotation> computeAnnotations(final RetentionPolicy retention, final TypeAnnotation.TargetInfo targetInfo,
+                final ArrayList<TypeAnnotation> list, final ArrayDeque<TypeAnnotation.TypePathComponent> path) {
+            super.computeAnnotations(retention, targetInfo, list, path);
+            List<TypeArgument> typeArguments = this.typeArguments;
+            List<TypeAnnotation.TypePathComponent> pathSnapshot;
+            int size = typeArguments.size();
+            for (int i = 0; i < size; i++) {
+                path.addLast(TypeAnnotation.TypePathComponent.of(TypeAnnotation.TypePathComponent.Kind.TYPE_ARGUMENT, i));
+                TypeArgument arg = typeArguments.get(i);
+                if (arg instanceof TypeArgument.OfAnnotated ann) {
+                    List<Annotation> argAnnotations = switch (retention) {
+                        case RUNTIME -> ann.visible();
+                        case CLASS -> ann.invisible();
+                        default -> throw Assert.impossibleSwitchCase(retention);
+                    };
+                    pathSnapshot = List.copyOf(path);
+                    for (Annotation annotation : argAnnotations) {
+                        list.add(TypeAnnotation.of(targetInfo, pathSnapshot, annotation));
+                    }
+                    if (ann instanceof TypeArgument.OfBounded bnd) {
+                        // extends or super; add the inner annotations
+                        path.addLast(TypeAnnotation.TypePathComponent.WILDCARD);
+                        bnd.bound().computeAnnotations(retention, targetInfo, list, path);
+                        path.removeLast();
+                    }
+                } else if (arg instanceof TypeArgument.OfExact exact) {
+                    // exact
+                    exact.bound().computeAnnotations(retention, targetInfo, list, path);
+                } else {
+                    throw Assert.unreachableCode();
+                }
+                path.removeLast();
+            }
+            return list;
+        }
+
+        abstract Signature.ClassTypeSig computeSignature();
+
+        Signature.TypeArg[] toTypeArgs(final List<TypeArgument> typeArguments) {
+            return typeArguments.stream().map(TypeArgument::toTypeArg).toArray(Signature.TypeArg[]::new);
+        }
+
+        StringBuilder typeArgumentsToString(StringBuilder b) {
+            Iterator<TypeArgument> iter = typeArguments.iterator();
+            if (iter.hasNext()) {
+                b.append('<');
+                iter.next().toString(b);
+                while (iter.hasNext()) {
+                    b.append(',');
+                    iter.next().toString(b);
+                }
+                b.append('>');
+            }
+            return b;
+        }
+    }
+
+    public static final class OfRootClass extends OfClass {
+        private final ClassDesc desc;
+
+        OfRootClass(final List<Annotation> visible, final List<Annotation> invisible, final ClassDesc desc,
+                final List<TypeArgument> typeArguments) {
+            super(visible, invisible, typeArguments);
+            this.desc = desc;
+        }
+
+        public OfRootClass withArguments(final List<TypeArgument> newArguments) {
+            if (typeArguments.equals(newArguments)) {
+                return this;
+            }
+            return (OfRootClass) super.withArguments(newArguments);
+        }
+
+        public ClassDesc desc() {
+            return desc;
+        }
+
+        OfRootClass copy(final List<Annotation> visible, final List<Annotation> invisible,
+                final List<TypeArgument> typeArguments) {
+            return new OfRootClass(visible, invisible, desc, typeArguments);
+        }
+
+        OfRootClass copy(final List<Annotation> visible, final List<Annotation> invisible) {
+            return new OfRootClass(visible, invisible, desc, typeArguments);
+        }
+
+        public OfRootClass withAnnotations(final Consumer<AnnotatableCreator> builder) {
+            return (OfRootClass) super.withAnnotations(builder);
+        }
+
+        public StringBuilder toString(final StringBuilder b) {
+            return typeArgumentsToString(super.toString(b).append(Util.binaryName(desc)));
+        }
+
+        Signature.ClassTypeSig computeSignature() {
+            return Signature.ClassTypeSig.of(desc, toTypeArgs(typeArguments));
+        }
+    }
+
+    public static final class OfInnerClass extends OfClass {
+        private final OfClass outerType;
+        private final String name;
+        private ClassDesc desc;
+
+        OfInnerClass(final List<Annotation> visible, final List<Annotation> invisible, final OfClass outerType,
+                final String name, final List<TypeArgument> typeArguments) {
+            super(visible, invisible, typeArguments);
+            this.outerType = outerType;
+            this.name = name;
+        }
+
+        public ClassDesc desc() {
+            ClassDesc desc = this.desc;
+            if (desc == null) {
+                desc = this.desc = outerType.desc().nested(name);
+            }
+            return desc;
+        }
+
+        OfInnerClass copy(final List<Annotation> visible, final List<Annotation> invisible) {
+            return new OfInnerClass(visible, invisible, outerType, name, typeArguments);
+        }
+
+        OfInnerClass copy(final List<Annotation> visible, final List<Annotation> invisible,
+                final List<TypeArgument> typeArguments) {
+            return new OfInnerClass(visible, invisible, outerType, name, typeArguments);
+        }
+
+        public OfInnerClass withOuterType(OfClass outerType) {
+            return new OfInnerClass(visible, invisible, Assert.checkNotNullParam("outerType", outerType), name, typeArguments);
+        }
+
+        public StringBuilder toString(final StringBuilder b) {
+            return typeArgumentsToString(super.toString(outerType.toString(b).append('.')).append(name));
+        }
+
+        List<TypeAnnotation> computeAnnotations(final RetentionPolicy retention, final TypeAnnotation.TargetInfo targetInfo,
+                final ArrayList<TypeAnnotation> list, final ArrayDeque<TypeAnnotation.TypePathComponent> path) {
+            outerType.computeAnnotations(retention, targetInfo, list, path);
+            path.addLast(TypeAnnotation.TypePathComponent.INNER_TYPE);
+            super.computeAnnotations(retention, targetInfo, list, path);
+            path.removeLast();
+            return list;
+        }
+
+        Signature.ClassTypeSig computeSignature() {
+            return Signature.ClassTypeSig.of(outerType.computeSignature(), name, toTypeArgs(typeArguments));
+        }
+    }
+
+    public static final class OfPrimitive extends GenericType {
+        private static final Map<ClassDesc, OfPrimitive> baseItems = Stream.of(
+                CD_boolean,
+                CD_byte,
+                CD_short,
+                CD_char,
+                CD_int,
+                CD_long,
+                CD_float,
+                CD_double,
+                CD_void).collect(Collectors.toUnmodifiableMap(Function.identity(), OfPrimitive::new));
+
+        private final ClassDesc type;
+
+        private OfPrimitive(final ClassDesc type) {
+            this(List.of(), List.of(), type);
+        }
+
+        private OfPrimitive(final List<Annotation> visible, final List<Annotation> invisible, final ClassDesc type) {
+            super(visible, invisible);
+            this.type = type;
+        }
+
+        OfPrimitive copy(final List<Annotation> visible, final List<Annotation> invisible) {
+            return new OfPrimitive(visible, invisible, type);
+        }
+
+        public OfPrimitive withAnnotations(final Consumer<AnnotatableCreator> builder) {
+            return (OfPrimitive) super.withAnnotations(builder);
+        }
+
+        public StringBuilder toString(final StringBuilder b) {
+            return super.toString(b).append(Util.binaryName(type));
+        }
+
+        public ClassDesc desc() {
+            return type;
+        }
+
+        Signature computeSignature() {
+            return Signature.BaseTypeSig.of(type);
+        }
+    }
+}

--- a/src/main/java/io/quarkus/gizmo2/GenericTyped.java
+++ b/src/main/java/io/quarkus/gizmo2/GenericTyped.java
@@ -2,11 +2,12 @@ package io.quarkus.gizmo2;
 
 import io.quarkus.gizmo2.creator.FieldCreator;
 import io.quarkus.gizmo2.creator.ParamCreator;
+import io.quarkus.gizmo2.creator.TypeCreator;
 
 /**
  * A thing which has a type.
  */
-public sealed interface GenericTyped extends SimpleTyped permits TypeVariable, FieldCreator, ParamCreator {
+public sealed interface GenericTyped extends SimpleTyped permits TypeVariable, FieldCreator, ParamCreator, TypeCreator {
     /**
      * {@return the generic type of this entity (not {@code null})}
      */

--- a/src/main/java/io/quarkus/gizmo2/GenericTyped.java
+++ b/src/main/java/io/quarkus/gizmo2/GenericTyped.java
@@ -1,9 +1,11 @@
 package io.quarkus.gizmo2;
 
+import io.quarkus.gizmo2.creator.FieldCreator;
+
 /**
  * A thing which has a type.
  */
-public sealed interface GenericTyped permits TypeVariable {
+public sealed interface GenericTyped extends SimpleTyped permits TypeVariable, FieldCreator {
     /**
      * {@return the generic type of this entity (not {@code null})}
      */

--- a/src/main/java/io/quarkus/gizmo2/GenericTyped.java
+++ b/src/main/java/io/quarkus/gizmo2/GenericTyped.java
@@ -1,11 +1,12 @@
 package io.quarkus.gizmo2;
 
 import io.quarkus.gizmo2.creator.FieldCreator;
+import io.quarkus.gizmo2.creator.ParamCreator;
 
 /**
  * A thing which has a type.
  */
-public sealed interface GenericTyped extends SimpleTyped permits TypeVariable, FieldCreator {
+public sealed interface GenericTyped extends SimpleTyped permits TypeVariable, FieldCreator, ParamCreator {
     /**
      * {@return the generic type of this entity (not {@code null})}
      */

--- a/src/main/java/io/quarkus/gizmo2/GenericTyped.java
+++ b/src/main/java/io/quarkus/gizmo2/GenericTyped.java
@@ -1,0 +1,11 @@
+package io.quarkus.gizmo2;
+
+/**
+ * A thing which has a type.
+ */
+public sealed interface GenericTyped permits TypeVariable {
+    /**
+     * {@return the generic type of this entity (not {@code null})}
+     */
+    GenericType genericType();
+}

--- a/src/main/java/io/quarkus/gizmo2/MethodTyped.java
+++ b/src/main/java/io/quarkus/gizmo2/MethodTyped.java
@@ -27,6 +27,13 @@ public sealed interface MethodTyped extends Typed permits MethodDesc, Constructo
     }
 
     /**
+     * {@return the generic return type}
+     */
+    default GenericType genericReturnType() {
+        return GenericType.of(returnType());
+    }
+
+    /**
      * {@return the type kind of the return type (not {@code null})}
      */
     default TypeKind returnTypeKind() {

--- a/src/main/java/io/quarkus/gizmo2/SimpleTyped.java
+++ b/src/main/java/io/quarkus/gizmo2/SimpleTyped.java
@@ -4,7 +4,6 @@ import java.lang.constant.ClassDesc;
 
 import io.quarkus.gizmo2.creator.BlockCreator;
 import io.quarkus.gizmo2.creator.ClassCreator;
-import io.quarkus.gizmo2.creator.FieldCreator;
 import io.quarkus.gizmo2.creator.ParamCreator;
 import io.quarkus.gizmo2.creator.SwitchCreator;
 import io.quarkus.gizmo2.creator.TypeCreator;
@@ -14,7 +13,7 @@ import io.quarkus.gizmo2.desc.FieldDesc;
  * A typed thing whose type is a simple type.
  */
 public sealed interface SimpleTyped extends Typed
-        permits Expr, FieldDesc, BlockCreator, ClassCreator, FieldCreator, ParamCreator, SwitchCreator, TypeCreator {
+        permits Expr, GenericTyped, BlockCreator, ClassCreator, ParamCreator, SwitchCreator, TypeCreator, FieldDesc {
     /**
      * {@return the type of this entity (not {@code null})}
      */

--- a/src/main/java/io/quarkus/gizmo2/SimpleTyped.java
+++ b/src/main/java/io/quarkus/gizmo2/SimpleTyped.java
@@ -5,14 +5,13 @@ import java.lang.constant.ClassDesc;
 import io.quarkus.gizmo2.creator.BlockCreator;
 import io.quarkus.gizmo2.creator.ClassCreator;
 import io.quarkus.gizmo2.creator.SwitchCreator;
-import io.quarkus.gizmo2.creator.TypeCreator;
 import io.quarkus.gizmo2.desc.FieldDesc;
 
 /**
  * A typed thing whose type is a simple type.
  */
 public sealed interface SimpleTyped extends Typed
-        permits Expr, GenericTyped, BlockCreator, ClassCreator, SwitchCreator, TypeCreator, FieldDesc {
+        permits Expr, GenericTyped, BlockCreator, ClassCreator, SwitchCreator, FieldDesc {
     /**
      * {@return the type of this entity (not {@code null})}
      */

--- a/src/main/java/io/quarkus/gizmo2/SimpleTyped.java
+++ b/src/main/java/io/quarkus/gizmo2/SimpleTyped.java
@@ -4,7 +4,6 @@ import java.lang.constant.ClassDesc;
 
 import io.quarkus.gizmo2.creator.BlockCreator;
 import io.quarkus.gizmo2.creator.ClassCreator;
-import io.quarkus.gizmo2.creator.ParamCreator;
 import io.quarkus.gizmo2.creator.SwitchCreator;
 import io.quarkus.gizmo2.creator.TypeCreator;
 import io.quarkus.gizmo2.desc.FieldDesc;
@@ -13,7 +12,7 @@ import io.quarkus.gizmo2.desc.FieldDesc;
  * A typed thing whose type is a simple type.
  */
 public sealed interface SimpleTyped extends Typed
-        permits Expr, GenericTyped, BlockCreator, ClassCreator, ParamCreator, SwitchCreator, TypeCreator, FieldDesc {
+        permits Expr, GenericTyped, BlockCreator, ClassCreator, SwitchCreator, TypeCreator, FieldDesc {
     /**
      * {@return the type of this entity (not {@code null})}
      */

--- a/src/main/java/io/quarkus/gizmo2/TypeArgument.java
+++ b/src/main/java/io/quarkus/gizmo2/TypeArgument.java
@@ -1,0 +1,248 @@
+package io.quarkus.gizmo2;
+
+import java.lang.reflect.AnnotatedType;
+import java.lang.reflect.AnnotatedWildcardType;
+import java.lang.reflect.Type;
+import java.lang.reflect.WildcardType;
+import java.util.List;
+import java.util.function.Consumer;
+
+import io.github.dmlloyd.classfile.Annotation;
+import io.github.dmlloyd.classfile.Signature;
+import io.quarkus.gizmo2.impl.TypeAnnotatableCreatorImpl;
+import io.quarkus.gizmo2.impl.Util;
+import io.smallrye.common.constraint.Assert;
+
+/**
+ * An actual type argument for a formal type parameter.
+ */
+public abstract class TypeArgument {
+
+    TypeArgument() {
+    }
+
+    public static TypeArgument of(final Type type) {
+        if (type instanceof WildcardType wt) {
+            return of(wt);
+        }
+        return ofExact((GenericType.OfReference) GenericType.of(type));
+    }
+
+    public static TypeArgument of(final AnnotatedType type) {
+        if (type instanceof AnnotatedWildcardType wt) {
+            return of(wt);
+        }
+        return ofExact((GenericType.OfReference) GenericType.of(type));
+    }
+
+    public static OfAnnotated of(final WildcardType type) {
+        List<Type> ub = List.of(type.getUpperBounds());
+        List<Type> lb = List.of(type.getLowerBounds());
+        if (!lb.isEmpty()) {
+            return ofSuper((GenericType.OfReference) GenericType.of(lb.get(0)));
+        } else if (ub.isEmpty() || ub.size() == 1 && ub.get(0).equals(Object.class)) {
+            return ofWildcard();
+        } else {
+            return ofExtends((GenericType.OfReference) GenericType.of(ub.get(0)));
+        }
+    }
+
+    public static OfAnnotated of(final AnnotatedWildcardType type) {
+        List<AnnotatedType> aub = List.of(type.getAnnotatedUpperBounds());
+        List<AnnotatedType> alb = List.of(type.getAnnotatedLowerBounds());
+        if (!alb.isEmpty()) {
+            return ofSuper((GenericType.OfReference) GenericType.of(alb.get(0))).withAnnotations(AnnotatableCreator.from(type));
+        }
+        if (aub.isEmpty() || aub.size() == 1 && aub.get(0).getType().equals(Object.class)) {
+            return ofWildcard().withAnnotations(AnnotatableCreator.from(type));
+        }
+        return ofExtends((GenericType.OfReference) GenericType.of(aub.get(0))).withAnnotations(AnnotatableCreator.from(type));
+    }
+
+    public abstract StringBuilder toString(StringBuilder b);
+
+    public String toString() {
+        return toString(new StringBuilder()).toString();
+    }
+
+    public static TypeArgument.OfExact ofExact(GenericType.OfReference bound) {
+        Assert.checkNotNullParam("bound", bound);
+        OfExact ofExact = bound.exactArg;
+        if (ofExact == null) {
+            ofExact = bound.exactArg = new OfExact(bound);
+        }
+        return ofExact;
+    }
+
+    public static TypeArgument.OfExtends ofExtends(GenericType.OfReference bound) {
+        Assert.checkNotNullParam("bound", bound);
+        OfExtends ofExtends = bound.extendsArg;
+        if (ofExtends == null) {
+            ofExtends = bound.extendsArg = new OfExtends(List.of(), List.of(), bound);
+        }
+        return ofExtends;
+    }
+
+    public static TypeArgument.OfSuper ofSuper(GenericType.OfReference bound) {
+        Assert.checkNotNullParam("bound", bound);
+        OfSuper ofSuper = bound.superArg;
+        if (ofSuper == null) {
+            ofSuper = bound.superArg = new OfSuper(List.of(), List.of(), bound);
+        }
+        return ofSuper;
+    }
+
+    public static Wildcard ofWildcard() {
+        return Wildcard.instance;
+    }
+
+    abstract Signature.TypeArg toTypeArg();
+
+    public sealed interface OfBounded permits OfExtends, OfSuper, OfExact {
+        GenericType.OfReference bound();
+    }
+
+    public static abstract class OfAnnotated extends TypeArgument {
+        final List<Annotation> visible;
+        final List<Annotation> invisible;
+
+        OfAnnotated(final List<Annotation> visible, final List<Annotation> invisible) {
+            this.visible = visible;
+            this.invisible = invisible;
+        }
+
+        List<Annotation> visible() {
+            return visible;
+        }
+
+        List<Annotation> invisible() {
+            return invisible;
+        }
+
+        OfAnnotated copy(final List<Annotation> visible, final List<Annotation> invisible) {
+            return null;
+        }
+
+        public OfAnnotated withAnnotations(Consumer<AnnotatableCreator> builder) {
+            TypeAnnotatableCreatorImpl tac = new TypeAnnotatableCreatorImpl(visible, invisible);
+            builder.accept(tac);
+            return copy(tac.visible(), tac.invisible());
+        }
+
+        public StringBuilder toString(StringBuilder b) {
+            for (Annotation annotation : visible) {
+                Util.appendAnnotation(b, annotation).append(' ');
+            }
+            for (Annotation annotation : invisible) {
+                Util.appendAnnotation(b, annotation).append(' ');
+            }
+            return b;
+        }
+    }
+
+    public static final class OfExtends extends OfAnnotated implements OfBounded {
+        private final GenericType.OfReference bound;
+
+        OfExtends(final List<Annotation> visible, final List<Annotation> invisible, final GenericType.OfReference bound) {
+            super(visible, invisible);
+            this.bound = bound;
+        }
+
+        public GenericType.OfReference bound() {
+            return bound;
+        }
+
+        OfExtends copy(final List<Annotation> visible, final List<Annotation> invisible) {
+            return new OfExtends(visible, invisible, bound());
+        }
+
+        public OfExtends withAnnotations(final Consumer<AnnotatableCreator> builder) {
+            return (OfExtends) super.withAnnotations(builder);
+        }
+
+        public StringBuilder toString(final StringBuilder b) {
+            return super.toString(b.append("? extends "));
+        }
+
+        Signature.TypeArg toTypeArg() {
+            return Signature.TypeArg.extendsOf(bound.computeSignature());
+        }
+    }
+
+    public static final class OfExact extends TypeArgument implements OfBounded {
+        private final GenericType.OfReference bound;
+
+        OfExact(final GenericType.OfReference bound) {
+            this.bound = bound;
+        }
+
+        public GenericType.OfReference bound() {
+            return bound;
+        }
+
+        public StringBuilder toString(final StringBuilder b) {
+            return bound.toString(b);
+        }
+
+        Signature.TypeArg toTypeArg() {
+            return Signature.TypeArg.of(bound.computeSignature());
+        }
+    }
+
+    public static final class OfSuper extends OfAnnotated implements OfBounded {
+        private final GenericType.OfReference bound;
+
+        OfSuper(final List<Annotation> visible, final List<Annotation> invisible, final GenericType.OfReference bound) {
+            super(visible, invisible);
+            this.bound = bound;
+        }
+
+        public GenericType.OfReference bound() {
+            return bound;
+        }
+
+        OfSuper copy(final List<Annotation> visible, final List<Annotation> invisible) {
+            return new OfSuper(visible, invisible, bound());
+        }
+
+        public OfSuper withAnnotations(final Consumer<AnnotatableCreator> builder) {
+            return (OfSuper) super.withAnnotations(builder);
+        }
+
+        public StringBuilder toString(final StringBuilder b) {
+            return super.toString(b.append("? super "));
+        }
+
+        Signature.TypeArg toTypeArg() {
+            return Signature.TypeArg.superOf(bound.computeSignature());
+        }
+    }
+
+    public static final class Wildcard extends OfAnnotated {
+        private Wildcard() {
+            super(List.of(), List.of());
+        }
+
+        private Wildcard(final List<Annotation> visible, final List<Annotation> invisible) {
+            super(visible, invisible);
+        }
+
+        Wildcard copy(final List<Annotation> visible, final List<Annotation> invisible) {
+            return new Wildcard(visible, invisible);
+        }
+
+        public Wildcard withAnnotations(final Consumer<AnnotatableCreator> builder) {
+            return (Wildcard) super.withAnnotations(builder);
+        }
+
+        private static final Wildcard instance = new Wildcard();
+
+        public StringBuilder toString(final StringBuilder b) {
+            return super.toString(b).append('*');
+        }
+
+        Signature.TypeArg toTypeArg() {
+            return Signature.TypeArg.unbounded();
+        }
+    }
+}

--- a/src/main/java/io/quarkus/gizmo2/TypeArgument.java
+++ b/src/main/java/io/quarkus/gizmo2/TypeArgument.java
@@ -58,6 +58,14 @@ public abstract class TypeArgument {
         return ofExtends((GenericType.OfReference) GenericType.of(aub.get(0))).withAnnotations(AnnotatableCreator.from(type));
     }
 
+    public abstract boolean hasVisibleAnnotations();
+
+    public abstract boolean hasInvisibleAnnotations();
+
+    public final boolean hasAnnotations() {
+        return hasVisibleAnnotations() || hasInvisibleAnnotations();
+    }
+
     public abstract StringBuilder toString(StringBuilder b);
 
     public String toString() {
@@ -120,6 +128,14 @@ public abstract class TypeArgument {
             return null;
         }
 
+        public boolean hasVisibleAnnotations() {
+            return !visible.isEmpty();
+        }
+
+        public boolean hasInvisibleAnnotations() {
+            return !invisible.isEmpty();
+        }
+
         public OfAnnotated withAnnotations(Consumer<AnnotatableCreator> builder) {
             TypeAnnotatableCreatorImpl tac = new TypeAnnotatableCreatorImpl(visible, invisible);
             builder.accept(tac);
@@ -149,6 +165,14 @@ public abstract class TypeArgument {
             return bound;
         }
 
+        public boolean hasVisibleAnnotations() {
+            return super.hasVisibleAnnotations() || bound.hasVisibleAnnotations();
+        }
+
+        public boolean hasInvisibleAnnotations() {
+            return super.hasInvisibleAnnotations() || bound.hasInvisibleAnnotations();
+        }
+
         OfExtends copy(final List<Annotation> visible, final List<Annotation> invisible) {
             return new OfExtends(visible, invisible, bound());
         }
@@ -173,6 +197,14 @@ public abstract class TypeArgument {
             return bound;
         }
 
+        public boolean hasVisibleAnnotations() {
+            return bound.hasVisibleAnnotations();
+        }
+
+        public boolean hasInvisibleAnnotations() {
+            return bound.hasInvisibleAnnotations();
+        }
+
         public StringBuilder toString(final StringBuilder b) {
             return bound.toString(b);
         }
@@ -188,6 +220,14 @@ public abstract class TypeArgument {
 
         public GenericType.OfReference bound() {
             return bound;
+        }
+
+        public boolean hasVisibleAnnotations() {
+            return super.hasVisibleAnnotations() || bound.hasVisibleAnnotations();
+        }
+
+        public boolean hasInvisibleAnnotations() {
+            return super.hasInvisibleAnnotations() || bound.hasInvisibleAnnotations();
         }
 
         OfSuper copy(final List<Annotation> visible, final List<Annotation> invisible) {

--- a/src/main/java/io/quarkus/gizmo2/TypeArgument.java
+++ b/src/main/java/io/quarkus/gizmo2/TypeArgument.java
@@ -8,7 +8,6 @@ import java.util.List;
 import java.util.function.Consumer;
 
 import io.github.dmlloyd.classfile.Annotation;
-import io.github.dmlloyd.classfile.Signature;
 import io.quarkus.gizmo2.impl.TypeAnnotatableCreatorImpl;
 import io.quarkus.gizmo2.impl.Util;
 import io.smallrye.common.constraint.Assert;
@@ -96,8 +95,6 @@ public abstract class TypeArgument {
         return Wildcard.instance;
     }
 
-    abstract Signature.TypeArg toTypeArg();
-
     public sealed interface OfBounded permits OfExtends, OfSuper, OfExact {
         GenericType.OfReference bound();
     }
@@ -163,10 +160,6 @@ public abstract class TypeArgument {
         public StringBuilder toString(final StringBuilder b) {
             return super.toString(b.append("? extends "));
         }
-
-        Signature.TypeArg toTypeArg() {
-            return Signature.TypeArg.extendsOf(bound.computeSignature());
-        }
     }
 
     public static final class OfExact extends TypeArgument implements OfBounded {
@@ -182,10 +175,6 @@ public abstract class TypeArgument {
 
         public StringBuilder toString(final StringBuilder b) {
             return bound.toString(b);
-        }
-
-        Signature.TypeArg toTypeArg() {
-            return Signature.TypeArg.of(bound.computeSignature());
         }
     }
 
@@ -212,10 +201,6 @@ public abstract class TypeArgument {
         public StringBuilder toString(final StringBuilder b) {
             return super.toString(b.append("? super "));
         }
-
-        Signature.TypeArg toTypeArg() {
-            return Signature.TypeArg.superOf(bound.computeSignature());
-        }
     }
 
     public static final class Wildcard extends OfAnnotated {
@@ -239,10 +224,6 @@ public abstract class TypeArgument {
 
         public StringBuilder toString(final StringBuilder b) {
             return super.toString(b).append('*');
-        }
-
-        Signature.TypeArg toTypeArg() {
-            return Signature.TypeArg.unbounded();
         }
     }
 }

--- a/src/main/java/io/quarkus/gizmo2/TypeArgument.java
+++ b/src/main/java/io/quarkus/gizmo2/TypeArgument.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.function.Consumer;
 
 import io.github.dmlloyd.classfile.Annotation;
+import io.quarkus.gizmo2.creator.AnnotationCreator;
 import io.quarkus.gizmo2.impl.TypeAnnotatableCreatorImpl;
 import io.quarkus.gizmo2.impl.Util;
 import io.smallrye.common.constraint.Assert;
@@ -20,14 +21,14 @@ public abstract class TypeArgument {
     TypeArgument() {
     }
 
-    public static TypeArgument of(final Type type) {
+    public static TypeArgument ofExact(final Type type) {
         if (type instanceof WildcardType wt) {
             return of(wt);
         }
         return ofExact((GenericType.OfReference) GenericType.of(type));
     }
 
-    public static TypeArgument of(final AnnotatedType type) {
+    public static TypeArgument ofExact(final AnnotatedType type) {
         if (type instanceof AnnotatedWildcardType wt) {
             return of(wt);
         }
@@ -142,6 +143,15 @@ public abstract class TypeArgument {
             return copy(tac.visible(), tac.invisible());
         }
 
+        public <A extends java.lang.annotation.Annotation> OfAnnotated withAnnotation(final Class<A> annotationType) {
+            return withAnnotations(ac -> ac.withAnnotation(annotationType));
+        }
+
+        public <A extends java.lang.annotation.Annotation> OfAnnotated withAnnotation(final Class<A> annotationType,
+                final Consumer<AnnotationCreator<A>> builder) {
+            return withAnnotations(ac -> ac.withAnnotation(annotationType, builder));
+        }
+
         public StringBuilder toString(StringBuilder b) {
             for (Annotation annotation : visible) {
                 Util.appendAnnotation(b, annotation).append(' ');
@@ -181,8 +191,17 @@ public abstract class TypeArgument {
             return (OfExtends) super.withAnnotations(builder);
         }
 
+        public <A extends java.lang.annotation.Annotation> OfExtends withAnnotation(final Class<A> annotationType) {
+            return (OfExtends) super.withAnnotation(annotationType);
+        }
+
+        public <A extends java.lang.annotation.Annotation> OfExtends withAnnotation(final Class<A> annotationType,
+                final Consumer<AnnotationCreator<A>> builder) {
+            return (OfExtends) super.withAnnotation(annotationType, builder);
+        }
+
         public StringBuilder toString(final StringBuilder b) {
-            return super.toString(b.append("? extends "));
+            return bound.toString(super.toString(b).append("? extends "));
         }
     }
 
@@ -238,8 +257,17 @@ public abstract class TypeArgument {
             return (OfSuper) super.withAnnotations(builder);
         }
 
+        public <A extends java.lang.annotation.Annotation> OfSuper withAnnotation(final Class<A> annotationType) {
+            return (OfSuper) super.withAnnotation(annotationType);
+        }
+
+        public <A extends java.lang.annotation.Annotation> OfSuper withAnnotation(final Class<A> annotationType,
+                final Consumer<AnnotationCreator<A>> builder) {
+            return (OfSuper) super.withAnnotation(annotationType, builder);
+        }
+
         public StringBuilder toString(final StringBuilder b) {
-            return super.toString(b.append("? super "));
+            return bound.toString(super.toString(b).append("? super "));
         }
     }
 
@@ -258,6 +286,15 @@ public abstract class TypeArgument {
 
         public Wildcard withAnnotations(final Consumer<AnnotatableCreator> builder) {
             return (Wildcard) super.withAnnotations(builder);
+        }
+
+        public <A extends java.lang.annotation.Annotation> Wildcard withAnnotation(final Class<A> annotationType) {
+            return (Wildcard) super.withAnnotation(annotationType);
+        }
+
+        public <A extends java.lang.annotation.Annotation> Wildcard withAnnotation(final Class<A> annotationType,
+                final Consumer<AnnotationCreator<A>> builder) {
+            return (Wildcard) super.withAnnotation(annotationType, builder);
         }
 
         private static final Wildcard instance = new Wildcard();

--- a/src/main/java/io/quarkus/gizmo2/TypeVariable.java
+++ b/src/main/java/io/quarkus/gizmo2/TypeVariable.java
@@ -168,7 +168,7 @@ public sealed abstract class TypeVariable implements GenericTyped {
      * {@return the erased type of this type variable (not {@code null})}
      */
     public ClassDesc erasure() {
-        return otherBounds().stream().findFirst().map(GenericType::desc).orElse(CD_Object);
+        return firstBound.map(GenericType::desc).orElse(CD_Object);
     }
 
     @SuppressWarnings("unused") // called from Util reflectively

--- a/src/main/java/io/quarkus/gizmo2/TypeVariable.java
+++ b/src/main/java/io/quarkus/gizmo2/TypeVariable.java
@@ -1,0 +1,230 @@
+package io.quarkus.gizmo2;
+
+import static java.lang.constant.ConstantDescs.*;
+
+import java.lang.annotation.Annotation;
+import java.lang.constant.ClassDesc;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.GenericDeclaration;
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Stream;
+
+import io.quarkus.gizmo2.desc.ConstructorDesc;
+import io.quarkus.gizmo2.desc.MethodDesc;
+import io.quarkus.gizmo2.impl.Util;
+
+/**
+ * A type variable on a class, interface, or method.
+ */
+public sealed abstract class TypeVariable implements GenericTyped {
+    // TODO arguments for classes we do not define
+    private final String name;
+    private final List<GenericType.OfThrows> bounds;
+    private final List<Annotation> visible;
+    private final List<Annotation> invisible;
+
+    GenericType.OfTypeVariable genericType;
+
+    TypeVariable(final List<Annotation> visible, final List<Annotation> invisible, final String name,
+            final List<GenericType.OfThrows> bounds) {
+        this.name = name;
+        this.bounds = bounds;
+        this.visible = visible;
+        this.invisible = invisible;
+    }
+
+    static TypeVariable of(final java.lang.reflect.TypeVariable<?> typeVar) {
+        GenericDeclaration decl = typeVar.getGenericDeclaration();
+        List<GenericType.OfThrows> bounds = Stream.of(typeVar.getAnnotatedBounds())
+                .map(GenericType::of)
+                .map(GenericType.OfThrows.class::cast)
+                .toList();
+        // TODO: populate annotations
+        if (decl instanceof Class<?> c) {
+            return new OfType(List.of(), List.of(), typeVar.getName(), bounds, Util.classDesc(c));
+        } else if (decl instanceof Method m) {
+            return new OfMethod(List.of(), List.of(), typeVar.getName(), bounds, MethodDesc.of(m));
+        } else if (decl instanceof Constructor<?> c) {
+            return new OfConstructor(List.of(), List.of(), typeVar.getName(), bounds, ConstructorDesc.of(c));
+        } else {
+            // should be impossible, actually
+            throw new IllegalStateException("Unexpected declaration " + decl);
+        }
+    }
+
+    public List<GenericType.OfThrows> bounds() {
+        return bounds;
+    }
+
+    /**
+     * {@return the type variable name}
+     */
+    public String name() {
+        return name;
+    }
+
+    public GenericType.OfTypeVariable genericType() {
+        return GenericType.ofTypeVariable(this);
+    }
+
+    List<Annotation> visible() {
+        return visible;
+    }
+
+    List<Annotation> invisible() {
+        return invisible;
+    }
+
+    public abstract boolean visibleIn(ClassDesc desc);
+
+    public abstract boolean visibleIn(MethodDesc desc);
+
+    public abstract boolean visibleIn(ConstructorDesc desc);
+
+    public final boolean equals(final Object obj) {
+        return obj instanceof TypeVariable tv && equals(tv);
+    }
+
+    public boolean equals(final TypeVariable other) {
+        return other != null && name.equals(other.name) && bounds.equals(other.bounds);
+    }
+
+    public int hashCode() {
+        return Objects.hash(name, bounds);
+    }
+
+    public String toString() {
+        return name();
+    }
+
+    public ClassDesc erasure() {
+        return bounds().stream().findFirst().map(GenericType::desc).orElse(CD_Object);
+    }
+
+    public static final class OfType extends TypeVariable {
+        private final ClassDesc owner;
+
+        OfType(final List<Annotation> visible, final List<Annotation> invisible, final String name,
+                final List<GenericType.OfThrows> bounds, final ClassDesc owner) {
+            super(visible, invisible, name, bounds);
+            this.owner = owner;
+        }
+
+        /**
+         * {@return the owner of the type variable}
+         */
+        public ClassDesc owner() {
+            return owner;
+        }
+
+        public boolean visibleIn(final ClassDesc desc) {
+            return owner.equals(desc);
+        }
+
+        public boolean visibleIn(final MethodDesc desc) {
+            return visibleIn(desc.owner());
+        }
+
+        public boolean visibleIn(final ConstructorDesc desc) {
+            return visibleIn(desc.owner());
+        }
+
+        public boolean equals(final TypeVariable other) {
+            return other instanceof OfType ot && equals(ot);
+        }
+
+        public boolean equals(final OfType other) {
+            return this == other || super.equals(other) && owner.equals(other.owner);
+        }
+
+        public int hashCode() {
+            return super.hashCode() * 19 + owner.hashCode();
+        }
+    }
+
+    public static final class OfMethod extends TypeVariable {
+        private final MethodDesc owner;
+
+        OfMethod(final List<Annotation> visible, final List<Annotation> invisible, final String name,
+                final List<GenericType.OfThrows> bounds, final MethodDesc owner) {
+            super(visible, invisible, name, bounds);
+            this.owner = owner;
+        }
+
+        /**
+         * {@return the owner of the type variable}
+         */
+        public MethodDesc owner() {
+            return owner;
+        }
+
+        public boolean visibleIn(final ClassDesc desc) {
+            // only visible in methods
+            return false;
+        }
+
+        public boolean visibleIn(final MethodDesc desc) {
+            return desc.equals(owner);
+        }
+
+        public boolean visibleIn(final ConstructorDesc desc) {
+            return false;
+        }
+
+        public boolean equals(final TypeVariable other) {
+            return other instanceof OfMethod om && equals(om);
+        }
+
+        public boolean equals(final OfMethod other) {
+            return this == other || super.equals(other) && owner.equals(other.owner);
+        }
+
+        public int hashCode() {
+            return super.hashCode();
+        }
+    }
+
+    public static final class OfConstructor extends TypeVariable {
+        private final ConstructorDesc owner;
+
+        OfConstructor(final List<Annotation> visible, final List<Annotation> invisible, final String name,
+                final List<GenericType.OfThrows> bounds, final ConstructorDesc owner) {
+            super(visible, invisible, name, bounds);
+            this.owner = owner;
+        }
+
+        /**
+         * {@return the owner of the type variable}
+         */
+        public ConstructorDesc owner() {
+            return owner;
+        }
+
+        public boolean visibleIn(final ClassDesc desc) {
+            // only visible in constructors
+            return false;
+        }
+
+        public boolean visibleIn(final MethodDesc desc) {
+            return false;
+        }
+
+        public boolean visibleIn(final ConstructorDesc desc) {
+            return desc.equals(owner);
+        }
+
+        public boolean equals(final TypeVariable other) {
+            return other instanceof OfConstructor om && equals(om);
+        }
+
+        public boolean equals(final OfConstructor other) {
+            return this == other || super.equals(other) && owner.equals(other.owner);
+        }
+
+        public int hashCode() {
+            return super.hashCode();
+        }
+    }
+}

--- a/src/main/java/io/quarkus/gizmo2/TypeVariable.java
+++ b/src/main/java/io/quarkus/gizmo2/TypeVariable.java
@@ -47,7 +47,7 @@ public sealed abstract class TypeVariable implements GenericTyped {
         Optional<GenericType.OfThrows> firstBound;
         List<GenericType.OfThrows> otherBounds;
         // make a best-effort guess to populate this stuff as correctly as possible
-        if (allBounds.isEmpty() || allBounds.size() == 1 && allBounds.get(0).equals(GenericType.of(Object.class))) {
+        if (allBounds.isEmpty() || allBounds.size() == 1 && allBounds.get(0).equals(GenericType.ofClass(Object.class))) {
             firstBound = Optional.empty();
             otherBounds = List.of();
         } else if (typeVar.getBounds()[0] instanceof Class<?> c && !c.isInterface()) {

--- a/src/main/java/io/quarkus/gizmo2/TypeVariableCreator.java
+++ b/src/main/java/io/quarkus/gizmo2/TypeVariableCreator.java
@@ -1,0 +1,22 @@
+package io.quarkus.gizmo2;
+
+import java.util.List;
+
+import io.quarkus.gizmo2.impl.TypeVariableCreatorImpl;
+
+/**
+ * A creator for a type variable.
+ */
+public sealed interface TypeVariableCreator extends AnnotatableCreator permits TypeVariableCreatorImpl {
+    /**
+     * {@return the name of the type variable being created (not {@code null})}
+     */
+    String name();
+
+    /**
+     * Establish the given bounds for the type variable.
+     *
+     * @param bounds the bounds (must not be {@code null})
+     */
+    void withBounds(List<GenericType.OfReference> bounds);
+}

--- a/src/main/java/io/quarkus/gizmo2/TypeVariableCreator.java
+++ b/src/main/java/io/quarkus/gizmo2/TypeVariableCreator.java
@@ -14,9 +14,16 @@ public sealed interface TypeVariableCreator extends AnnotatableCreator permits T
     String name();
 
     /**
-     * Establish the given bounds for the type variable.
+     * Establish the (optional) first bound for the type variable.
      *
-     * @param bounds the bounds (must not be {@code null})
+     * @param bound the first bound (must not be {@code null})
      */
-    void withBounds(List<GenericType.OfReference> bounds);
+    void withFirstBound(GenericType.OfReference bound);
+
+    /**
+     * Establish the other (secondary) bounds for the type variable.
+     *
+     * @param bounds the secondary bounds (must not be {@code null})
+     */
+    void withOtherBounds(List<GenericType.OfReference> bounds);
 }

--- a/src/main/java/io/quarkus/gizmo2/creator/AnnotationCreator.java
+++ b/src/main/java/io/quarkus/gizmo2/creator/AnnotationCreator.java
@@ -3,10 +3,18 @@ package io.quarkus.gizmo2.creator;
 import java.io.Serializable;
 import java.lang.annotation.Annotation;
 import java.lang.constant.ClassDesc;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.lang.reflect.UndeclaredThrowableException;
 import java.util.List;
+import java.util.Objects;
 import java.util.function.Consumer;
+import java.util.stream.Stream;
 
 import io.quarkus.gizmo2.impl.AnnotationCreatorImpl;
+import io.quarkus.gizmo2.impl.Util;
+import io.smallrye.common.constraint.Assert;
 
 /**
  * A typesafe creator for an annotation body.
@@ -14,6 +22,104 @@ import io.quarkus.gizmo2.impl.AnnotationCreatorImpl;
  * @param <A> the annotation type
  */
 public sealed interface AnnotationCreator<A extends Annotation> permits AnnotationCreatorImpl {
+    /**
+     * Get an annotation builder which adds the given annotation to its given creator.
+     * The builder may be used more than once.
+     *
+     * @param annotation the annotation to copy (must not be {@code null})
+     * @return the annotation builder (not {@code null})
+     * @param <A> the annotation type
+     */
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    static <A extends Annotation> Consumer<AnnotationCreator<A>> from(A annotation) {
+        return ac -> {
+            Class<A> annotationType = (Class<A>) annotation.annotationType();
+            Method[] methods = annotationType.getDeclaredMethods();
+            for (Method method : methods) {
+                int mods = method.getModifiers();
+                if (Modifier.isPublic(mods) && Modifier.isAbstract(mods) && !Modifier.isStatic(mods)) {
+                    Object val;
+                    try {
+                        val = method.invoke(annotation);
+                    } catch (IllegalAccessException e) {
+                        throw new IllegalAccessError(e.getMessage());
+                    } catch (InvocationTargetException e) {
+                        try {
+                            throw e.getCause();
+                        } catch (RuntimeException | Error e2) {
+                            throw e2;
+                        } catch (Throwable e2) {
+                            throw new UndeclaredThrowableException(e2);
+                        }
+                    }
+                    if (val == null || Objects.equals(val, method.getDefaultValue())) {
+                        // skip it (use default if there is one, otherwise ignore)
+                        continue;
+                    }
+                    // the ABCs of annotation value types
+                    String name = method.getName();
+                    if (val instanceof Annotation a) {
+                        ac.with(name, a.getClass().asSubclass(Annotation.class), AnnotationCreator.from(a));
+                    } else if (val instanceof Boolean b) {
+                        ac.with(name, b.booleanValue());
+                    } else if (val instanceof Byte b) {
+                        ac.with(name, b.byteValue());
+                    } else if (val instanceof Class<?> z) {
+                        ac.with(name, z);
+                    } else if (val instanceof Character c) {
+                        ac.with(name, c.charValue());
+                    } else if (val instanceof Double d) {
+                        ac.with(name, d.doubleValue());
+                    } else if (val instanceof Float f) {
+                        ac.with(name, f.floatValue());
+                    } else if (val instanceof Integer i) {
+                        ac.with(name, i.intValue());
+                    } else if (val instanceof Long l) {
+                        ac.with(name, l.longValue());
+                    } else if (val instanceof Short s) {
+                        ac.with(name, s.shortValue());
+                    } else if (val instanceof String s) {
+                        ac.with(name, s);
+                    } else if (val instanceof Enum<?> e) {
+                        ac.with(name, (Enum) e);
+                    } else if (val instanceof Annotation[] array) {
+                        ac.doWithArray(name, method.getReturnType().asSubclass(Annotation.class), array);
+                    } else if (val instanceof boolean[] array) {
+                        ac.withArray(name, array);
+                    } else if (val instanceof byte[] array) {
+                        ac.withArray(name, array);
+                    } else if (val instanceof Class<?>[] array) {
+                        ac.withArray(name, array);
+                    } else if (val instanceof char[] array) {
+                        ac.withArray(name, array);
+                    } else if (val instanceof double[] array) {
+                        ac.withArray(name, array);
+                    } else if (val instanceof float[] array) {
+                        ac.withArray(name, array);
+                    } else if (val instanceof int[] array) {
+                        ac.withArray(name, array);
+                    } else if (val instanceof long[] array) {
+                        ac.withArray(name, array);
+                    } else if (val instanceof short[] array) {
+                        ac.withArray(name, array);
+                    } else if (val instanceof String[] array) {
+                        ac.withArray(name, array);
+                    } else if (val instanceof Enum<?>[] array) {
+                        ac.withArray(name, Util.classDesc(method.getReturnType().asSubclass(Enum.class)),
+                                Stream.of(array).map(Enum::name).toArray(String[]::new));
+                    } else {
+                        throw Assert.unreachableCode();
+                    }
+                }
+            }
+
+        };
+    }
+
+    private <AA extends Annotation> void doWithArray(String name, Class<AA> type, Annotation[] values) {
+        withArray(name, type, Stream.of(values).map(type::cast).map(AnnotationCreator::from).toList());
+    }
+
     /**
      * Add an annotation property with the given name and value.
      *

--- a/src/main/java/io/quarkus/gizmo2/creator/ClassCreator.java
+++ b/src/main/java/io/quarkus/gizmo2/creator/ClassCreator.java
@@ -18,7 +18,8 @@ import io.quarkus.gizmo2.impl.Util;
 /**
  * A creator for a class type.
  */
-public sealed interface ClassCreator extends TypeCreator, SimpleTyped permits AnonymousClassCreator, ClassCreatorImpl {
+public sealed interface ClassCreator extends TypeCreator, SimpleTyped, TypeParameterizedCreator
+        permits AnonymousClassCreator, ClassCreatorImpl {
     /**
      * {@return the superclass}
      *

--- a/src/main/java/io/quarkus/gizmo2/creator/ClassCreator.java
+++ b/src/main/java/io/quarkus/gizmo2/creator/ClassCreator.java
@@ -5,8 +5,8 @@ import java.lang.constant.MethodTypeDesc;
 import java.util.List;
 import java.util.function.Consumer;
 
-import io.github.dmlloyd.classfile.Signature;
 import io.quarkus.gizmo2.Const;
+import io.quarkus.gizmo2.GenericType;
 import io.quarkus.gizmo2.SimpleTyped;
 import io.quarkus.gizmo2.desc.ConstructorDesc;
 import io.quarkus.gizmo2.desc.FieldDesc;
@@ -32,7 +32,7 @@ public sealed interface ClassCreator extends TypeCreator, SimpleTyped, TypeParam
      *
      * @param genericType the generic class (must not be {@code null})
      */
-    void extends_(Signature.ClassTypeSig genericType);
+    void extends_(GenericType.OfClass genericType);
 
     /**
      * Extend the given class.

--- a/src/main/java/io/quarkus/gizmo2/creator/ExecutableCreator.java
+++ b/src/main/java/io/quarkus/gizmo2/creator/ExecutableCreator.java
@@ -12,7 +12,7 @@ import io.quarkus.gizmo2.impl.Util;
 /**
  * A creator for an executable (i.e. something that can be called with arguments).
  */
-public sealed interface ExecutableCreator extends MethodTyped
+public sealed interface ExecutableCreator extends MethodTyped, TypeParameterizedCreator
         permits InstanceExecutableCreator, MethodCreator, StaticExecutableCreator, ExecutableCreatorImpl {
     /**
      * {@return the type descriptor of this executable (not {@code null})}

--- a/src/main/java/io/quarkus/gizmo2/creator/ExecutableCreator.java
+++ b/src/main/java/io/quarkus/gizmo2/creator/ExecutableCreator.java
@@ -4,6 +4,7 @@ import java.lang.constant.ClassDesc;
 import java.lang.constant.MethodTypeDesc;
 import java.util.function.Consumer;
 
+import io.quarkus.gizmo2.GenericType;
 import io.quarkus.gizmo2.MethodTyped;
 import io.quarkus.gizmo2.ParamVar;
 import io.quarkus.gizmo2.impl.ExecutableCreatorImpl;
@@ -188,8 +189,27 @@ public sealed interface ExecutableCreator extends MethodTyped, TypeParameterized
         return parameter(name, position, Util.classDesc(type));
     }
 
-    void throws_(ClassDesc throwableType);
+    /**
+     * Declare that this method throws exceptions of the given type.
+     *
+     * @param throwableType the generic exception type (must not be {@code null})
+     */
+    void throws_(GenericType.OfThrows throwableType);
 
+    /**
+     * Declare that this method throws exceptions of the given type.
+     *
+     * @param throwableType the exception type (must not be {@code null})
+     */
+    default void throws_(ClassDesc throwableType) {
+        throws_((GenericType.OfThrows) GenericType.of(throwableType));
+    }
+
+    /**
+     * Declare that this method throws exceptions of the given type.
+     *
+     * @param throwableType the exception type (must not be {@code null})
+     */
     default void throws_(Class<? extends Throwable> throwableType) {
         throws_(Util.classDesc(throwableType));
     }

--- a/src/main/java/io/quarkus/gizmo2/creator/FieldCreator.java
+++ b/src/main/java/io/quarkus/gizmo2/creator/FieldCreator.java
@@ -5,9 +5,9 @@ import static java.lang.constant.ConstantDescs.*;
 import java.lang.constant.ClassDesc;
 import java.util.function.Consumer;
 
-import io.github.dmlloyd.classfile.Signature;
 import io.quarkus.gizmo2.Const;
-import io.quarkus.gizmo2.SimpleTyped;
+import io.quarkus.gizmo2.GenericType;
+import io.quarkus.gizmo2.GenericTyped;
 import io.quarkus.gizmo2.desc.FieldDesc;
 import io.quarkus.gizmo2.impl.FieldCreatorImpl;
 import io.quarkus.gizmo2.impl.Util;
@@ -15,7 +15,7 @@ import io.quarkus.gizmo2.impl.Util;
 /**
  * A creator for a field.
  */
-public sealed interface FieldCreator extends MemberCreator, SimpleTyped
+public sealed interface FieldCreator extends MemberCreator, GenericTyped
         permits InstanceFieldCreator, StaticFieldCreator, FieldCreatorImpl {
     ClassDesc type();
 
@@ -25,11 +25,11 @@ public sealed interface FieldCreator extends MemberCreator, SimpleTyped
     FieldDesc desc();
 
     /**
-     * Change the type of the field to the given generic type.
+     * Change the type of the field to the given type.
      *
-     * @param type the class type signature (must not be {@code null})
+     * @param type the generic type (must not be {@code null})
      */
-    void withTypeSignature(Signature type);
+    void withType(GenericType type);
 
     /**
      * Change the type of the field to the given type.

--- a/src/main/java/io/quarkus/gizmo2/creator/InterfaceCreator.java
+++ b/src/main/java/io/quarkus/gizmo2/creator/InterfaceCreator.java
@@ -9,7 +9,7 @@ import io.quarkus.gizmo2.impl.InterfaceCreatorImpl;
 /**
  * A creator for an interface type.
  */
-public sealed interface InterfaceCreator extends TypeCreator permits InterfaceCreatorImpl {
+public sealed interface InterfaceCreator extends TypeCreator, TypeParameterizedCreator permits InterfaceCreatorImpl {
 
     /**
      * Add a default method to the interface.

--- a/src/main/java/io/quarkus/gizmo2/creator/MemberCreator.java
+++ b/src/main/java/io/quarkus/gizmo2/creator/MemberCreator.java
@@ -4,14 +4,14 @@ import java.lang.constant.ClassDesc;
 import java.lang.constant.ConstantDesc;
 
 import io.github.dmlloyd.classfile.extras.reflect.AccessFlag;
-import io.quarkus.gizmo2.Annotatable;
+import io.quarkus.gizmo2.AnnotatableCreator;
 import io.quarkus.gizmo2.Typed;
 import io.quarkus.gizmo2.desc.MemberDesc;
 
 /**
  * A generalized creator for any kind of class member.
  */
-public sealed interface MemberCreator extends Annotatable, Typed
+public sealed interface MemberCreator extends AnnotatableCreator, Typed
         permits ConstructorCreator, FieldCreator, MethodCreator {
 
     /**

--- a/src/main/java/io/quarkus/gizmo2/creator/MethodCreator.java
+++ b/src/main/java/io/quarkus/gizmo2/creator/MethodCreator.java
@@ -2,6 +2,7 @@ package io.quarkus.gizmo2.creator;
 
 import java.lang.constant.ClassDesc;
 
+import io.quarkus.gizmo2.GenericType;
 import io.quarkus.gizmo2.desc.MethodDesc;
 import io.quarkus.gizmo2.impl.MethodCreatorImpl;
 import io.quarkus.gizmo2.impl.Util;
@@ -16,6 +17,14 @@ public sealed interface MethodCreator extends ExecutableCreator, MemberCreator
      * {@return the descriptor of the method}
      */
     MethodDesc desc();
+
+    /**
+     * Change the generic return type of this method.
+     * The method type is changed with the new return type.
+     *
+     * @param type the generic return type (must not be {@code null})
+     */
+    void returning(GenericType type);
 
     /**
      * Change the return type of this method.

--- a/src/main/java/io/quarkus/gizmo2/creator/ParamCreator.java
+++ b/src/main/java/io/quarkus/gizmo2/creator/ParamCreator.java
@@ -3,7 +3,7 @@ package io.quarkus.gizmo2.creator;
 import java.lang.constant.ClassDesc;
 
 import io.github.dmlloyd.classfile.extras.reflect.AccessFlag;
-import io.quarkus.gizmo2.Annotatable;
+import io.quarkus.gizmo2.AnnotatableCreator;
 import io.quarkus.gizmo2.SimpleTyped;
 import io.quarkus.gizmo2.impl.ParamCreatorImpl;
 import io.quarkus.gizmo2.impl.Util;
@@ -11,7 +11,7 @@ import io.quarkus.gizmo2.impl.Util;
 /**
  * A creator interface for parameters.
  */
-public sealed interface ParamCreator extends Annotatable, SimpleTyped permits ParamCreatorImpl {
+public sealed interface ParamCreator extends AnnotatableCreator, SimpleTyped permits ParamCreatorImpl {
     /**
      * Add a flag to this parameter.
      *

--- a/src/main/java/io/quarkus/gizmo2/creator/ParamCreator.java
+++ b/src/main/java/io/quarkus/gizmo2/creator/ParamCreator.java
@@ -4,6 +4,7 @@ import java.lang.constant.ClassDesc;
 
 import io.github.dmlloyd.classfile.extras.reflect.AccessFlag;
 import io.quarkus.gizmo2.AnnotatableCreator;
+import io.quarkus.gizmo2.GenericType;
 import io.quarkus.gizmo2.SimpleTyped;
 import io.quarkus.gizmo2.impl.ParamCreatorImpl;
 import io.quarkus.gizmo2.impl.Util;
@@ -18,6 +19,14 @@ public sealed interface ParamCreator extends AnnotatableCreator, SimpleTyped per
      * @param flag the flag to add (must not be {@code null})
      */
     void withFlag(AccessFlag flag);
+
+    /**
+     * Change the type of this parameter.
+     *
+     * @param type the new generic type (must not be {@code null})
+     * @throws IllegalArgumentException if the new type is different from the established type
+     */
+    void withType(GenericType type);
 
     /**
      * Change the type of this parameter.

--- a/src/main/java/io/quarkus/gizmo2/creator/ParamCreator.java
+++ b/src/main/java/io/quarkus/gizmo2/creator/ParamCreator.java
@@ -5,14 +5,14 @@ import java.lang.constant.ClassDesc;
 import io.github.dmlloyd.classfile.extras.reflect.AccessFlag;
 import io.quarkus.gizmo2.AnnotatableCreator;
 import io.quarkus.gizmo2.GenericType;
-import io.quarkus.gizmo2.SimpleTyped;
+import io.quarkus.gizmo2.GenericTyped;
 import io.quarkus.gizmo2.impl.ParamCreatorImpl;
 import io.quarkus.gizmo2.impl.Util;
 
 /**
  * A creator interface for parameters.
  */
-public sealed interface ParamCreator extends AnnotatableCreator, SimpleTyped permits ParamCreatorImpl {
+public sealed interface ParamCreator extends AnnotatableCreator, GenericTyped permits ParamCreatorImpl {
     /**
      * Add a flag to this parameter.
      *

--- a/src/main/java/io/quarkus/gizmo2/creator/TypeCreator.java
+++ b/src/main/java/io/quarkus/gizmo2/creator/TypeCreator.java
@@ -8,11 +8,11 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
 
-import io.github.dmlloyd.classfile.Signature;
 import io.github.dmlloyd.classfile.extras.reflect.AccessFlag;
 import io.quarkus.gizmo2.AnnotatableCreator;
 import io.quarkus.gizmo2.ClassVersion;
 import io.quarkus.gizmo2.Const;
+import io.quarkus.gizmo2.GenericType;
 import io.quarkus.gizmo2.SimpleTyped;
 import io.quarkus.gizmo2.StaticFieldVar;
 import io.quarkus.gizmo2.This;
@@ -42,13 +42,6 @@ public sealed interface TypeCreator extends AnnotatableCreator, SimpleTyped
      * @param version the class file version (must not be {@code null})
      */
     void withVersion(ClassVersion version);
-
-    /**
-     * Add a type parameter.
-     *
-     * @param param the type parameter specification (must not be {@code null})
-     */
-    void withTypeParam(Signature.TypeParam param);
 
     /**
      * Add a flag to the type.
@@ -104,7 +97,7 @@ public sealed interface TypeCreator extends AnnotatableCreator, SimpleTyped
      *
      * @param genericType the generic interface type (must not be {@code null})
      */
-    void implements_(Signature.ClassTypeSig genericType);
+    void implements_(GenericType.OfClass genericType);
 
     /**
      * Implement an interface.

--- a/src/main/java/io/quarkus/gizmo2/creator/TypeCreator.java
+++ b/src/main/java/io/quarkus/gizmo2/creator/TypeCreator.java
@@ -10,7 +10,7 @@ import java.util.function.Consumer;
 
 import io.github.dmlloyd.classfile.Signature;
 import io.github.dmlloyd.classfile.extras.reflect.AccessFlag;
-import io.quarkus.gizmo2.Annotatable;
+import io.quarkus.gizmo2.AnnotatableCreator;
 import io.quarkus.gizmo2.ClassVersion;
 import io.quarkus.gizmo2.Const;
 import io.quarkus.gizmo2.SimpleTyped;
@@ -25,7 +25,8 @@ import io.quarkus.gizmo2.impl.Util;
 /**
  * A creator for a type.
  */
-public sealed interface TypeCreator extends Annotatable, SimpleTyped permits ClassCreator, InterfaceCreator, TypeCreatorImpl {
+public sealed interface TypeCreator extends AnnotatableCreator, SimpleTyped
+        permits ClassCreator, InterfaceCreator, TypeCreatorImpl {
     /**
      * Set the class file version to correspond with a run time version.
      * If not called, the generated class has the version of Java 17.

--- a/src/main/java/io/quarkus/gizmo2/creator/TypeCreator.java
+++ b/src/main/java/io/quarkus/gizmo2/creator/TypeCreator.java
@@ -13,7 +13,7 @@ import io.quarkus.gizmo2.AnnotatableCreator;
 import io.quarkus.gizmo2.ClassVersion;
 import io.quarkus.gizmo2.Const;
 import io.quarkus.gizmo2.GenericType;
-import io.quarkus.gizmo2.SimpleTyped;
+import io.quarkus.gizmo2.GenericTyped;
 import io.quarkus.gizmo2.StaticFieldVar;
 import io.quarkus.gizmo2.This;
 import io.quarkus.gizmo2.desc.ConstructorDesc;
@@ -25,7 +25,7 @@ import io.quarkus.gizmo2.impl.Util;
 /**
  * A creator for a type.
  */
-public sealed interface TypeCreator extends AnnotatableCreator, SimpleTyped
+public sealed interface TypeCreator extends AnnotatableCreator, GenericTyped
         permits ClassCreator, InterfaceCreator, TypeCreatorImpl {
     /**
      * Set the class file version to correspond with a run time version.
@@ -91,6 +91,11 @@ public sealed interface TypeCreator extends AnnotatableCreator, SimpleTyped
      * {@return the descriptor of the type of this class}
      */
     ClassDesc type();
+
+    /**
+     * {@return the generic type of this class}
+     */
+    GenericType.OfClass genericType();
 
     /**
      * Implement a generic interface.

--- a/src/main/java/io/quarkus/gizmo2/creator/TypeParameterizedCreator.java
+++ b/src/main/java/io/quarkus/gizmo2/creator/TypeParameterizedCreator.java
@@ -1,0 +1,13 @@
+package io.quarkus.gizmo2.creator;
+
+import java.util.function.Consumer;
+
+import io.quarkus.gizmo2.TypeVariable;
+import io.quarkus.gizmo2.TypeVariableCreator;
+
+/**
+ * A creator for things which can have type parameters.
+ */
+public sealed interface TypeParameterizedCreator permits ClassCreator, InterfaceCreator, ExecutableCreator {
+    TypeVariable typeParameter(String name, Consumer<TypeVariableCreator> builder);
+}

--- a/src/main/java/io/quarkus/gizmo2/desc/ConstructorDesc.java
+++ b/src/main/java/io/quarkus/gizmo2/desc/ConstructorDesc.java
@@ -4,6 +4,7 @@ import java.lang.constant.ClassDesc;
 import java.lang.constant.ConstantDescs;
 import java.lang.constant.MethodTypeDesc;
 import java.lang.invoke.MethodType;
+import java.lang.reflect.Constructor;
 import java.util.List;
 import java.util.stream.Stream;
 
@@ -112,6 +113,15 @@ public sealed interface ConstructorDesc extends MemberDesc, MethodTyped permits 
      */
     static ConstructorDesc of(Class<?> owner, List<Class<?>> paramTypes) {
         return of(owner, MethodType.methodType(void.class, paramTypes));
+    }
+
+    /**
+     * {@return a constructor descriptor for the given constructor}
+     *
+     * @param ctor the constructor (must not be {@code null})
+     */
+    static ConstructorDesc of(Constructor<?> ctor) {
+        return of(ctor.getDeclaringClass(), ctor.getParameterTypes());
     }
 
     /**

--- a/src/main/java/io/quarkus/gizmo2/desc/FieldDesc.java
+++ b/src/main/java/io/quarkus/gizmo2/desc/FieldDesc.java
@@ -3,6 +3,7 @@ package io.quarkus.gizmo2.desc;
 import static io.smallrye.common.constraint.Assert.checkNotNullParam;
 
 import java.lang.constant.ClassDesc;
+import java.lang.reflect.Field;
 
 import io.quarkus.gizmo2.SimpleTyped;
 import io.quarkus.gizmo2.impl.FieldDescImpl;
@@ -51,10 +52,19 @@ public sealed interface FieldDesc extends MemberDesc, SimpleTyped permits FieldD
         checkNotNullParam("owner", owner);
         checkNotNullParam("name", name);
         try {
-            return of(Util.classDesc(owner), name, Util.classDesc(owner.getDeclaredField(name).getType()));
+            return of(owner.getDeclaredField(name));
         } catch (NoSuchFieldException e) {
             throw new IllegalArgumentException("No such field \"" + name + "\" found on " + owner);
         }
+    }
+
+    /**
+     * {@return a field descriptor for the given field}
+     *
+     * @param field the field (must not be {@code null})
+     */
+    static FieldDesc of(Field field) {
+        return of(Util.classDesc(field.getDeclaringClass()), field.getName(), Util.classDesc(field.getType()));
     }
 
     /**

--- a/src/main/java/io/quarkus/gizmo2/desc/MethodDesc.java
+++ b/src/main/java/io/quarkus/gizmo2/desc/MethodDesc.java
@@ -2,6 +2,7 @@ package io.quarkus.gizmo2.desc;
 
 import java.lang.constant.MethodTypeDesc;
 import java.lang.invoke.MethodType;
+import java.lang.reflect.Method;
 import java.util.List;
 
 import io.quarkus.gizmo2.MethodTyped;
@@ -63,5 +64,14 @@ public sealed interface MethodDesc extends MemberDesc, MethodTyped
      */
     static MethodDesc of(Class<?> owner, String name, Class<?> returnType, List<Class<?>> paramTypes) {
         return of(owner, name, MethodType.methodType(returnType, paramTypes));
+    }
+
+    /**
+     * {@return a method descriptor for the given method}
+     *
+     * @param method the method (must not be {@code null})
+     */
+    static MethodDesc of(Method method) {
+        return of(method.getDeclaringClass(), method.getName(), method.getReturnType(), method.getParameterTypes());
     }
 }

--- a/src/main/java/io/quarkus/gizmo2/impl/AnonymousClassCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/AnonymousClassCreatorImpl.java
@@ -43,7 +43,7 @@ public final class AnonymousClassCreatorImpl extends ClassCreatorImpl implements
                 superArgs.add(cc.parameter("p" + i, ctorType.parameterType(i)));
             }
         });
-        this_ = new ThisExpr(type);
+        this_ = new ThisExpr(genericType());
     }
 
     public Var capture(final String name, final Expr value) {

--- a/src/main/java/io/quarkus/gizmo2/impl/Cast.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/Cast.java
@@ -4,12 +4,13 @@ import java.lang.constant.ClassDesc;
 import java.util.function.BiFunction;
 
 import io.quarkus.gizmo2.Expr;
+import io.quarkus.gizmo2.GenericType;
 
 abstract class Cast extends Item {
     final Item a;
-    final ClassDesc toType;
+    final GenericType toType;
 
-    public Cast(final Expr a, final ClassDesc toType) {
+    public Cast(final Expr a, final GenericType toType) {
         this.a = (Item) a;
         this.toType = toType;
     }
@@ -18,7 +19,11 @@ abstract class Cast extends Item {
         return a.process(node.prev(), op);
     }
 
-    public ClassDesc type() {
+    public GenericType genericType() {
         return toType;
+    }
+
+    public ClassDesc type() {
+        return toType.desc();
     }
 }

--- a/src/main/java/io/quarkus/gizmo2/impl/CheckCast.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/CheckCast.java
@@ -1,17 +1,31 @@
 package io.quarkus.gizmo2.impl;
 
-import java.lang.constant.ClassDesc;
+import java.lang.annotation.RetentionPolicy;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
 
 import io.github.dmlloyd.classfile.CodeBuilder;
+import io.github.dmlloyd.classfile.Label;
+import io.github.dmlloyd.classfile.TypeAnnotation;
 import io.quarkus.gizmo2.Expr;
+import io.quarkus.gizmo2.GenericType;
 
 final class CheckCast extends Cast {
+    private Label label;
 
-    CheckCast(final Expr a, final ClassDesc toType) {
+    CheckCast(final Expr a, final GenericType toType) {
         super(a, toType);
     }
 
     public void writeCode(final CodeBuilder cb, final BlockCreatorImpl block) {
-        cb.checkcast(toType);
+        label = cb.newBoundLabel();
+        cb.checkcast(toType.desc());
+    }
+
+    public void writeAnnotations(final RetentionPolicy retention, final ArrayList<TypeAnnotation> annotations) {
+        if (toType.hasAnnotations(retention)) {
+            Util.computeAnnotations(toType, retention, TypeAnnotation.TargetInfo.ofCastExpr(label, 0), annotations,
+                    new ArrayDeque<>());
+        }
     }
 }

--- a/src/main/java/io/quarkus/gizmo2/impl/ClassCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/ClassCreatorImpl.java
@@ -7,9 +7,9 @@ import java.lang.constant.MethodTypeDesc;
 import java.util.function.Consumer;
 
 import io.github.dmlloyd.classfile.ClassBuilder;
-import io.github.dmlloyd.classfile.Signature;
 import io.github.dmlloyd.classfile.extras.reflect.AccessFlag;
 import io.quarkus.gizmo2.ClassOutput;
+import io.quarkus.gizmo2.GenericType;
 import io.quarkus.gizmo2.creator.AbstractMethodCreator;
 import io.quarkus.gizmo2.creator.ClassCreator;
 import io.quarkus.gizmo2.creator.ConstructorCreator;
@@ -32,7 +32,7 @@ public sealed class ClassCreatorImpl extends TypeCreatorImpl implements ClassCre
         super.withFlag(flag);
     }
 
-    public void extends_(final Signature.ClassTypeSig genericType) {
+    public void extends_(final GenericType.OfClass genericType) {
         super.extends_(genericType);
     }
 

--- a/src/main/java/io/quarkus/gizmo2/impl/ClassCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/ClassCreatorImpl.java
@@ -1,6 +1,6 @@
 package io.quarkus.gizmo2.impl;
 
-import static io.smallrye.common.constraint.Assert.checkNotNullParam;
+import static io.smallrye.common.constraint.Assert.*;
 
 import java.lang.constant.ClassDesc;
 import java.lang.constant.MethodTypeDesc;

--- a/src/main/java/io/quarkus/gizmo2/impl/ConstructorCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/ConstructorCreatorImpl.java
@@ -14,6 +14,8 @@ import java.util.List;
 import java.util.Set;
 import java.util.function.Consumer;
 
+import io.quarkus.gizmo2.TypeVariable;
+import io.quarkus.gizmo2.TypeVariableCreator;
 import io.quarkus.gizmo2.creator.BlockCreator;
 import io.quarkus.gizmo2.creator.ConstructorCreator;
 import io.quarkus.gizmo2.desc.ConstructorDesc;
@@ -68,7 +70,13 @@ public final class ConstructorCreatorImpl extends ExecutableCreatorImpl implemen
         super.clearType();
     }
 
-    ElementType annotationTargetType() {
+    public ElementType annotationTargetType() {
         return ElementType.CONSTRUCTOR;
+    }
+
+    public TypeVariable.OfConstructor typeParameter(final String name, final Consumer<TypeVariableCreator> builder) {
+        TypeVariableCreatorImpl creator = new TypeVariableCreatorImpl(name);
+        builder.accept(creator);
+        return creator.forConstructor(desc);
     }
 }

--- a/src/main/java/io/quarkus/gizmo2/impl/ConstructorCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/ConstructorCreatorImpl.java
@@ -77,6 +77,6 @@ public final class ConstructorCreatorImpl extends ExecutableCreatorImpl implemen
     public TypeVariable.OfConstructor typeParameter(final String name, final Consumer<TypeVariableCreator> builder) {
         TypeVariableCreatorImpl creator = new TypeVariableCreatorImpl(name);
         builder.accept(creator);
-        return creator.forConstructor(desc);
+        return addTypeVariable(creator.forConstructor(desc));
     }
 }

--- a/src/main/java/io/quarkus/gizmo2/impl/ExecutableCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/ExecutableCreatorImpl.java
@@ -257,7 +257,24 @@ public sealed abstract class ExecutableCreatorImpl extends AnnotatableCreatorImp
         if ((flags & AccessFlag.STATIC.mask()) == 0) {
             // reserve `this` for all instance methods
             cb.localVariable(0, "this", typeCreator.type(), bc.startLabel(), bc.endLabel());
-            // todo: typeCreator.genericType()
+            GenericType.OfClass genericType = typeCreator.genericType();
+            if (!genericType.isRaw()) {
+                cb.localVariableType(0, "this", Util.signatureOf(genericType), bc.startLabel(), bc.endLabel());
+            }
+            if (genericType.hasVisibleAnnotations()) {
+                Util.computeAnnotations(genericType, RetentionPolicy.RUNTIME, TypeAnnotation.TargetInfo.ofLocalVariable(
+                        List.of(TypeAnnotation.LocalVarTargetInfo.of(bc.startLabel(), bc.endLabel(), 0))),
+                        visible, new ArrayDeque<>());
+                Util.computeAnnotations(genericType, RetentionPolicy.RUNTIME, TypeAnnotation.TargetInfo.ofMethodReceiver(),
+                        visible, new ArrayDeque<>());
+            }
+            if (genericType.hasInvisibleAnnotations()) {
+                Util.computeAnnotations(genericType, RetentionPolicy.CLASS, TypeAnnotation.TargetInfo.ofLocalVariable(
+                        List.of(TypeAnnotation.LocalVarTargetInfo.of(bc.startLabel(), bc.endLabel(), 0))),
+                        invisible, new ArrayDeque<>());
+                Util.computeAnnotations(genericType, RetentionPolicy.CLASS, TypeAnnotation.TargetInfo.ofMethodReceiver(),
+                        invisible, new ArrayDeque<>());
+            }
         }
         for (final ParamVarImpl param : params) {
             if (param != null) {

--- a/src/main/java/io/quarkus/gizmo2/impl/ExecutableCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/ExecutableCreatorImpl.java
@@ -215,6 +215,15 @@ public sealed abstract class ExecutableCreatorImpl extends AnnotatableCreatorImp
             Util.computeAnnotations(genericType, RetentionPolicy.CLASS, TypeAnnotation.TargetInfo.ofMethodFormalParameter(i),
                     invisible, new ArrayDeque<>());
         }
+        for (int i = 0; i < typeVariables.size(); i++) {
+            final TypeVariable tv = typeVariables.get(i);
+            Util.computeAnnotations(tv, RetentionPolicy.RUNTIME,
+                    TypeAnnotation.TargetInfo.ofTypeParameter(TypeAnnotation.TargetType.METHOD_TYPE_PARAMETER, i),
+                    visible, new ArrayDeque<>());
+            Util.computeAnnotations(tv, RetentionPolicy.CLASS,
+                    TypeAnnotation.TargetInfo.ofTypeParameter(TypeAnnotation.TargetType.METHOD_TYPE_PARAMETER, i),
+                    invisible, new ArrayDeque<>());
+        }
         if (builder != null) {
             mb.withCode(cb -> {
                 doCode(builder, cb);

--- a/src/main/java/io/quarkus/gizmo2/impl/ExecutableCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/ExecutableCreatorImpl.java
@@ -1,31 +1,34 @@
 package io.quarkus.gizmo2.impl;
 
-import static io.smallrye.common.constraint.Assert.checkNotNullParam;
-import static java.lang.constant.ConstantDescs.CD_void;
+import static io.smallrye.common.constraint.Assert.*;
+import static java.lang.constant.ConstantDescs.*;
 
 import java.lang.constant.ClassDesc;
 import java.lang.constant.MethodTypeDesc;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.BitSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.stream.IntStream;
-import java.util.stream.Stream;
 
 import io.github.dmlloyd.classfile.Annotation;
 import io.github.dmlloyd.classfile.CodeBuilder;
 import io.github.dmlloyd.classfile.MethodBuilder;
+import io.github.dmlloyd.classfile.MethodSignature;
+import io.github.dmlloyd.classfile.Signature;
 import io.github.dmlloyd.classfile.TypeKind;
 import io.github.dmlloyd.classfile.attribute.ExceptionsAttribute;
 import io.github.dmlloyd.classfile.attribute.MethodParameterInfo;
 import io.github.dmlloyd.classfile.attribute.MethodParametersAttribute;
 import io.github.dmlloyd.classfile.attribute.RuntimeInvisibleParameterAnnotationsAttribute;
 import io.github.dmlloyd.classfile.attribute.RuntimeVisibleParameterAnnotationsAttribute;
+import io.github.dmlloyd.classfile.attribute.SignatureAttribute;
 import io.github.dmlloyd.classfile.extras.reflect.AccessFlag;
+import io.quarkus.gizmo2.GenericType;
 import io.quarkus.gizmo2.ParamVar;
+import io.quarkus.gizmo2.TypeVariable;
 import io.quarkus.gizmo2.creator.BlockCreator;
 import io.quarkus.gizmo2.creator.ExecutableCreator;
 import io.quarkus.gizmo2.creator.ParamCreator;
@@ -33,7 +36,6 @@ import io.quarkus.gizmo2.creator.ParamCreator;
 public sealed abstract class ExecutableCreatorImpl extends AnnotatableCreatorImpl implements ExecutableCreator
         permits ConstructorCreatorImpl, MethodCreatorImpl {
 
-    private static final ParamVarImpl[] NO_PARAMS = new ParamVarImpl[0];
     private static final MethodParameterInfo EMPTY_PI = MethodParameterInfo.of(Optional.empty(), 0);
 
     static final int ST_INITIAL = 0;
@@ -47,13 +49,15 @@ public sealed abstract class ExecutableCreatorImpl extends AnnotatableCreatorImp
     final Set<AccessFlag> allowedFlags;
     final Set<AccessFlag> unremovableFlags;
 
-    ClassDesc returnType;
+    private List<TypeVariable> typeVariables = List.of();
+
+    GenericType genericReturnType;
     boolean typeEstablished;
     MethodTypeDesc type = null;
     int flags;
-    ParamVarImpl[] params = NO_PARAMS;
-    int nextParam;
+    List<ParamVarImpl> params = List.of();
     int state = ST_INITIAL;
+    List<GenericType.OfThrows> genericThrows = List.of();
     List<ClassDesc> throws_ = List.of();
 
     // `defaultFlags` are also flags that cannot be removed
@@ -94,20 +98,20 @@ public sealed abstract class ExecutableCreatorImpl extends AnnotatableCreatorImp
                 return;
             }
             // validate existing information
-            ClassDesc returnType = this.returnType;
-            if (returnType != null && !desc.returnType().equals(returnType)) {
+            GenericType returnType = this.genericReturnType;
+            if (returnType != null && !desc.returnType().equals(returnType.desc())) {
                 throw new IllegalArgumentException(
                         "Type " + desc + " has a return type that does not match established return type " + returnType);
             }
-            int paramCnt = nextParam;
+            int paramCnt = params.size();
             int descParamCnt = desc.parameterCount();
             if (paramCnt > descParamCnt) {
                 throw new IllegalArgumentException(
                         "Existing parameter count (" + paramCnt + ") is greater than the number of parameters in " + desc);
             }
-            ParamVarImpl[] params = this.params;
+            List<ParamVarImpl> params = this.params;
             for (int i = 0; i < paramCnt; i++) {
-                final ParamVarImpl param = params[i];
+                final ParamVarImpl param = params.get(i);
                 if (param != null && !param.type().equals(desc.parameterType(i))) {
                     throw new IllegalArgumentException(
                             "Defined parameter " + i + " has a type of " + param.type() + " which conflicts with " + desc);
@@ -115,10 +119,15 @@ public sealed abstract class ExecutableCreatorImpl extends AnnotatableCreatorImp
             }
             clearType();
             type = desc;
-            this.returnType = desc.returnType();
-            if (params.length != descParamCnt) {
-                // exactly size the array
-                this.params = Arrays.copyOf(params, descParamCnt);
+            this.genericReturnType = GenericType.of(desc.returnType());
+            if (params.size() != descParamCnt) {
+                if (params instanceof ArrayList<ParamVarImpl> al) {
+                    al.ensureCapacity(descParamCnt);
+                } else {
+                    // exactly size the array
+                    this.params = new ArrayList<>(descParamCnt);
+                    this.params.addAll(params);
+                }
             }
             typeEstablished = true;
         }
@@ -127,36 +136,41 @@ public sealed abstract class ExecutableCreatorImpl extends AnnotatableCreatorImp
     MethodTypeDesc computeType() {
         assert type == null;
         return MethodTypeDesc.of(returnType(),
-                IntStream.range(0, nextParam).mapToObj(this::param).map(ParamVarImpl::type).toArray(ClassDesc[]::new));
+                params.stream().map(ParamVarImpl::type).toArray(ClassDesc[]::new));
     }
 
-    private ParamVarImpl param(int idx) {
-        return params[idx];
-    }
-
-    public ClassDesc returnType() {
-        ClassDesc returnType = this.returnType;
+    public GenericType genericReturnType() {
+        GenericType returnType = this.genericReturnType;
         if (returnType == null) {
-            return CD_void;
+            return GenericType.of(CD_void);
         }
         return returnType;
     }
 
-    void returning(final ClassDesc type) {
+    public ClassDesc returnType() {
+        return genericReturnType().desc();
+    }
+
+    void returning(final GenericType type) {
         checkNotNullParam("type", type);
         if (state >= ST_BODY) {
             throw new IllegalStateException("Return type may no longer be changed");
         }
-        ClassDesc returnType = this.returnType;
+        GenericType returnType = this.genericReturnType;
         if (returnType == null) {
             assert !typeEstablished;
-            this.returnType = type;
+            this.genericReturnType = type;
         } else if (!returnType.equals(type)) {
             throw new IllegalArgumentException("Return type " + type + " does not match established return type " + returnType);
         }
     }
 
+    void returning(final ClassDesc type) {
+        returning(GenericType.of(type));
+    }
+
     void doBody(final Consumer<BlockCreator> builder, MethodBuilder mb) {
+        mb.with(SignatureAttribute.of(computeSignature()));
         mb.withFlags(flags);
         addVisible(mb);
         addInvisible(mb);
@@ -165,24 +179,19 @@ public sealed abstract class ExecutableCreatorImpl extends AnnotatableCreatorImp
             mb.with(ExceptionsAttribute.of(throws_.stream().map(cd -> typeCreator.zb.constantPool().classEntry(cd)).toList()));
         }
         // lock parameters
-        int arraySize = params.length;
-        int parameterCount = type().parameterCount();
-        if (parameterCount != arraySize) {
-            params = Arrays.copyOf(params, parameterCount);
-        }
-        List<MethodParameterInfo> mpi = Stream.of(params)
+        List<MethodParameterInfo> mpi = params.stream()
                 .map(pv -> pv == null ? EMPTY_PI : MethodParameterInfo.ofParameter(Optional.of(pv.name()), pv.flags()))
                 .toList();
         if (!mpi.isEmpty()) {
             mb.with(MethodParametersAttribute.of(mpi));
         }
         // find parameter annotations, if any
-        if (Stream.of(params).anyMatch(pvi -> !pvi.visible.isEmpty())) {
-            mb.with(RuntimeVisibleParameterAnnotationsAttribute.of(Stream.of(params).map(
+        if (params.stream().anyMatch(pvi -> !pvi.visible.isEmpty())) {
+            mb.with(RuntimeVisibleParameterAnnotationsAttribute.of(params.stream().map(
                     pvi -> pvi != null ? pvi.visible : List.<Annotation> of()).toList()));
         }
-        if (Stream.of(params).anyMatch(pvi -> !pvi.invisible.isEmpty())) {
-            mb.with(RuntimeInvisibleParameterAnnotationsAttribute.of(Stream.of(params).map(
+        if (params.stream().anyMatch(pvi -> !pvi.invisible.isEmpty())) {
+            mb.with(RuntimeInvisibleParameterAnnotationsAttribute.of(params.stream().map(
                     pvi -> pvi != null ? pvi.invisible : List.<Annotation> of()).toList()));
         }
         if (builder != null) {
@@ -190,6 +199,14 @@ public sealed abstract class ExecutableCreatorImpl extends AnnotatableCreatorImp
                 doCode(builder, cb);
             });
         }
+    }
+
+    MethodSignature computeSignature() {
+        return MethodSignature.of(
+                typeVariables.stream().map(Util::typeParamOf).toList(),
+                genericThrows.stream().map(Util::signatureOf).map(Signature.ThrowableSig.class::cast).toList(),
+                Util.signatureOf(genericReturnType()),
+                params.stream().map(ParamVarImpl::genericType).map(Util::signatureOf).toArray(Signature[]::new));
     }
 
     void doCode(final Consumer<BlockCreator> builder, final CodeBuilder cb) {
@@ -233,7 +250,7 @@ public sealed abstract class ExecutableCreatorImpl extends AnnotatableCreatorImp
     }
 
     public ParamVar parameter(final String name, final Consumer<ParamCreator> builder) {
-        return parameter(name, nextParam, builder);
+        return parameter(name, params.size(), builder);
     }
 
     public ParamVar parameter(final String name, final int position, final Consumer<ParamCreator> builder) {
@@ -249,7 +266,7 @@ public sealed abstract class ExecutableCreatorImpl extends AnnotatableCreatorImp
         ParamCreatorImpl pc;
         if (type == null) {
             // all parameters not established
-            int size = nextParam;
+            int size = params.size();
             if (position != size) {
                 throw new IllegalStateException(
                         "Cannot define positional parameter with index " + position + " before the type has been established");
@@ -257,20 +274,15 @@ public sealed abstract class ExecutableCreatorImpl extends AnnotatableCreatorImp
             if (size == 0) {
                 slot = firstSlot();
             } else {
-                ParamVarImpl last = params[size - 1];
+                ParamVarImpl last = params.get(size - 1);
                 slot = last.slot() + last.slotSize();
             }
             pc = new ParamCreatorImpl();
-            if (params.length == nextParam) {
-                // grow it
-                params = Arrays.copyOf(params, params.length + 5);
-            }
         } else {
             if (position < 0 || position > type.parameterCount()) {
                 throw new IndexOutOfBoundsException("Parameter position " + position + " is out of bounds for type " + type);
             }
-            ParamVarImpl existing = params[position];
-            if (existing != null) {
+            if (position < params.size()) {
                 throw new IllegalStateException("Parameter already defined at position " + position);
             }
             pc = new ParamCreatorImpl(type.parameterType(position));
@@ -278,13 +290,16 @@ public sealed abstract class ExecutableCreatorImpl extends AnnotatableCreatorImp
                     .mapToInt(TypeKind::slotSize).sum();
         }
         ParamVarImpl pv = pc.apply(builder, name, position, slot);
-        params[position] = pv;
+        if (params instanceof ArrayList<ParamVarImpl> al) {
+            al.add(pv);
+        } else {
+            params = Util.listWith(params, pv);
+        }
         locals.set(slot);
         if (TypeKind.from(pv.type()).slotSize() == 2) {
             // reserve the next slot as well
             locals.set(slot + 1);
         }
-        nextParam = position + 1;
         return pv;
     }
 
@@ -355,5 +370,14 @@ public sealed abstract class ExecutableCreatorImpl extends AnnotatableCreatorImp
         for (AccessFlag flag : flags) {
             withoutFlag(flag);
         }
+    }
+
+    <T extends TypeVariable> T addTypeVariable(T var) {
+        if (typeVariables instanceof ArrayList<TypeVariable> al) {
+            al.add(var);
+        } else {
+            typeVariables = Util.listWith(typeVariables, var);
+        }
+        return var;
     }
 }

--- a/src/main/java/io/quarkus/gizmo2/impl/ExecutableCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/ExecutableCreatorImpl.java
@@ -215,6 +215,11 @@ public sealed abstract class ExecutableCreatorImpl extends AnnotatableCreatorImp
             Util.computeAnnotations(genericType, RetentionPolicy.CLASS, TypeAnnotation.TargetInfo.ofMethodFormalParameter(i),
                     invisible, new ArrayDeque<>());
         }
+        Util.computeAnnotations(genericReturnType(), RetentionPolicy.RUNTIME, TypeAnnotation.TargetInfo.ofMethodReturn(),
+                visible, new ArrayDeque<>());
+        Util.computeAnnotations(genericReturnType(), RetentionPolicy.CLASS, TypeAnnotation.TargetInfo.ofMethodReturn(),
+                invisible, new ArrayDeque<>());
+        // todo: `this` type annotations and generic type
         for (int i = 0; i < typeVariables.size(); i++) {
             final TypeVariable tv = typeVariables.get(i);
             Util.computeAnnotations(tv, RetentionPolicy.RUNTIME,

--- a/src/main/java/io/quarkus/gizmo2/impl/FieldCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/FieldCreatorImpl.java
@@ -4,9 +4,16 @@ import static io.smallrye.common.constraint.Assert.*;
 import static java.lang.constant.ConstantDescs.*;
 
 import java.lang.annotation.ElementType;
+import java.lang.annotation.RetentionPolicy;
 import java.lang.constant.ClassDesc;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
 import java.util.Set;
 
+import io.github.dmlloyd.classfile.FieldBuilder;
+import io.github.dmlloyd.classfile.TypeAnnotation;
+import io.github.dmlloyd.classfile.attribute.RuntimeInvisibleTypeAnnotationsAttribute;
+import io.github.dmlloyd.classfile.attribute.RuntimeVisibleTypeAnnotationsAttribute;
 import io.github.dmlloyd.classfile.extras.reflect.AccessFlag;
 import io.quarkus.gizmo2.GenericType;
 import io.quarkus.gizmo2.creator.FieldCreator;
@@ -130,5 +137,20 @@ public abstract sealed class FieldCreatorImpl extends AnnotatableCreatorImpl imp
 
     public ElementType annotationTargetType() {
         return ElementType.FIELD;
+    }
+
+    void addTypeAnnotations(final FieldBuilder fb) {
+        ArrayList<TypeAnnotation> visible = new ArrayList<>();
+        ArrayList<TypeAnnotation> invisible = new ArrayList<>();
+        Util.computeAnnotations(genericType, RetentionPolicy.RUNTIME, TypeAnnotation.TargetInfo.ofField(),
+                visible, new ArrayDeque<>());
+        Util.computeAnnotations(genericType, RetentionPolicy.CLASS, TypeAnnotation.TargetInfo.ofField(),
+                invisible, new ArrayDeque<>());
+        if (!visible.isEmpty()) {
+            fb.with(RuntimeVisibleTypeAnnotationsAttribute.of(visible));
+        }
+        if (!invisible.isEmpty()) {
+            fb.with(RuntimeInvisibleTypeAnnotationsAttribute.of(invisible));
+        }
     }
 }

--- a/src/main/java/io/quarkus/gizmo2/impl/FieldCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/FieldCreatorImpl.java
@@ -123,7 +123,7 @@ public abstract sealed class FieldCreatorImpl extends AnnotatableCreatorImpl imp
         return type;
     }
 
-    ElementType annotationTargetType() {
+    public ElementType annotationTargetType() {
         return ElementType.FIELD;
     }
 }

--- a/src/main/java/io/quarkus/gizmo2/impl/InstanceFieldCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/InstanceFieldCreatorImpl.java
@@ -4,6 +4,7 @@ import java.lang.constant.ClassDesc;
 import java.util.Set;
 import java.util.function.Consumer;
 
+import io.github.dmlloyd.classfile.attribute.SignatureAttribute;
 import io.quarkus.gizmo2.Const;
 import io.quarkus.gizmo2.creator.BlockCreator;
 import io.quarkus.gizmo2.creator.InstanceFieldCreator;
@@ -52,6 +53,7 @@ public final class InstanceFieldCreatorImpl extends FieldCreatorImpl implements 
         }
         tc.zb.withField(name(), desc().type(), fb -> {
             fb.withFlags(flags);
+            fb.with(SignatureAttribute.of(Util.signatureOf(genericType())));
             addVisible(fb);
             addInvisible(fb);
         });

--- a/src/main/java/io/quarkus/gizmo2/impl/InstanceFieldCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/InstanceFieldCreatorImpl.java
@@ -56,6 +56,7 @@ public final class InstanceFieldCreatorImpl extends FieldCreatorImpl implements 
             fb.with(SignatureAttribute.of(Util.signatureOf(genericType())));
             addVisible(fb);
             addInvisible(fb);
+            addTypeAnnotations(fb);
         });
     }
 }

--- a/src/main/java/io/quarkus/gizmo2/impl/InstanceFieldCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/InstanceFieldCreatorImpl.java
@@ -32,8 +32,7 @@ public final class InstanceFieldCreatorImpl extends FieldCreatorImpl implements 
         checkOneInit();
         initializer = (b0 -> {
             FieldDesc desc = desc();
-            // todo: replace ThisExpr from a shared instance on TypeCreator
-            b0.set(new ThisExpr(owner()).field(desc), b0.blockExpr(desc.type(), init));
+            b0.set(tc.this_().field(desc), b0.blockExpr(desc.type(), init));
         });
     }
 
@@ -46,8 +45,7 @@ public final class InstanceFieldCreatorImpl extends FieldCreatorImpl implements 
     void accept(final Consumer<InstanceFieldCreator> builder) {
         builder.accept(this);
         if (initial != null) {
-            // todo: replace ThisExpr from a shared instance on TypeCreator
-            tc.instancePreinitializer(b0 -> b0.set(new ThisExpr(owner()).field(desc()), initial));
+            tc.instancePreinitializer(b0 -> b0.set(tc.this_().field(desc()), initial));
         } else if (initializer != null) {
             tc.instanceInitializer(initializer);
         }

--- a/src/main/java/io/quarkus/gizmo2/impl/InstanceOf.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/InstanceOf.java
@@ -1,17 +1,24 @@
 package io.quarkus.gizmo2.impl;
 
+import java.lang.annotation.RetentionPolicy;
 import java.lang.constant.ClassDesc;
 import java.lang.constant.ConstantDescs;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
 import java.util.function.BiFunction;
 
 import io.github.dmlloyd.classfile.CodeBuilder;
+import io.github.dmlloyd.classfile.Label;
+import io.github.dmlloyd.classfile.TypeAnnotation;
 import io.quarkus.gizmo2.Expr;
+import io.quarkus.gizmo2.GenericType;
 
 final class InstanceOf extends Item {
     private final Item input;
-    private final ClassDesc type;
+    private final GenericType type;
+    private Label label;
 
-    InstanceOf(final Expr input, final ClassDesc type) {
+    InstanceOf(final Expr input, final GenericType type) {
         this.input = (Item) input;
         this.type = type;
     }
@@ -25,6 +32,14 @@ final class InstanceOf extends Item {
     }
 
     public void writeCode(final CodeBuilder cb, final BlockCreatorImpl block) {
-        cb.instanceOf(type);
+        label = cb.newBoundLabel();
+        cb.instanceOf(type.desc());
+    }
+
+    public void writeAnnotations(final RetentionPolicy retention, final ArrayList<TypeAnnotation> annotations) {
+        if (type.hasAnnotations(retention)) {
+            Util.computeAnnotations(type, retention, TypeAnnotation.TargetInfo.ofInstanceofExpr(label), annotations,
+                    new ArrayDeque<>());
+        }
     }
 }

--- a/src/main/java/io/quarkus/gizmo2/impl/InterfaceCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/InterfaceCreatorImpl.java
@@ -1,6 +1,6 @@
 package io.quarkus.gizmo2.impl;
 
-import static io.smallrye.common.constraint.Assert.checkNotNullParam;
+import static io.smallrye.common.constraint.Assert.*;
 
 import java.lang.constant.ClassDesc;
 import java.lang.constant.MethodTypeDesc;

--- a/src/main/java/io/quarkus/gizmo2/impl/Item.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/Item.java
@@ -2,11 +2,14 @@ package io.quarkus.gizmo2.impl;
 
 import static io.smallrye.common.constraint.Assert.checkNotNullParam;
 
+import java.lang.annotation.RetentionPolicy;
 import java.lang.constant.ClassDesc;
 import java.lang.constant.ConstantDescs;
+import java.util.ArrayList;
 import java.util.function.BiFunction;
 
 import io.github.dmlloyd.classfile.CodeBuilder;
+import io.github.dmlloyd.classfile.TypeAnnotation;
 import io.quarkus.gizmo2.Assignable;
 import io.quarkus.gizmo2.Expr;
 import io.quarkus.gizmo2.InstanceFieldVar;
@@ -187,6 +190,9 @@ public abstract non-sealed class Item implements Expr {
     }
 
     public abstract void writeCode(CodeBuilder cb, BlockCreatorImpl block);
+
+    public void writeAnnotations(final RetentionPolicy retention, ArrayList<TypeAnnotation> annotations) {
+    }
 
     /**
      * {@return true if this node may fall through to the next node}

--- a/src/main/java/io/quarkus/gizmo2/impl/LocalVarAllocator.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/LocalVarAllocator.java
@@ -1,11 +1,19 @@
 package io.quarkus.gizmo2.impl;
 
+import java.lang.annotation.RetentionPolicy;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.List;
+
 import io.github.dmlloyd.classfile.CodeBuilder;
 import io.github.dmlloyd.classfile.Label;
+import io.github.dmlloyd.classfile.TypeAnnotation;
 import io.quarkus.gizmo2.GenericType;
 
 final class LocalVarAllocator extends Item {
     private final LocalVarImpl localVar;
+    private Label startScope;
+    private Label endScope;
 
     LocalVarAllocator(final LocalVarImpl localVar) {
         this.localVar = localVar;
@@ -14,8 +22,8 @@ final class LocalVarAllocator extends Item {
     public void writeCode(final CodeBuilder cb, final BlockCreatorImpl block) {
         int slot = cb.allocateLocal(Util.actualKindOf(localVar.typeKind()));
         // we reserve the slot for the full remainder of the block to avoid control-flow analysis
-        Label startScope = cb.newBoundLabel();
-        Label endScope = block.endLabel();
+        startScope = cb.newBoundLabel();
+        endScope = block.endLabel();
         cb.localVariable(slot, localVar.name(), localVar.type(), startScope, endScope);
         GenericType gt = localVar.genericType();
         if (gt instanceof GenericType.OfClass oc && !oc.typeArguments().isEmpty()) {
@@ -26,5 +34,14 @@ final class LocalVarAllocator extends Item {
             throw new IllegalStateException("Local variable reallocated into a different slot");
         }
         localVar.slot = slot;
+    }
+
+    public void writeAnnotations(final RetentionPolicy retention, final ArrayList<TypeAnnotation> annotations) {
+        if (localVar.genericType().hasAnnotations(retention)) {
+            Util.computeAnnotations(localVar.genericType(), retention, TypeAnnotation.TargetInfo.ofLocalVariable(
+                    List.of(
+                            TypeAnnotation.LocalVarTargetInfo.of(startScope, endScope, localVar.slot))),
+                    annotations, new ArrayDeque<>());
+        }
     }
 }

--- a/src/main/java/io/quarkus/gizmo2/impl/LocalVarAllocator.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/LocalVarAllocator.java
@@ -26,12 +26,8 @@ final class LocalVarAllocator extends Item {
         endScope = block.endLabel();
         cb.localVariable(slot, localVar.name(), localVar.type(), startScope, endScope);
         GenericType gt = localVar.genericType();
-        if (gt instanceof GenericType.OfClass oc && !oc.typeArguments().isEmpty()) {
+        if (!gt.isRaw()) {
             cb.localVariableType(slot, localVar.name(), Util.signatureOf(gt), startScope, endScope);
-        }
-        int lvSlot = localVar.slot;
-        if (lvSlot != -1 && slot != lvSlot) {
-            throw new IllegalStateException("Local variable reallocated into a different slot");
         }
         localVar.slot = slot;
     }

--- a/src/main/java/io/quarkus/gizmo2/impl/LocalVarAllocator.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/LocalVarAllocator.java
@@ -1,6 +1,8 @@
 package io.quarkus.gizmo2.impl;
 
 import io.github.dmlloyd.classfile.CodeBuilder;
+import io.github.dmlloyd.classfile.Label;
+import io.quarkus.gizmo2.GenericType;
 
 final class LocalVarAllocator extends Item {
     private final LocalVarImpl localVar;
@@ -12,7 +14,13 @@ final class LocalVarAllocator extends Item {
     public void writeCode(final CodeBuilder cb, final BlockCreatorImpl block) {
         int slot = cb.allocateLocal(Util.actualKindOf(localVar.typeKind()));
         // we reserve the slot for the full remainder of the block to avoid control-flow analysis
-        cb.localVariable(slot, localVar.name(), localVar.type(), cb.newBoundLabel(), block.endLabel());
+        Label startScope = cb.newBoundLabel();
+        Label endScope = block.endLabel();
+        cb.localVariable(slot, localVar.name(), localVar.type(), startScope, endScope);
+        GenericType gt = localVar.genericType();
+        if (gt instanceof GenericType.OfClass oc && !oc.typeArguments().isEmpty()) {
+            cb.localVariableType(slot, localVar.name(), Util.signatureOf(gt), startScope, endScope);
+        }
         int lvSlot = localVar.slot;
         if (lvSlot != -1 && slot != lvSlot) {
             throw new IllegalStateException("Local variable reallocated into a different slot");

--- a/src/main/java/io/quarkus/gizmo2/impl/LocalVarImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/LocalVarImpl.java
@@ -4,6 +4,7 @@ import java.lang.constant.ClassDesc;
 
 import io.github.dmlloyd.classfile.CodeBuilder;
 import io.quarkus.gizmo2.Const;
+import io.quarkus.gizmo2.GenericType;
 import io.quarkus.gizmo2.LocalVar;
 import io.quarkus.gizmo2.MemoryOrder;
 import io.quarkus.gizmo2.TypeKind;
@@ -11,11 +12,11 @@ import io.quarkus.gizmo2.creator.BlockCreator;
 
 public final class LocalVarImpl extends AssignableImpl implements LocalVar {
     private final String name;
-    private final ClassDesc type;
+    private final GenericType type;
     private final BlockCreatorImpl owner;
     int slot = -1;
 
-    LocalVarImpl(final BlockCreatorImpl owner, final String name, final ClassDesc type) {
+    LocalVarImpl(final BlockCreatorImpl owner, final String name, final GenericType type) {
         this.name = name;
         this.type = type;
         this.owner = owner;
@@ -34,6 +35,10 @@ public final class LocalVarImpl extends AssignableImpl implements LocalVar {
     }
 
     public ClassDesc type() {
+        return type.desc();
+    }
+
+    public GenericType genericType() {
         return type;
     }
 

--- a/src/main/java/io/quarkus/gizmo2/impl/MethodCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/MethodCreatorImpl.java
@@ -3,8 +3,11 @@ package io.quarkus.gizmo2.impl;
 import java.lang.annotation.ElementType;
 import java.lang.constant.ClassDesc;
 import java.util.Set;
+import java.util.function.Consumer;
 
 import io.github.dmlloyd.classfile.extras.reflect.AccessFlag;
+import io.quarkus.gizmo2.TypeVariable;
+import io.quarkus.gizmo2.TypeVariableCreator;
 import io.quarkus.gizmo2.creator.MethodCreator;
 import io.quarkus.gizmo2.desc.MethodDesc;
 
@@ -42,7 +45,13 @@ public abstract sealed class MethodCreatorImpl extends ExecutableCreatorImpl imp
         return name;
     }
 
-    ElementType annotationTargetType() {
+    public ElementType annotationTargetType() {
         return ElementType.METHOD;
+    }
+
+    public TypeVariable.OfMethod typeParameter(final String name, final Consumer<TypeVariableCreator> builder) {
+        TypeVariableCreatorImpl creator = new TypeVariableCreatorImpl(name);
+        builder.accept(creator);
+        return creator.forMethod(desc);
     }
 }

--- a/src/main/java/io/quarkus/gizmo2/impl/MethodCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/MethodCreatorImpl.java
@@ -6,6 +6,7 @@ import java.util.Set;
 import java.util.function.Consumer;
 
 import io.github.dmlloyd.classfile.extras.reflect.AccessFlag;
+import io.quarkus.gizmo2.GenericType;
 import io.quarkus.gizmo2.TypeVariable;
 import io.quarkus.gizmo2.TypeVariableCreator;
 import io.quarkus.gizmo2.creator.MethodCreator;
@@ -32,6 +33,10 @@ public abstract sealed class MethodCreatorImpl extends ExecutableCreatorImpl imp
         return desc;
     }
 
+    public void returning(final GenericType type) {
+        super.returning(type);
+    }
+
     public void returning(final ClassDesc type) {
         super.returning(type);
     }
@@ -52,6 +57,6 @@ public abstract sealed class MethodCreatorImpl extends ExecutableCreatorImpl imp
     public TypeVariable.OfMethod typeParameter(final String name, final Consumer<TypeVariableCreator> builder) {
         TypeVariableCreatorImpl creator = new TypeVariableCreatorImpl(name);
         builder.accept(creator);
-        return creator.forMethod(desc);
+        return addTypeVariable(creator.forMethod(desc));
     }
 }

--- a/src/main/java/io/quarkus/gizmo2/impl/New.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/New.java
@@ -1,26 +1,45 @@
 package io.quarkus.gizmo2.impl;
 
+import java.lang.annotation.RetentionPolicy;
 import java.lang.constant.ClassDesc;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
 
 import io.github.dmlloyd.classfile.CodeBuilder;
+import io.github.dmlloyd.classfile.Label;
+import io.github.dmlloyd.classfile.TypeAnnotation;
+import io.quarkus.gizmo2.GenericType;
 
 final class New extends Item {
-    private final ClassDesc type;
+    private final GenericType type;
+    private Label label;
 
-    New(final ClassDesc type) {
+    New(final GenericType type) {
         this.type = type;
     }
 
     @Override
     public String itemName() {
-        return "New:" + type.displayName();
+        return "New:" + type().displayName();
     }
 
-    public ClassDesc type() {
+    public GenericType genericType() {
         return type;
     }
 
+    public ClassDesc type() {
+        return type.desc();
+    }
+
     public void writeCode(final CodeBuilder cb, final BlockCreatorImpl block) {
-        cb.new_(type);
+        label = cb.newBoundLabel();
+        cb.new_(type.desc());
+    }
+
+    public void writeAnnotations(final RetentionPolicy retention, final ArrayList<TypeAnnotation> annotations) {
+        if (type.hasAnnotations(retention)) {
+            Util.computeAnnotations(type, retention, TypeAnnotation.TargetInfo.ofNewExpr(label), annotations,
+                    new ArrayDeque<>());
+        }
     }
 }

--- a/src/main/java/io/quarkus/gizmo2/impl/ParamCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/ParamCreatorImpl.java
@@ -15,24 +15,24 @@ import io.quarkus.gizmo2.creator.ParamCreator;
 public final class ParamCreatorImpl extends AnnotatableCreatorImpl implements ParamCreator {
     int flags = 0;
     boolean typeEstablished;
-    ClassDesc type;
     GenericType genericType;
 
     public ParamCreatorImpl() {
     }
 
-    public ParamCreatorImpl(final ClassDesc type) {
-        this.type = type;
+    public ParamCreatorImpl(final GenericType type) {
+        this.genericType = type;
         typeEstablished = true;
     }
 
     ParamVarImpl apply(final Consumer<ParamCreator> builder, final String name, final int index, final int slot) {
         builder.accept(this);
-        if (type == null) {
+        if (genericType == null) {
             throw new IllegalStateException("Parameter type was not set");
         }
         typeEstablished = true;
-        return new ParamVarImpl(type, name, index, slot, flags, List.copyOf(invisible.values()), List.copyOf(visible.values()));
+        return new ParamVarImpl(genericType, name, index, slot, flags, List.copyOf(invisible.values()),
+                List.copyOf(visible.values()));
     }
 
     public void withFlag(final AccessFlag flag) {
@@ -48,37 +48,24 @@ public final class ParamCreatorImpl extends AnnotatableCreatorImpl implements Pa
         if (genericType.desc().equals(ConstantDescs.CD_void)) {
             throw new IllegalArgumentException("Bad genericType for parameter: " + genericType);
         }
-        if (typeEstablished && !genericType.desc().equals(this.type)) {
+        if (typeEstablished && !genericType.equals(this.genericType)) {
             throw new IllegalArgumentException(
-                    "Given genericType " + genericType + " differs from established genericType " + this.type);
+                    "Given type " + genericType + " differs from established type " + this.genericType);
         }
         this.genericType = genericType;
     }
 
     public void withType(final ClassDesc type) {
         checkNotNullParam("type", type);
-        if (type.equals(ConstantDescs.CD_void)) {
-            throw new IllegalArgumentException("Bad type for parameter: " + type);
-        }
-        if (typeEstablished && !type.equals(this.type)) {
-            throw new IllegalArgumentException("Given type " + type + " differs from established type " + this.type);
-        }
-        this.type = type;
-    }
-
-    void establishType(ClassDesc type) {
-        if (typeEstablished) {
-            if (!type.equals(this.type)) {
-                throw new IllegalArgumentException("Established type " + type + " differs from existing type " + this.type);
-            }
-        } else {
-            this.type = type;
-            typeEstablished = true;
-        }
+        withType(GenericType.of(type));
     }
 
     public ClassDesc type() {
-        return type;
+        return genericType.desc();
+    }
+
+    public GenericType genericType() {
+        return genericType;
     }
 
     public ElementType annotationTargetType() {

--- a/src/main/java/io/quarkus/gizmo2/impl/ParamCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/ParamCreatorImpl.java
@@ -67,7 +67,7 @@ public final class ParamCreatorImpl extends AnnotatableCreatorImpl implements Pa
         return type;
     }
 
-    ElementType annotationTargetType() {
+    public ElementType annotationTargetType() {
         return ElementType.PARAMETER;
     }
 }

--- a/src/main/java/io/quarkus/gizmo2/impl/ParamCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/ParamCreatorImpl.java
@@ -9,12 +9,14 @@ import java.util.List;
 import java.util.function.Consumer;
 
 import io.github.dmlloyd.classfile.extras.reflect.AccessFlag;
+import io.quarkus.gizmo2.GenericType;
 import io.quarkus.gizmo2.creator.ParamCreator;
 
 public final class ParamCreatorImpl extends AnnotatableCreatorImpl implements ParamCreator {
     int flags = 0;
     boolean typeEstablished;
     ClassDesc type;
+    GenericType genericType;
 
     public ParamCreatorImpl() {
     }
@@ -39,6 +41,18 @@ public final class ParamCreatorImpl extends AnnotatableCreatorImpl implements Pa
         } else {
             throw new IllegalArgumentException("Invalid flag for parameter: " + flag);
         }
+    }
+
+    public void withType(final GenericType genericType) {
+        checkNotNullParam("type", genericType);
+        if (genericType.desc().equals(ConstantDescs.CD_void)) {
+            throw new IllegalArgumentException("Bad genericType for parameter: " + genericType);
+        }
+        if (typeEstablished && !genericType.desc().equals(this.type)) {
+            throw new IllegalArgumentException(
+                    "Given genericType " + genericType + " differs from established genericType " + this.type);
+        }
+        this.genericType = genericType;
     }
 
     public void withType(final ClassDesc type) {

--- a/src/main/java/io/quarkus/gizmo2/impl/ParamVarImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/ParamVarImpl.java
@@ -5,11 +5,12 @@ import java.util.List;
 
 import io.github.dmlloyd.classfile.Annotation;
 import io.github.dmlloyd.classfile.CodeBuilder;
+import io.quarkus.gizmo2.GenericType;
 import io.quarkus.gizmo2.MemoryOrder;
 import io.quarkus.gizmo2.ParamVar;
 
 public final class ParamVarImpl extends AssignableImpl implements ParamVar {
-    private final ClassDesc type;
+    private final GenericType type;
     private final String name;
     private final int index;
     private final int slot;
@@ -17,7 +18,7 @@ public final class ParamVarImpl extends AssignableImpl implements ParamVar {
     final List<Annotation> visible;
     private final int flags;
 
-    public ParamVarImpl(final ClassDesc type, final String name, final int index, final int slot, final int flags,
+    public ParamVarImpl(final GenericType type, final String name, final int index, final int slot, final int flags,
             final List<Annotation> invisible, final List<Annotation> visible) {
         this.type = type;
         this.name = name;
@@ -54,6 +55,10 @@ public final class ParamVarImpl extends AssignableImpl implements ParamVar {
     }
 
     public ClassDesc type() {
+        return type.desc();
+    }
+
+    public GenericType genericType() {
         return type;
     }
 

--- a/src/main/java/io/quarkus/gizmo2/impl/PrimitiveCast.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/PrimitiveCast.java
@@ -1,18 +1,17 @@
 package io.quarkus.gizmo2.impl;
 
-import java.lang.constant.ClassDesc;
-
 import io.github.dmlloyd.classfile.CodeBuilder;
 import io.github.dmlloyd.classfile.TypeKind;
 import io.quarkus.gizmo2.Expr;
+import io.quarkus.gizmo2.GenericType;
 
 final class PrimitiveCast extends Cast {
 
-    PrimitiveCast(final Expr a, final ClassDesc toType) {
+    PrimitiveCast(final Expr a, final GenericType toType) {
         super(a, toType);
     }
 
     public void writeCode(final CodeBuilder cb, final BlockCreatorImpl block) {
-        cb.conversion(Util.actualKindOf(a.typeKind()), TypeKind.from(toType));
+        cb.conversion(Util.actualKindOf(a.typeKind()), TypeKind.from(toType.desc()));
     }
 }

--- a/src/main/java/io/quarkus/gizmo2/impl/StaticFieldCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/StaticFieldCreatorImpl.java
@@ -10,6 +10,7 @@ import java.util.Set;
 import java.util.function.Consumer;
 
 import io.github.dmlloyd.classfile.attribute.ConstantValueAttribute;
+import io.github.dmlloyd.classfile.attribute.SignatureAttribute;
 import io.quarkus.gizmo2.Const;
 import io.quarkus.gizmo2.creator.BlockCreator;
 import io.quarkus.gizmo2.creator.StaticFieldCreator;
@@ -58,6 +59,7 @@ public final class StaticFieldCreatorImpl extends FieldCreatorImpl implements St
         }
         tc.zb.withField(name(), desc().type(), fb -> {
             fb.withFlags(flags);
+            fb.with(SignatureAttribute.of(Util.signatureOf(genericType())));
             addVisible(fb);
             addInvisible(fb);
             if (initial != null) {

--- a/src/main/java/io/quarkus/gizmo2/impl/ThisExpr.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/ThisExpr.java
@@ -3,12 +3,13 @@ package io.quarkus.gizmo2.impl;
 import java.lang.constant.ClassDesc;
 
 import io.github.dmlloyd.classfile.CodeBuilder;
+import io.quarkus.gizmo2.GenericType;
 import io.quarkus.gizmo2.This;
 
 public final class ThisExpr extends Item implements This {
-    private final ClassDesc type;
+    private final GenericType type;
 
-    ThisExpr(final ClassDesc type) {
+    public ThisExpr(final GenericType type) {
         this.type = type;
     }
 
@@ -17,6 +18,10 @@ public final class ThisExpr extends Item implements This {
     }
 
     public ClassDesc type() {
+        return type.desc();
+    }
+
+    public GenericType genericType() {
         return type;
     }
 

--- a/src/main/java/io/quarkus/gizmo2/impl/TypeAnnotatableCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/TypeAnnotatableCreatorImpl.java
@@ -1,0 +1,20 @@
+package io.quarkus.gizmo2.impl;
+
+import java.lang.annotation.ElementType;
+import java.util.List;
+
+import io.github.dmlloyd.classfile.Annotation;
+
+public final class TypeAnnotatableCreatorImpl extends AnnotatableCreatorImpl {
+
+    public TypeAnnotatableCreatorImpl() {
+    }
+
+    public TypeAnnotatableCreatorImpl(final List<Annotation> visible, final List<Annotation> invisible) {
+        super(visible, invisible);
+    }
+
+    public ElementType annotationTargetType() {
+        return ElementType.TYPE_USE;
+    }
+}

--- a/src/main/java/io/quarkus/gizmo2/impl/TypeCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/TypeCreatorImpl.java
@@ -93,7 +93,7 @@ public abstract sealed class TypeCreatorImpl extends AnnotatableCreatorImpl impl
     private final ClassOutput output;
     private final ThisExpr this_;
     private ClassDesc superType = ConstantDescs.CD_Object;
-    private GenericType.OfClass superSig = (GenericType.OfClass) GenericType.of(Object.class);
+    private GenericType.OfClass superSig = GenericType.ofClass(Object.class);
     private List<GenericType.OfClass> interfaceSigs = List.of();
     private List<TypeVariable> typeVariables = List.of();
     final ClassBuilder zb;

--- a/src/main/java/io/quarkus/gizmo2/impl/TypeCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/TypeCreatorImpl.java
@@ -43,6 +43,8 @@ import io.quarkus.gizmo2.LocalVar;
 import io.quarkus.gizmo2.ParamVar;
 import io.quarkus.gizmo2.StaticFieldVar;
 import io.quarkus.gizmo2.This;
+import io.quarkus.gizmo2.TypeVariable;
+import io.quarkus.gizmo2.TypeVariableCreator;
 import io.quarkus.gizmo2.creator.BlockCreator;
 import io.quarkus.gizmo2.creator.StaticFieldCreator;
 import io.quarkus.gizmo2.creator.StaticMethodCreator;
@@ -460,8 +462,14 @@ public abstract sealed class TypeCreatorImpl extends AnnotatableCreatorImpl impl
         return List.copyOf(constructors);
     }
 
-    ElementType annotationTargetType() {
+    public ElementType annotationTargetType() {
         return ElementType.TYPE;
+    }
+
+    public TypeVariable typeParameter(final String name, final Consumer<TypeVariableCreator> builder) {
+        TypeVariableCreatorImpl creator = new TypeVariableCreatorImpl(name);
+        builder.accept(creator);
+        return creator.forType(type());
     }
 
     void buildReadLineBoostrapHelper() {

--- a/src/main/java/io/quarkus/gizmo2/impl/TypeVariableCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/TypeVariableCreatorImpl.java
@@ -7,6 +7,7 @@ import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
 import java.lang.reflect.UndeclaredThrowableException;
 import java.util.List;
+import java.util.Optional;
 
 import io.github.dmlloyd.classfile.Annotation;
 import io.quarkus.gizmo2.GenericType;
@@ -14,10 +15,12 @@ import io.quarkus.gizmo2.TypeVariable;
 import io.quarkus.gizmo2.TypeVariableCreator;
 import io.quarkus.gizmo2.desc.ConstructorDesc;
 import io.quarkus.gizmo2.desc.MethodDesc;
+import io.smallrye.common.constraint.Assert;
 
 public final class TypeVariableCreatorImpl extends AnnotatableCreatorImpl implements TypeVariableCreator {
     private final String name;
-    private List<GenericType.OfReference> bounds = List.of();
+    private GenericType.OfReference firstBound;
+    private List<GenericType.OfReference> otherBounds = List.of();
 
     public TypeVariableCreatorImpl(final String name) {
         this.name = name;
@@ -32,12 +35,16 @@ public final class TypeVariableCreatorImpl extends AnnotatableCreatorImpl implem
         return name;
     }
 
-    public void withBounds(final List<GenericType.OfReference> bounds) {
-        this.bounds = List.copyOf(bounds);
+    public void withFirstBound(final GenericType.OfReference bound) {
+        firstBound = Assert.checkNotNullParam("bound", bound);
+    }
+
+    public void withOtherBounds(final List<GenericType.OfReference> bounds) {
+        this.otherBounds = List.copyOf(bounds);
     }
 
     public List<GenericType.OfReference> bounds() {
-        return bounds;
+        return otherBounds;
     }
 
     public ElementType annotationTargetType() {
@@ -53,13 +60,13 @@ public final class TypeVariableCreatorImpl extends AnnotatableCreatorImpl implem
             MethodHandles.Lookup lookup = MethodHandles.privateLookupIn(TypeVariable.class, MethodHandles.lookup());
             ofType = lookup.findConstructor(TypeVariable.OfType.class, MethodType.methodType(
                     void.class,
-                    List.class, List.class, String.class, List.class, ClassDesc.class));
+                    List.class, List.class, String.class, Optional.class, List.class, ClassDesc.class));
             ofConstructor = lookup.findConstructor(TypeVariable.OfConstructor.class, MethodType.methodType(
                     void.class,
-                    List.class, List.class, String.class, List.class, ConstructorDesc.class));
+                    List.class, List.class, String.class, Optional.class, List.class, ConstructorDesc.class));
             ofMethod = lookup.findConstructor(TypeVariable.OfMethod.class, MethodType.methodType(
                     void.class,
-                    List.class, List.class, String.class, List.class, MethodDesc.class));
+                    List.class, List.class, String.class, Optional.class, List.class, MethodDesc.class));
         } catch (IllegalAccessException e) {
             throw new IllegalAccessError(e.getMessage());
         } catch (NoSuchMethodException e) {
@@ -73,7 +80,8 @@ public final class TypeVariableCreatorImpl extends AnnotatableCreatorImpl implem
                     List.copyOf(visible.values()),
                     List.copyOf(invisible.values()),
                     name,
-                    bounds,
+                    Optional.ofNullable(firstBound),
+                    otherBounds,
                     desc);
         } catch (RuntimeException | Error e) {
             throw e;
@@ -88,7 +96,8 @@ public final class TypeVariableCreatorImpl extends AnnotatableCreatorImpl implem
                     List.copyOf(visible.values()),
                     List.copyOf(invisible.values()),
                     name,
-                    bounds,
+                    Optional.ofNullable(firstBound),
+                    otherBounds,
                     desc);
         } catch (RuntimeException | Error e) {
             throw e;
@@ -103,7 +112,8 @@ public final class TypeVariableCreatorImpl extends AnnotatableCreatorImpl implem
                     List.copyOf(visible.values()),
                     List.copyOf(invisible.values()),
                     name,
-                    bounds,
+                    Optional.ofNullable(firstBound),
+                    otherBounds,
                     desc);
         } catch (RuntimeException | Error e) {
             throw e;

--- a/src/main/java/io/quarkus/gizmo2/impl/TypeVariableCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/TypeVariableCreatorImpl.java
@@ -1,0 +1,114 @@
+package io.quarkus.gizmo2.impl;
+
+import java.lang.annotation.ElementType;
+import java.lang.constant.ClassDesc;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.lang.reflect.UndeclaredThrowableException;
+import java.util.List;
+
+import io.github.dmlloyd.classfile.Annotation;
+import io.quarkus.gizmo2.GenericType;
+import io.quarkus.gizmo2.TypeVariable;
+import io.quarkus.gizmo2.TypeVariableCreator;
+import io.quarkus.gizmo2.desc.ConstructorDesc;
+import io.quarkus.gizmo2.desc.MethodDesc;
+
+public final class TypeVariableCreatorImpl extends AnnotatableCreatorImpl implements TypeVariableCreator {
+    private final String name;
+    private List<GenericType.OfReference> bounds = List.of();
+
+    public TypeVariableCreatorImpl(final String name) {
+        this.name = name;
+    }
+
+    public TypeVariableCreatorImpl(final List<Annotation> visible, final List<Annotation> invisible, final String name) {
+        super(visible, invisible);
+        this.name = name;
+    }
+
+    public String name() {
+        return name;
+    }
+
+    public void withBounds(final List<GenericType.OfReference> bounds) {
+        this.bounds = List.copyOf(bounds);
+    }
+
+    public List<GenericType.OfReference> bounds() {
+        return bounds;
+    }
+
+    public ElementType annotationTargetType() {
+        return ElementType.TYPE_PARAMETER;
+    }
+
+    private static final MethodHandle ofType;
+    private static final MethodHandle ofConstructor;
+    private static final MethodHandle ofMethod;
+
+    static {
+        try {
+            MethodHandles.Lookup lookup = MethodHandles.privateLookupIn(TypeVariable.class, MethodHandles.lookup());
+            ofType = lookup.findConstructor(TypeVariable.OfType.class, MethodType.methodType(
+                    void.class,
+                    List.class, List.class, String.class, List.class, ClassDesc.class));
+            ofConstructor = lookup.findConstructor(TypeVariable.OfConstructor.class, MethodType.methodType(
+                    void.class,
+                    List.class, List.class, String.class, List.class, ConstructorDesc.class));
+            ofMethod = lookup.findConstructor(TypeVariable.OfMethod.class, MethodType.methodType(
+                    void.class,
+                    List.class, List.class, String.class, List.class, MethodDesc.class));
+        } catch (IllegalAccessException e) {
+            throw new IllegalAccessError(e.getMessage());
+        } catch (NoSuchMethodException e) {
+            throw new NoSuchMethodError(e.getMessage());
+        }
+    }
+
+    TypeVariable.OfConstructor forConstructor(ConstructorDesc desc) {
+        try {
+            return (TypeVariable.OfConstructor) ofConstructor.invokeExact(
+                    List.copyOf(visible.values()),
+                    List.copyOf(invisible.values()),
+                    name,
+                    bounds,
+                    desc);
+        } catch (RuntimeException | Error e) {
+            throw e;
+        } catch (Throwable e) {
+            throw new UndeclaredThrowableException(e);
+        }
+    }
+
+    TypeVariable.OfMethod forMethod(MethodDesc desc) {
+        try {
+            return (TypeVariable.OfMethod) ofMethod.invokeExact(
+                    List.copyOf(visible.values()),
+                    List.copyOf(invisible.values()),
+                    name,
+                    bounds,
+                    desc);
+        } catch (RuntimeException | Error e) {
+            throw e;
+        } catch (Throwable e) {
+            throw new UndeclaredThrowableException(e);
+        }
+    }
+
+    TypeVariable.OfType forType(ClassDesc desc) {
+        try {
+            return (TypeVariable.OfType) ofType.invokeExact(
+                    List.copyOf(visible.values()),
+                    List.copyOf(invisible.values()),
+                    name,
+                    bounds,
+                    desc);
+        } catch (RuntimeException | Error e) {
+            throw e;
+        } catch (Throwable e) {
+            throw new UndeclaredThrowableException(e);
+        }
+    }
+}

--- a/src/main/java/io/quarkus/gizmo2/impl/UncheckedCast.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/UncheckedCast.java
@@ -1,13 +1,12 @@
 package io.quarkus.gizmo2.impl;
 
-import java.lang.constant.ClassDesc;
-
 import io.github.dmlloyd.classfile.CodeBuilder;
 import io.quarkus.gizmo2.Expr;
+import io.quarkus.gizmo2.GenericType;
 
 final class UncheckedCast extends Cast {
 
-    UncheckedCast(final Expr a, final ClassDesc toType) {
+    UncheckedCast(final Expr a, final GenericType toType) {
         super(a, toType);
     }
 

--- a/src/main/java/io/quarkus/gizmo2/impl/Util.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/Util.java
@@ -69,6 +69,7 @@ public final class Util {
 
     private static final MethodHandle actualKind;
     private static final MethodHandle GenericType_computeAnnotations;
+    private static final MethodHandle TypeVariable_computeAnnotations;
 
     static {
         try {
@@ -77,6 +78,13 @@ public final class Util {
             MethodHandles.Lookup genericTypeLookup = MethodHandles.privateLookupIn(GenericType.class, MethodHandles.lookup());
             GenericType_computeAnnotations = genericTypeLookup.findVirtual(
                     GenericType.class, "computeAnnotations", MethodType.methodType(
+                            List.class,
+                            RetentionPolicy.class,
+                            TypeAnnotation.TargetInfo.class,
+                            ArrayList.class,
+                            ArrayDeque.class));
+            TypeVariable_computeAnnotations = genericTypeLookup.findVirtual(
+                    TypeVariable.class, "computeAnnotations", MethodType.methodType(
                             List.class,
                             RetentionPolicy.class,
                             TypeAnnotation.TargetInfo.class,
@@ -455,6 +463,20 @@ public final class Util {
         try {
             var ignored = (List<?>) GenericType_computeAnnotations.invokeExact(
                     type, retention, targetInfo, list, path);
+            return list;
+        } catch (RuntimeException | Error e) {
+            throw e;
+        } catch (Throwable e) {
+            throw new UndeclaredThrowableException(e);
+        }
+    }
+
+    public static List<TypeAnnotation> computeAnnotations(TypeVariable tv, RetentionPolicy retention,
+            TypeAnnotation.TargetInfo targetInfo,
+            ArrayList<TypeAnnotation> list, ArrayDeque<TypeAnnotation.TypePathComponent> path) {
+        try {
+            var ignored = (List<?>) TypeVariable_computeAnnotations.invokeExact(
+                    tv, retention, targetInfo, list, path);
             return list;
         } catch (RuntimeException | Error e) {
             throw e;

--- a/src/test/java/io/quarkus/gizmo2/GenericTypeTest.java
+++ b/src/test/java/io/quarkus/gizmo2/GenericTypeTest.java
@@ -1,0 +1,207 @@
+package io.quarkus.gizmo2;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.lang.constant.ClassDesc;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import io.github.dmlloyd.classfile.Attributes;
+import io.github.dmlloyd.classfile.ClassModel;
+import io.github.dmlloyd.classfile.CodeModel;
+import io.github.dmlloyd.classfile.FieldModel;
+import io.github.dmlloyd.classfile.MethodModel;
+import io.github.dmlloyd.classfile.attribute.LocalVariableTypeInfo;
+import io.github.dmlloyd.classfile.attribute.LocalVariableTypeTableAttribute;
+import io.github.dmlloyd.classfile.attribute.RuntimeInvisibleTypeAnnotationsAttribute;
+import io.github.dmlloyd.classfile.attribute.RuntimeVisibleTypeAnnotationsAttribute;
+import io.github.dmlloyd.classfile.attribute.SignatureAttribute;
+import io.quarkus.gizmo2.creator.BlockCreator;
+
+public final class GenericTypeTest {
+
+    @Test
+    public void testGenericLocalVar() {
+        TestClassMaker tcm = new TestClassMaker();
+        Gizmo g = Gizmo.create(tcm);
+        ClassDesc desc = g.class_("io.quarkus.gizmo2.TestGenericLocalVar", zc -> {
+            zc.staticMethod("test0", mc -> {
+                mc.body(b0 -> {
+                    LocalVar list = b0.declare("list", GenericType.of(List.class, List.of(TypeArgument.of(String.class))));
+                    b0.set(list, Const.ofNull(List.class));
+                    b0.return_();
+                });
+            });
+        });
+        ClassModel model = tcm.forClass(desc).getModel();
+        MethodModel test0 = model.methods().stream().filter(mm -> mm.methodName().equalsString("test0")).findFirst()
+                .orElseThrow();
+        CodeModel test0code = test0.code().orElseThrow();
+        LocalVariableTypeTableAttribute lvtt = test0code.findAttribute(Attributes.localVariableTypeTable()).orElseThrow();
+        assertEquals(1, lvtt.localVariableTypes().size());
+        LocalVariableTypeInfo info = lvtt.localVariableTypes().get(0);
+        assertEquals("list", info.name().stringValue());
+        assertEquals("Ljava/util/List<Ljava/lang/String;>;", info.signature().stringValue());
+    }
+
+    @Test
+    public void testTypeAnnotationLocalVar() {
+        TestClassMaker tcm = new TestClassMaker();
+        Gizmo g = Gizmo.create(tcm);
+        ClassDesc desc = g.class_("io.quarkus.gizmo2.TestTypeAnnotationLocalVar", zc -> {
+            zc.staticMethod("test0", mc -> {
+                mc.body(b0 -> {
+                    LocalVar foo = b0.declare("foo", GenericType.of(String.class).withAnnotation(Visible.class));
+                    b0.set(foo, Const.of("hello"));
+                    b0.return_();
+                });
+            });
+            zc.staticMethod("test1", mc -> {
+                mc.body(b0 -> {
+                    LocalVar foo = b0.declare("foo", GenericType.of(String.class).withAnnotation(Invisible.class));
+                    b0.set(foo, Const.of("hello"));
+                    b0.return_();
+                });
+            });
+        });
+        ClassModel model = tcm.forClass(desc).getModel();
+        MethodModel test0 = model.methods().stream().filter(mm -> mm.methodName().equalsString("test0")).findFirst()
+                .orElseThrow();
+        CodeModel test0code = test0.code().orElseThrow();
+        RuntimeVisibleTypeAnnotationsAttribute test0ann = test0code.findAttribute(Attributes.runtimeVisibleTypeAnnotations())
+                .orElseThrow();
+        assertEquals(1, test0ann.annotations().size());
+        assertEquals(Visible.class.descriptorString(), test0ann.annotations().get(0).annotation().className().stringValue());
+        MethodModel test1 = model.methods().stream().filter(mm -> mm.methodName().equalsString("test1")).findFirst()
+                .orElseThrow();
+        CodeModel test1code = test1.code().orElseThrow();
+        RuntimeInvisibleTypeAnnotationsAttribute test1ann = test1code
+                .findAttribute(Attributes.runtimeInvisibleTypeAnnotations()).orElseThrow();
+        assertEquals(1, test1ann.annotations().size());
+        assertEquals(Invisible.class.descriptorString(), test1ann.annotations().get(0).annotation().className().stringValue());
+    }
+
+    @Test
+    public void testGenericParameter() {
+        TestClassMaker tcm = new TestClassMaker();
+        Gizmo g = Gizmo.create(tcm);
+        ClassDesc desc = g.class_("io.quarkus.gizmo2.TestGenericParameter", zc -> {
+            zc.staticMethod("test0", mc -> {
+                mc.parameter("list", pc -> {
+                    pc.withType(GenericType.of(List.class, List.of(TypeArgument.of(String.class))));
+                });
+                mc.body(BlockCreator::return_);
+            });
+        });
+        ClassModel model = tcm.forClass(desc).getModel();
+        MethodModel test0 = model.methods().stream().filter(mm -> mm.methodName().equalsString("test0")).findFirst()
+                .orElseThrow();
+        SignatureAttribute sa = test0.findAttribute(Attributes.signature()).orElseThrow();
+        assertEquals("(Ljava/util/List<Ljava/lang/String;>;)V", sa.signature().stringValue());
+        CodeModel test0code = test0.code().orElseThrow();
+        LocalVariableTypeTableAttribute lvtt = test0code.findAttribute(Attributes.localVariableTypeTable()).orElseThrow();
+        assertEquals(1, lvtt.localVariableTypes().size());
+        LocalVariableTypeInfo info = lvtt.localVariableTypes().get(0);
+        assertEquals("list", info.name().stringValue());
+        assertEquals("Ljava/util/List<Ljava/lang/String;>;", info.signature().stringValue());
+    }
+
+    @Test
+    public void testTypeAnnotationParameter() {
+        TestClassMaker tcm = new TestClassMaker();
+        Gizmo g = Gizmo.create(tcm);
+        ClassDesc desc = g.class_("io.quarkus.gizmo2.TestTypeAnnotationParameter", zc -> {
+            zc.staticMethod("test0", mc -> {
+                mc.parameter("foo", pc -> {
+                    pc.withType(GenericType.of(String.class).withAnnotation(Visible.class));
+                });
+                mc.body(BlockCreator::return_);
+            });
+            zc.staticMethod("test1", mc -> {
+                mc.parameter("foo", pc -> {
+                    pc.withType(GenericType.of(String.class).withAnnotation(Invisible.class));
+                });
+                mc.body(BlockCreator::return_);
+            });
+        });
+        ClassModel model = tcm.forClass(desc).getModel();
+        MethodModel test0 = model.methods().stream().filter(mm -> mm.methodName().equalsString("test0")).findFirst()
+                .orElseThrow();
+        RuntimeVisibleTypeAnnotationsAttribute test0topAnn = test0.findAttribute(Attributes.runtimeVisibleTypeAnnotations())
+                .orElseThrow();
+        assertEquals(1, test0topAnn.annotations().size());
+        assertEquals(Visible.class.descriptorString(), test0topAnn.annotations().get(0).annotation().className().stringValue());
+        CodeModel test0code = test0.code().orElseThrow();
+        RuntimeVisibleTypeAnnotationsAttribute test0ann = test0code.findAttribute(Attributes.runtimeVisibleTypeAnnotations())
+                .orElseThrow();
+        assertEquals(1, test0ann.annotations().size());
+        assertEquals(Visible.class.descriptorString(), test0ann.annotations().get(0).annotation().className().stringValue());
+        MethodModel test1 = model.methods().stream().filter(mm -> mm.methodName().equalsString("test1")).findFirst()
+                .orElseThrow();
+        RuntimeInvisibleTypeAnnotationsAttribute test1topAnn = test1.findAttribute(Attributes.runtimeInvisibleTypeAnnotations())
+                .orElseThrow();
+        assertEquals(1, test1topAnn.annotations().size());
+        assertEquals(Invisible.class.descriptorString(),
+                test1topAnn.annotations().get(0).annotation().className().stringValue());
+        CodeModel test1code = test1.code().orElseThrow();
+        RuntimeInvisibleTypeAnnotationsAttribute test1ann = test1code
+                .findAttribute(Attributes.runtimeInvisibleTypeAnnotations()).orElseThrow();
+        assertEquals(1, test1ann.annotations().size());
+        assertEquals(Invisible.class.descriptorString(), test1ann.annotations().get(0).annotation().className().stringValue());
+    }
+
+    @Test
+    public void testGenericField() {
+        TestClassMaker tcm = new TestClassMaker();
+        Gizmo g = Gizmo.create(tcm);
+        ClassDesc desc = g.class_("io.quarkus.gizmo2.TestGenericField", zc -> {
+            zc.field("test0", fc -> {
+                fc.withType(GenericType.of(List.class, List.of(TypeArgument.of(String.class))));
+            });
+        });
+        ClassModel model = tcm.forClass(desc).getModel();
+        FieldModel test0 = model.fields().stream().filter(fm -> fm.fieldName().equalsString("test0")).findFirst().orElseThrow();
+        SignatureAttribute sa = test0.findAttribute(Attributes.signature()).orElseThrow();
+        assertEquals("Ljava/util/List<Ljava/lang/String;>;", sa.signature().stringValue());
+    }
+
+    @Test
+    public void testTypeAnnotationField() {
+        TestClassMaker tcm = new TestClassMaker();
+        Gizmo g = Gizmo.create(tcm);
+        ClassDesc desc = g.class_("io.quarkus.gizmo2.TestTypeAnnotationField", zc -> {
+            zc.field("test0", fc -> {
+                fc.withType(GenericType.of(String.class).withAnnotation(Visible.class));
+            });
+            zc.field("test1", fc -> {
+                fc.withType(GenericType.of(String.class).withAnnotation(Invisible.class));
+            });
+        });
+        ClassModel model = tcm.forClass(desc).getModel();
+        FieldModel test0 = model.fields().stream().filter(fm -> fm.fieldName().equalsString("test0")).findFirst().orElseThrow();
+        RuntimeVisibleTypeAnnotationsAttribute test0ann = test0.findAttribute(Attributes.runtimeVisibleTypeAnnotations())
+                .orElseThrow();
+        assertEquals(1, test0ann.annotations().size());
+        assertEquals(Visible.class.descriptorString(), test0ann.annotations().get(0).annotation().className().stringValue());
+        FieldModel test1 = model.fields().stream().filter(fm -> fm.fieldName().equalsString("test1")).findFirst().orElseThrow();
+        RuntimeInvisibleTypeAnnotationsAttribute test1ann = test1
+                .findAttribute(Attributes.runtimeInvisibleTypeAnnotations()).orElseThrow();
+        assertEquals(1, test1ann.annotations().size());
+        assertEquals(Invisible.class.descriptorString(), test1ann.annotations().get(0).annotation().className().stringValue());
+    }
+
+    @Target(ElementType.TYPE_USE)
+    @Retention(RetentionPolicy.RUNTIME)
+    public @interface Visible {
+    }
+
+    @Target(ElementType.TYPE_USE)
+    @Retention(RetentionPolicy.CLASS)
+    public @interface Invisible {
+    }
+}

--- a/src/test/java/io/quarkus/gizmo2/GenericTypeTest.java
+++ b/src/test/java/io/quarkus/gizmo2/GenericTypeTest.java
@@ -160,6 +160,53 @@ public final class GenericTypeTest {
     }
 
     @Test
+    public void testGenericReturn() {
+        TestClassMaker tcm = new TestClassMaker();
+        Gizmo g = Gizmo.create(tcm);
+        ClassDesc desc = g.class_("io.quarkus.gizmo2.TestGenericReturn", zc -> {
+            zc.staticMethod("test0", mc -> {
+                mc.returning(GenericType.of(List.class, List.of(TypeArgument.of(String.class))));
+                mc.body(BlockCreator::returnNull);
+            });
+        });
+        ClassModel model = tcm.forClass(desc).getModel();
+        MethodModel test0 = model.methods().stream().filter(mm -> mm.methodName().equalsString("test0")).findFirst()
+                .orElseThrow();
+        SignatureAttribute sa = test0.findAttribute(Attributes.signature()).orElseThrow();
+        assertEquals("()Ljava/util/List<Ljava/lang/String;>;", sa.signature().stringValue());
+    }
+
+    @Test
+    public void testTypeAnnotationReturn() {
+        TestClassMaker tcm = new TestClassMaker();
+        Gizmo g = Gizmo.create(tcm);
+        ClassDesc desc = g.class_("io.quarkus.gizmo2.TestTypeAnnotationReturn", zc -> {
+            zc.staticMethod("test0", mc -> {
+                mc.returning(GenericType.ofClass(String.class).withAnnotation(Visible.class));
+                mc.body(BlockCreator::returnNull);
+            });
+            zc.staticMethod("test1", mc -> {
+                mc.returning(GenericType.ofClass(String.class).withAnnotation(Invisible.class));
+                mc.body(BlockCreator::returnNull);
+            });
+        });
+        ClassModel model = tcm.forClass(desc).getModel();
+        MethodModel test0 = model.methods().stream().filter(mm -> mm.methodName().equalsString("test0")).findFirst()
+                .orElseThrow();
+        RuntimeVisibleTypeAnnotationsAttribute test0topAnn = test0.findAttribute(Attributes.runtimeVisibleTypeAnnotations())
+                .orElseThrow();
+        assertEquals(1, test0topAnn.annotations().size());
+        assertEquals(Visible.class.descriptorString(), test0topAnn.annotations().get(0).annotation().className().stringValue());
+        MethodModel test1 = model.methods().stream().filter(mm -> mm.methodName().equalsString("test1")).findFirst()
+                .orElseThrow();
+        RuntimeInvisibleTypeAnnotationsAttribute test1topAnn = test1.findAttribute(Attributes.runtimeInvisibleTypeAnnotations())
+                .orElseThrow();
+        assertEquals(1, test1topAnn.annotations().size());
+        assertEquals(Invisible.class.descriptorString(),
+                test1topAnn.annotations().get(0).annotation().className().stringValue());
+    }
+
+    @Test
     public void testGenericField() {
         TestClassMaker tcm = new TestClassMaker();
         Gizmo g = Gizmo.create(tcm);

--- a/src/test/java/io/quarkus/gizmo2/GenericTypeTest.java
+++ b/src/test/java/io/quarkus/gizmo2/GenericTypeTest.java
@@ -36,7 +36,7 @@ public final class GenericTypeTest {
         ClassDesc desc = g.class_("io.quarkus.gizmo2.TestGenericLocalVar", zc -> {
             zc.staticMethod("test0", mc -> {
                 mc.body(b0 -> {
-                    LocalVar list = b0.declare("list", GenericType.of(List.class, List.of(TypeArgument.ofExact(String.class))));
+                    LocalVar list = b0.declare("list", GenericType.of(List.class, List.of(TypeArgument.of(String.class))));
                     b0.set(list, Const.ofNull(List.class));
                     b0.return_();
                 });
@@ -97,7 +97,7 @@ public final class GenericTypeTest {
         ClassDesc desc = g.class_("io.quarkus.gizmo2.TestGenericParameter", zc -> {
             zc.staticMethod("test0", mc -> {
                 mc.parameter("list", pc -> {
-                    pc.withType(GenericType.of(List.class, List.of(TypeArgument.ofExact(String.class))));
+                    pc.withType(GenericType.of(List.class, List.of(TypeArgument.of(String.class))));
                 });
                 mc.body(BlockCreator::return_);
             });
@@ -165,7 +165,7 @@ public final class GenericTypeTest {
         Gizmo g = Gizmo.create(tcm);
         ClassDesc desc = g.class_("io.quarkus.gizmo2.TestGenericField", zc -> {
             zc.field("test0", fc -> {
-                fc.withType(GenericType.of(List.class, List.of(TypeArgument.ofExact(String.class))));
+                fc.withType(GenericType.of(List.class, List.of(TypeArgument.of(String.class))));
             });
         });
         ClassModel model = tcm.forClass(desc).getModel();

--- a/src/test/java/io/quarkus/gizmo2/GenericTypeTest.java
+++ b/src/test/java/io/quarkus/gizmo2/GenericTypeTest.java
@@ -389,4 +389,26 @@ public final class GenericTypeTest {
         SignatureAttribute sa = model.findAttribute(Attributes.signature()).orElseThrow();
         assertEquals("Ljava/lang/Object;Ljava/util/List<+Ljava/lang/String;>;", sa.signature().stringValue());
     }
+
+    @Test
+    public void testGenericReceiver() {
+        TestClassMaker tcm = new TestClassMaker();
+        Gizmo g = Gizmo.create(tcm);
+        ClassDesc desc = g.class_("io.quarkus.gizmo2.TestGenericReceiver", zc -> {
+            zc.typeParameter("T", tvc -> {
+                tvc.withOtherBounds(List.of(GenericType.ofClass(CharSequence.class)));
+            });
+            zc.method("test0", mc -> {
+                mc.returning(zc.genericType());
+                mc.body(b0 -> b0.return_(zc.this_()));
+            });
+        });
+        ClassModel model = tcm.forClass(desc).getModel();
+        SignatureAttribute sa = model.findAttribute(Attributes.signature()).orElseThrow();
+        assertEquals("<T::Ljava/lang/CharSequence;>Ljava/lang/Object;", sa.signature().stringValue());
+        MethodModel test0 = model.methods().stream().filter(mm -> mm.methodName().equalsString("test0")).findFirst()
+                .orElseThrow();
+        assertEquals("()Lio/quarkus/gizmo2/TestGenericReceiver<TT;>;",
+                test0.findAttribute(Attributes.signature()).orElseThrow().signature().stringValue());
+    }
 }

--- a/src/test/java/io/quarkus/gizmo2/InstanceExecutableCreatorTest.java
+++ b/src/test/java/io/quarkus/gizmo2/InstanceExecutableCreatorTest.java
@@ -1,14 +1,13 @@
 package io.quarkus.gizmo2;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.lang.constant.ClassDesc;
+import java.util.List;
 import java.util.function.Function;
 
 import org.junit.jupiter.api.Test;
 
-import io.github.dmlloyd.classfile.Signature.ClassTypeSig;
-import io.github.dmlloyd.classfile.Signature.TypeArg;
 import io.quarkus.gizmo2.desc.ConstructorDesc;
 import io.quarkus.gizmo2.desc.MethodDesc;
 
@@ -20,7 +19,9 @@ public class InstanceExecutableCreatorTest {
         TestClassMaker tcm = new TestClassMaker();
         Gizmo g = Gizmo.create(tcm);
         g.class_(ClassDesc.of("io.quarkus.gizmo2.TestFun"), cc -> {
-            cc.implements_(ClassTypeSig.of(Function.class.getName(), TypeArg.of(ClassTypeSig.of(String.class.getName()))));
+            cc.implements_(
+                    (GenericType.OfClass) GenericType.of(Function.class,
+                            List.of(TypeArgument.of(String.class), TypeArgument.of(String.class))));
             cc.constructor(con -> {
                 con.public_();
                 con.body(bc -> {

--- a/src/test/java/io/quarkus/gizmo2/InstanceExecutableCreatorTest.java
+++ b/src/test/java/io/quarkus/gizmo2/InstanceExecutableCreatorTest.java
@@ -21,7 +21,7 @@ public class InstanceExecutableCreatorTest {
         g.class_(ClassDesc.of("io.quarkus.gizmo2.TestFun"), cc -> {
             cc.implements_(
                     (GenericType.OfClass) GenericType.of(Function.class,
-                            List.of(TypeArgument.ofExact(String.class), TypeArgument.ofExact(String.class))));
+                            List.of(TypeArgument.of(String.class), TypeArgument.of(String.class))));
             cc.constructor(con -> {
                 con.public_();
                 con.body(bc -> {

--- a/src/test/java/io/quarkus/gizmo2/InstanceExecutableCreatorTest.java
+++ b/src/test/java/io/quarkus/gizmo2/InstanceExecutableCreatorTest.java
@@ -21,7 +21,7 @@ public class InstanceExecutableCreatorTest {
         g.class_(ClassDesc.of("io.quarkus.gizmo2.TestFun"), cc -> {
             cc.implements_(
                     (GenericType.OfClass) GenericType.of(Function.class,
-                            List.of(TypeArgument.of(String.class), TypeArgument.of(String.class))));
+                            List.of(TypeArgument.ofExact(String.class), TypeArgument.ofExact(String.class))));
             cc.constructor(con -> {
                 con.public_();
                 con.body(bc -> {

--- a/src/test/java/io/quarkus/gizmo2/TestClassMaker.java
+++ b/src/test/java/io/quarkus/gizmo2/TestClassMaker.java
@@ -108,6 +108,14 @@ public class TestClassMaker implements ClassOutput {
             this.desc = desc;
         }
 
+        public ClassModel getModel() {
+            try {
+                return cl.loadClassModel(desc);
+            } catch (ClassNotFoundException e) {
+                throw new IllegalStateException("Class was not defined");
+            }
+        }
+
         public Class<?> get() {
             try {
                 return cl.loadClass(desc);
@@ -213,6 +221,22 @@ public class TestClassMaker implements ClassOutput {
         private TestClassLoader() {
             super("[TEST]", TestClassMaker.class.getClassLoader());
             cf = ClassFile.of(ClassFile.ClassHierarchyResolverOption.of(this::getClassInfo));
+        }
+
+        public ClassModel loadClassModel(final ClassDesc desc) throws ClassNotFoundException {
+            if (desc.isClassOrInterface()) {
+                return loadClassModel(Util.binaryName(desc));
+            } else {
+                throw new IllegalArgumentException("Descriptor must be class or interface");
+            }
+        }
+
+        public ClassModel loadClassModel(final String name) throws ClassNotFoundException {
+            byte[] bytes = classes.get(name);
+            if (bytes == null) {
+                throw new ClassNotFoundException(name);
+            }
+            return cf.parse(bytes);
         }
 
         public Class<?> loadClass(final String name) throws ClassNotFoundException {


### PR DESCRIPTION
Implement our own generic type which includes type annotations to abstract away the class file API.

Fixes #334.

I don't hate it anymore. Feel free to review & leave comments.