### PR TITLE
Rework item binding

### DIFF
--- a/src/main/java/io/quarkus/gizmo2/Expr.java
+++ b/src/main/java/io/quarkus/gizmo2/Expr.java
@@ -16,7 +16,8 @@ public sealed interface Expr extends SimpleTyped permits Const, Assignable, This
     ClassDesc type();
 
     /**
-     * {@return true if the expression is bound to one location, or false if it may be reused many times}
+     * {@return {@code true} if the expression is bound to a single point in the instruction list, or {@code false} otherwise}
+     * Bound expressions may not be used again.
      */
     boolean bound();
 

--- a/src/main/java/io/quarkus/gizmo2/impl/BinOp.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/BinOp.java
@@ -44,10 +44,6 @@ final class BinOp extends Item {
         return a.type();
     }
 
-    public boolean bound() {
-        return a.bound() || b.bound() || kind == Kind.DIV || kind == Kind.REM;
-    }
-
     public void writeCode(final CodeBuilder cb, final BlockCreatorImpl block) {
         Operation op = kind.opFor(typeKind());
         // we validated op above

--- a/src/main/java/io/quarkus/gizmo2/impl/BlockCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/BlockCreatorImpl.java
@@ -443,7 +443,7 @@ public final class BlockCreatorImpl extends Item implements BlockCreator {
         switch (a.typeKind().asLoadable()) {
             case INT, REFERENCE -> {
                 // normal relZero
-                return addItemIfBound(new RelZero(a, kind));
+                return addItem(new RelZero(a, kind));
             }
             case LONG -> {
                 // wrap with cmp
@@ -466,7 +466,7 @@ public final class BlockCreatorImpl extends Item implements BlockCreator {
                 } else if (b instanceof IntConst bc && bc.intValue() == 0) {
                     return relZero(a, kind);
                 } else {
-                    return addItemIfBound(new Rel(a, b, kind));
+                    return addItem(new Rel(a, b, kind));
                 }
             }
             case LONG -> {
@@ -483,7 +483,7 @@ public final class BlockCreatorImpl extends Item implements BlockCreator {
                 } else if (b instanceof NullConst) {
                     return relZero(a, kind);
                 } else {
-                    return addItemIfBound(new Rel(a, b, kind));
+                    return addItem(new Rel(a, b, kind));
                 }
             }
             default -> throw new IllegalStateException();
@@ -687,8 +687,7 @@ public final class BlockCreatorImpl extends Item implements BlockCreator {
         if (toType.isPrimitive()) {
             throw new IllegalArgumentException("Cannot unsafely cast to a primitive type");
         }
-        UnsafeCast unsafeCast = new UnsafeCast(a, toType);
-        return unsafeCast.bound() ? addItem(unsafeCast) : unsafeCast;
+        return addItem(new UnsafeCast(a, toType));
     }
 
     public Expr instanceOf(final Expr obj, final ClassDesc type) {
@@ -1300,13 +1299,6 @@ public final class BlockCreatorImpl extends Item implements BlockCreator {
 
     void postInit(final List<Consumer<BlockCreator>> postInits) {
         this.postInits = postInits;
-    }
-
-    <I extends Item> I addItemIfBound(I item) {
-        if (item.bound()) {
-            addItem(item);
-        }
-        return item;
     }
 
     <I extends Item> I addItem(I item) {

--- a/src/main/java/io/quarkus/gizmo2/impl/CheckCast.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/CheckCast.java
@@ -11,11 +11,6 @@ final class CheckCast extends Cast {
         super(a, toType);
     }
 
-    public boolean bound() {
-        // has side effects
-        return true;
-    }
-
     public void writeCode(final CodeBuilder cb, final BlockCreatorImpl block) {
         cb.checkcast(toType);
     }

--- a/src/main/java/io/quarkus/gizmo2/impl/Cmp.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/Cmp.java
@@ -35,10 +35,6 @@ final class Cmp extends Item {
         return CD_int;
     }
 
-    public boolean bound() {
-        return a.bound() && b.bound();
-    }
-
     public void writeCode(final CodeBuilder cb, final BlockCreatorImpl block) {
         switch (a.typeKind().asLoadable()) {
             case INT -> kind.intOp.apply(cb);

--- a/src/main/java/io/quarkus/gizmo2/impl/EqualsHashCodeToStringGenerator.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/EqualsHashCodeToStringGenerator.java
@@ -97,8 +97,9 @@ public class EqualsHashCodeToStringGenerator {
                                 "Field does not belong to " + thisClass.displayName() + ": " + field);
                     }
 
-                    Expr value = b0.get(cc.this_().field(field));
-                    Expr hash = field.type().isArray() ? b0.arrayHashCode(value) : b0.exprHashCode(value);
+                    LocalVar value = b0.define("value", b0.get(cc.this_().field(field)));
+                    LocalVar hash = b0.define("hash",
+                            field.type().isArray() ? b0.arrayHashCode(value) : b0.exprHashCode(value));
                     b0.set(result, b0.add(b0.mul(Const.of(31), result), hash));
                 }
 

--- a/src/main/java/io/quarkus/gizmo2/impl/InstanceOf.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/InstanceOf.java
@@ -20,10 +20,6 @@ final class InstanceOf extends Item {
         return ConstantDescs.CD_boolean;
     }
 
-    public boolean bound() {
-        return input.bound();
-    }
-
     protected Node forEachDependency(final Node node, final BiFunction<Item, Node, Node> op) {
         return input.process(node.prev(), op);
     }

--- a/src/main/java/io/quarkus/gizmo2/impl/Item.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/Item.java
@@ -112,10 +112,18 @@ public abstract non-sealed class Item implements Expr {
      */
     protected Node insertIfUnbound(Node node) {
         if (!bound()) {
-            return forEachDependency(node.insertNext(this), Item::insertIfUnbound);
+            Node prev = forEachDependency(node.insertNext(this), Item::insertIfUnbound);
+            bind();
+            return prev;
         } else {
             return verify(node);
         }
+    }
+
+    /**
+     * If unbound and non-reusable, set this item's status to "bound".
+     */
+    protected void bind() {
     }
 
     /**
@@ -217,14 +225,22 @@ public abstract non-sealed class Item implements Expr {
             throw new IllegalArgumentException("Value type is not array: " + type().displayName());
         }
         return new Item() {
+            boolean bound;
+
             @Override
             public ClassDesc type() {
                 return ConstantDescs.CD_int;
             }
 
+            protected void bind() {
+                if (Item.this.bound()) {
+                    bound = true;
+                }
+            }
+
             @Override
             public boolean bound() {
-                return Item.this.bound();
+                return bound;
             }
 
             protected Node forEachDependency(final Node node, final BiFunction<Item, Node, Node> op) {
@@ -264,6 +280,7 @@ public abstract non-sealed class Item implements Expr {
 
     public final class FieldDeref extends AssignableImpl implements InstanceFieldVar {
         private final FieldDesc desc;
+        private boolean bound;
 
         private FieldDeref(final FieldDesc desc) {
             this.desc = desc;
@@ -274,7 +291,13 @@ public abstract non-sealed class Item implements Expr {
         }
 
         public boolean bound() {
-            return false;
+            return bound;
+        }
+
+        protected void bind() {
+            if (Item.this.bound()) {
+                bound = true;
+            }
         }
 
         public FieldDesc desc() {
@@ -373,6 +396,7 @@ public abstract non-sealed class Item implements Expr {
     public final class ArrayDeref extends AssignableImpl {
         private final ClassDesc componentType;
         private final Item index;
+        private boolean bound;
 
         public ArrayDeref(final ClassDesc componentType, final Expr index) {
             this.componentType = componentType;
@@ -453,8 +477,14 @@ public abstract non-sealed class Item implements Expr {
             return componentType;
         }
 
+        protected void bind() {
+            if (Item.this.bound() || index.bound()) {
+                bound = true;
+            }
+        }
+
         public boolean bound() {
-            return false;
+            return bound;
         }
 
         public void writeCode(final CodeBuilder cb, final BlockCreatorImpl block) {

--- a/src/main/java/io/quarkus/gizmo2/impl/Item.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/Item.java
@@ -207,14 +207,14 @@ public abstract non-sealed class Item implements Expr {
 
     public Assignable elem(final Expr index) {
         if (!type().isArray()) {
-            throw new IllegalArgumentException("Value type is not array");
+            throw new IllegalArgumentException("Value type is not array: " + type().displayName());
         }
         return new ArrayDeref(type().componentType(), index);
     }
 
     public Expr length() {
         if (!type().isArray()) {
-            throw new IllegalArgumentException("Length is only allowed on arrays (expression type is actually " + type() + ")");
+            throw new IllegalArgumentException("Value type is not array: " + type().displayName());
         }
         return new Item() {
             @Override

--- a/src/main/java/io/quarkus/gizmo2/impl/Neg.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/Neg.java
@@ -28,10 +28,6 @@ final class Neg extends Item {
         return a.type();
     }
 
-    public boolean bound() {
-        return a.bound();
-    }
-
     public void writeCode(final CodeBuilder cb, final BlockCreatorImpl block) {
         switch (typeKind().asLoadable()) {
             case INT -> cb.ineg();

--- a/src/main/java/io/quarkus/gizmo2/impl/PrimitiveCast.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/PrimitiveCast.java
@@ -24,10 +24,6 @@ final class PrimitiveCast extends Item {
         return toType;
     }
 
-    public boolean bound() {
-        return a.bound();
-    }
-
     public void writeCode(final CodeBuilder cb, final BlockCreatorImpl block) {
         cb.conversion(Util.actualKindOf(a.typeKind()), TypeKind.from(toType));
     }

--- a/src/main/java/io/quarkus/gizmo2/impl/Rel.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/Rel.java
@@ -47,10 +47,6 @@ final class Rel extends Item {
         return CD_boolean;
     }
 
-    public boolean bound() {
-        return a.bound() || b.bound();
-    }
-
     If.Kind kind() {
         return kind;
     }

--- a/src/main/java/io/quarkus/gizmo2/impl/RelZero.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/RelZero.java
@@ -36,10 +36,6 @@ final class RelZero extends Item {
         return CD_boolean;
     }
 
-    public boolean bound() {
-        return a.bound();
-    }
-
     If.Kind kind() {
         return kind;
     }

--- a/src/main/java/io/quarkus/gizmo2/impl/UnsafeCast.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/UnsafeCast.java
@@ -11,11 +11,6 @@ final class UnsafeCast extends Cast {
         super(a, toType);
     }
 
-    public boolean bound() {
-        // has side effects
-        return a.bound();
-    }
-
     public void writeCode(final CodeBuilder cb, final BlockCreatorImpl block) {
         // nothing
     }


### PR DESCRIPTION
An item is bound if it is added to the list. Constants are never bound. Derefs are bound once they have been added iff the thing they refer to is bound. Bound items may be used only once. Derefs of constants (or derefs of deref of constants etc.) can be reused many times.

Fixes #372
