### PR TITLE
Introduce revoke node operation

### DIFF
--- a/src/main/java/io/quarkus/gizmo2/impl/Dup.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/Dup.java
@@ -30,8 +30,9 @@ final class Dup extends Item {
     }
 
     protected Node process(final Node node, final BiFunction<Item, Node, Node> op) {
+        Node prev = node.prev();
         super.process(node, op);
-        return node.prev();
+        return prev;
     }
 
     public void writeCode(final CodeBuilder cb, final BlockCreatorImpl block) {

--- a/src/main/java/io/quarkus/gizmo2/impl/Item.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/Item.java
@@ -90,6 +90,19 @@ public abstract non-sealed class Item implements Expr {
     }
 
     /**
+     * Revoke this node from the instruction list, popping any dependencies that became unused as a result.
+     *
+     * @param node the current item's node (not {@code null})
+     * @return the node before the first dependency of this node (not {@code null})
+     */
+    public Node revoke(Node node) {
+        assert this == node.item();
+        Node prev = forEachDependency(node, Item::pop);
+        remove(node);
+        return prev;
+    }
+
+    /**
      * Insert this item into the instruction list before the given node.
      *
      * @param node the node which this item should be inserted before (must not be {@code null})

--- a/src/main/java/io/quarkus/gizmo2/impl/NewArrayResult.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/NewArrayResult.java
@@ -7,10 +7,10 @@ import java.util.function.BiFunction;
 import io.github.dmlloyd.classfile.CodeBuilder;
 
 public class NewArrayResult extends Item {
-    private final Item newEmptyArray;
-    private final List<Item> elements;
+    private final NewEmptyArray newEmptyArray;
+    private final List<ArrayStore> elements;
 
-    NewArrayResult(Item newEmptyArray, List<Item> elements) {
+    NewArrayResult(NewEmptyArray newEmptyArray, List<ArrayStore> elements) {
         this.newEmptyArray = newEmptyArray;
         this.elements = elements;
     }
@@ -34,6 +34,18 @@ public class NewArrayResult extends Item {
             node = elements.get(i).process(node, op);
         }
         node = newEmptyArray.process(node, op);
+        return node;
+    }
+
+    public Node pop(Node ourNode) {
+        Node node = ourNode.prev();
+        remove(ourNode);
+        int size = elements.size();
+        for (int i = size - 1; i >= 0; i--) {
+            // delete the array store and pop the things being stored
+            node = elements.get(i).revoke(node);
+        }
+        node = newEmptyArray.pop(node);
         return node;
     }
 


### PR DESCRIPTION
When a value is being popped, and the creation of the value involves void-typed operations whose only side effect is to mutate or set up that value, then we can revoke the void-typed nodes and pop their dependencies. In some cases the entire operation can be erased, if the mutation operation values do not have any side effects.

Also fixed a bug in `Dup#pop` where the node returned can be null due to excising the node from the list before capturing its `prev` pointer.