### PR TITLE
Create flags and access levels abstraction

### DIFF
--- a/src/main/java/io/quarkus/gizmo2/GenericType.java
+++ b/src/main/java/io/quarkus/gizmo2/GenericType.java
@@ -27,6 +27,7 @@ import java.util.stream.Stream;
 
 import io.github.dmlloyd.classfile.Annotation;
 import io.github.dmlloyd.classfile.TypeAnnotation;
+import io.quarkus.gizmo2.creator.AnnotatableCreator;
 import io.quarkus.gizmo2.creator.AnnotationCreator;
 import io.quarkus.gizmo2.impl.TypeAnnotatableCreatorImpl;
 import io.quarkus.gizmo2.impl.Util;

--- a/src/main/java/io/quarkus/gizmo2/TypeArgument.java
+++ b/src/main/java/io/quarkus/gizmo2/TypeArgument.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.function.Consumer;
 
 import io.github.dmlloyd.classfile.Annotation;
+import io.quarkus.gizmo2.creator.AnnotatableCreator;
 import io.quarkus.gizmo2.creator.AnnotationCreator;
 import io.quarkus.gizmo2.impl.TypeAnnotatableCreatorImpl;
 import io.quarkus.gizmo2.impl.Util;

--- a/src/main/java/io/quarkus/gizmo2/TypeVariable.java
+++ b/src/main/java/io/quarkus/gizmo2/TypeVariable.java
@@ -17,6 +17,7 @@ import java.util.stream.Stream;
 
 import io.github.dmlloyd.classfile.Annotation;
 import io.github.dmlloyd.classfile.TypeAnnotation;
+import io.quarkus.gizmo2.creator.AnnotatableCreator;
 import io.quarkus.gizmo2.desc.ConstructorDesc;
 import io.quarkus.gizmo2.desc.MethodDesc;
 import io.quarkus.gizmo2.impl.TypeAnnotatableCreatorImpl;

--- a/src/main/java/io/quarkus/gizmo2/creator/Access.java
+++ b/src/main/java/io/quarkus/gizmo2/creator/Access.java
@@ -1,0 +1,119 @@
+package io.quarkus.gizmo2.creator;
+
+import static io.github.dmlloyd.classfile.ClassFile.*;
+import static io.quarkus.gizmo2.creator.ModifierLocation.*;
+
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * The possible access levels for an item.
+ */
+public enum Access implements Modifier {
+    /**
+     * The {@code public} access level.
+     */
+    PUBLIC(ACC_PUBLIC, EnumSet.of(
+            INTERFACE_CONCRETE_METHOD,
+            INTERFACE_ABSTRACT_METHOD,
+            INTERFACE_STATIC_FIELD,
+            INTERFACE_STATIC_METHOD,
+            CLASS_CONSTRUCTOR,
+            CLASS_CONCRETE_METHOD,
+            CLASS_ABSTRACT_METHOD,
+            CLASS_NATIVE_METHOD,
+            CLASS_STATIC_METHOD,
+            CLASS_INSTANCE_FIELD,
+            CLASS_STATIC_FIELD,
+            CLASS,
+            INTERFACE,
+            NESTED_CLASS,
+            NESTED_INTERFACE)),
+    /**
+     * The {@code protected} access level.
+     */
+    PROTECTED(ACC_PROTECTED, EnumSet.of(
+            CLASS_CONSTRUCTOR,
+            CLASS_CONCRETE_METHOD,
+            CLASS_ABSTRACT_METHOD,
+            CLASS_NATIVE_METHOD,
+            CLASS_STATIC_METHOD,
+            CLASS_INSTANCE_FIELD,
+            CLASS_STATIC_FIELD,
+            NESTED_CLASS,
+            NESTED_INTERFACE)),
+    /**
+     * The package-private ("default") access level.
+     */
+    PACKAGE_PRIVATE(0, EnumSet.of(
+            CLASS_CONSTRUCTOR,
+            CLASS_CONCRETE_METHOD,
+            CLASS_ABSTRACT_METHOD,
+            CLASS_NATIVE_METHOD,
+            CLASS_STATIC_METHOD,
+            CLASS_INSTANCE_FIELD,
+            CLASS_STATIC_FIELD,
+            CLASS,
+            INTERFACE,
+            NESTED_CLASS,
+            NESTED_INTERFACE)),
+    /**
+     * The {@code private} access level.
+     */
+    PRIVATE(ACC_PRIVATE, EnumSet.of(
+            INTERFACE_CONCRETE_METHOD,
+            INTERFACE_STATIC_METHOD,
+            CLASS_CONSTRUCTOR,
+            CLASS_CONCRETE_METHOD,
+            CLASS_NATIVE_METHOD,
+            CLASS_STATIC_METHOD,
+            CLASS_INSTANCE_FIELD,
+            CLASS_STATIC_FIELD,
+            NESTED_CLASS,
+            NESTED_INTERFACE));
+
+    private final int mask;
+    private final Set<ModifierLocation> validLocations;
+
+    /**
+     * The list of access values.
+     */
+    public static final List<Access> values = List.of(values());
+
+    Access(final int mask, final Set<ModifierLocation> validLocations) {
+        this.mask = mask;
+        this.validLocations = validLocations;
+    }
+
+    public boolean validIn(ModifierLocation location) {
+        return validLocations.contains(location);
+    }
+
+    public int mask() {
+        return mask;
+    }
+
+    /**
+     * {@return the access level indicated by the given bit mask}
+     * If multiple access bits are present, then the access level with the highest bit value is returned.
+     *
+     * @param bits the bit mask
+     */
+    public static Access of(int bits) {
+        int hob = Integer.highestOneBit(bits & fullMask());
+        return switch (hob) {
+            case ACC_PROTECTED -> PROTECTED;
+            case ACC_PRIVATE -> PRIVATE;
+            case ACC_PUBLIC -> PUBLIC;
+            default -> PACKAGE_PRIVATE;
+        };
+    }
+
+    /**
+     * {@return the full bitmask for all access levels}
+     */
+    public static int fullMask() {
+        return ACC_PUBLIC | ACC_PROTECTED | ACC_PRIVATE;
+    }
+}

--- a/src/main/java/io/quarkus/gizmo2/creator/AccessLevel.java
+++ b/src/main/java/io/quarkus/gizmo2/creator/AccessLevel.java
@@ -10,7 +10,7 @@ import java.util.Set;
 /**
  * The possible access levels for an item.
  */
-public enum Access implements Modifier {
+public enum AccessLevel implements Modifier {
     /**
      * The {@code public} access level.
      */
@@ -79,9 +79,9 @@ public enum Access implements Modifier {
     /**
      * The list of access values.
      */
-    public static final List<Access> values = List.of(values());
+    public static final List<AccessLevel> values = List.of(values());
 
-    Access(final int mask, final Set<ModifierLocation> validLocations) {
+    AccessLevel(final int mask, final Set<ModifierLocation> validLocations) {
         this.mask = mask;
         this.validLocations = validLocations;
     }
@@ -100,7 +100,7 @@ public enum Access implements Modifier {
      *
      * @param bits the bit mask
      */
-    public static Access of(int bits) {
+    public static AccessLevel of(int bits) {
         int hob = Integer.highestOneBit(bits & fullMask());
         return switch (hob) {
             case ACC_PROTECTED -> PROTECTED;

--- a/src/main/java/io/quarkus/gizmo2/creator/AnnotatableCreator.java
+++ b/src/main/java/io/quarkus/gizmo2/creator/AnnotatableCreator.java
@@ -1,4 +1,4 @@
-package io.quarkus.gizmo2;
+package io.quarkus.gizmo2.creator;
 
 import static io.smallrye.common.constraint.Assert.*;
 
@@ -14,16 +14,12 @@ import java.util.Set;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
 
-import io.quarkus.gizmo2.creator.AnnotationCreator;
-import io.quarkus.gizmo2.creator.MemberCreator;
-import io.quarkus.gizmo2.creator.ParamCreator;
-import io.quarkus.gizmo2.creator.TypeCreator;
 import io.quarkus.gizmo2.impl.AnnotatableCreatorImpl;
 
 /**
  * An element that can be annotated.
  */
-public sealed interface AnnotatableCreator
+public sealed interface AnnotatableCreator extends ModifiableCreator
         permits TypeVariableCreator, MemberCreator, ParamCreator, TypeCreator, AnnotatableCreatorImpl {
     /**
      * Copy all of the annotations from the given annotated element.

--- a/src/main/java/io/quarkus/gizmo2/creator/AnnotatableCreator.java
+++ b/src/main/java/io/quarkus/gizmo2/creator/AnnotatableCreator.java
@@ -19,8 +19,8 @@ import io.quarkus.gizmo2.impl.AnnotatableCreatorImpl;
 /**
  * An element that can be annotated.
  */
-public sealed interface AnnotatableCreator extends ModifiableCreator
-        permits TypeVariableCreator, MemberCreator, ParamCreator, TypeCreator, AnnotatableCreatorImpl {
+public sealed interface AnnotatableCreator
+        permits ModifiableCreator, TypeVariableCreator, AnnotatableCreatorImpl {
     /**
      * Copy all of the annotations from the given annotated element.
      *

--- a/src/main/java/io/quarkus/gizmo2/creator/ClassCreator.java
+++ b/src/main/java/io/quarkus/gizmo2/creator/ClassCreator.java
@@ -276,14 +276,13 @@ public sealed interface ClassCreator extends TypeCreator, SimpleTyped, TypeParam
     void instanceInitializer(Consumer<BlockCreator> builder);
 
     /**
-     * Add the {@code abstract} access flag to the class.
+     * Add the {@code abstract} modifier flag to this creator.
+     *
+     * @throws IllegalArgumentException if this creator does not support the {@code abstract} modifier flag
      */
-    void abstract_();
-
-    /**
-     * Add the {@code final} access flag to the class.
-     */
-    void final_();
+    default void abstract_() {
+        withFlag(ModifierFlag.ABSTRACT);
+    }
 
     /**
      * Generates a structural {@code equals} method in this class that compares given

--- a/src/main/java/io/quarkus/gizmo2/creator/ExecutableCreator.java
+++ b/src/main/java/io/quarkus/gizmo2/creator/ExecutableCreator.java
@@ -13,7 +13,7 @@ import io.quarkus.gizmo2.impl.Util;
 /**
  * A creator for an executable (i.e. something that can be called with arguments).
  */
-public sealed interface ExecutableCreator extends MethodTyped, TypeParameterizedCreator
+public sealed interface ExecutableCreator extends MethodTyped, TypeParameterizedCreator, ModifiableCreator
         permits InstanceExecutableCreator, MethodCreator, StaticExecutableCreator, ExecutableCreatorImpl {
     /**
      * {@return the type descriptor of this executable (not {@code null})}
@@ -213,4 +213,12 @@ public sealed interface ExecutableCreator extends MethodTyped, TypeParameterized
     default void throws_(Class<? extends Throwable> throwableType) {
         throws_(Util.classDesc(throwableType));
     }
+
+    /**
+     * Add the variable arguments modifier flag to this creator.
+     */
+    default void varargs_() {
+        withFlag(ModifierFlag.VARARGS);
+    }
+
 }

--- a/src/main/java/io/quarkus/gizmo2/creator/ExecutableCreator.java
+++ b/src/main/java/io/quarkus/gizmo2/creator/ExecutableCreator.java
@@ -217,7 +217,7 @@ public sealed interface ExecutableCreator extends MethodTyped, TypeParameterized
     /**
      * Add the variable arguments modifier flag to this creator.
      */
-    default void varargs_() {
+    default void varargs() {
         withFlag(ModifierFlag.VARARGS);
     }
 

--- a/src/main/java/io/quarkus/gizmo2/creator/InstanceFieldCreator.java
+++ b/src/main/java/io/quarkus/gizmo2/creator/InstanceFieldCreator.java
@@ -1,7 +1,9 @@
 package io.quarkus.gizmo2.creator;
 
+import io.quarkus.gizmo2.impl.InstanceFieldCreatorImpl;
+
 /**
  * A creator for an instance field.
  */
-public sealed interface InstanceFieldCreator extends FieldCreator permits io.quarkus.gizmo2.impl.InstanceFieldCreatorImpl {
+public sealed interface InstanceFieldCreator extends FieldCreator permits InstanceFieldCreatorImpl {
 }

--- a/src/main/java/io/quarkus/gizmo2/creator/MemberCreator.java
+++ b/src/main/java/io/quarkus/gizmo2/creator/MemberCreator.java
@@ -9,7 +9,7 @@ import io.quarkus.gizmo2.desc.MemberDesc;
 /**
  * A generalized creator for any kind of class member.
  */
-public sealed interface MemberCreator extends AnnotatableCreator, Typed
+public sealed interface MemberCreator extends ModifiableCreator, Typed
         permits ConstructorCreator, FieldCreator, MethodCreator {
 
     /**

--- a/src/main/java/io/quarkus/gizmo2/creator/MemberCreator.java
+++ b/src/main/java/io/quarkus/gizmo2/creator/MemberCreator.java
@@ -3,8 +3,6 @@ package io.quarkus.gizmo2.creator;
 import java.lang.constant.ClassDesc;
 import java.lang.constant.ConstantDesc;
 
-import io.github.dmlloyd.classfile.extras.reflect.AccessFlag;
-import io.quarkus.gizmo2.AnnotatableCreator;
 import io.quarkus.gizmo2.Typed;
 import io.quarkus.gizmo2.desc.MemberDesc;
 
@@ -23,41 +21,6 @@ public sealed interface MemberCreator extends AnnotatableCreator, Typed
      * {@return the type of this member (not {@code null})}
      */
     ConstantDesc type();
-
-    /**
-     * Add the given flag to this member.
-     *
-     * @param flag the flag to add (must not be {@code null})
-     */
-    void withFlag(AccessFlag flag);
-
-    /**
-     * Add the {@code public} access flag to the member.
-     * Remove {@code private} and {@code protected}.
-     */
-    void public_();
-
-    /**
-     * Remove {@code public}, {@code private} and {@code protected} access flags.
-     */
-    void packagePrivate();
-
-    /**
-     * Add the {@code private} access flag to the member.
-     * Remove {@code public} and {@code protected}.
-     */
-    void private_();
-
-    /**
-     * Add the {@code protected} access flag to the member.
-     * Remove {@code public} and {@code private}.
-     */
-    void protected_();
-
-    /**
-     * Add the {@code final} access flag to the member.
-     */
-    void final_();
 
     /**
      * {@return the descriptor of the class which contains this member}

--- a/src/main/java/io/quarkus/gizmo2/creator/MethodCreator.java
+++ b/src/main/java/io/quarkus/gizmo2/creator/MethodCreator.java
@@ -43,4 +43,13 @@ public sealed interface MethodCreator extends ExecutableCreator, MemberCreator
     default void returning(Class<?> type) {
         returning(Util.classDesc(type));
     }
+
+    /**
+     * Add the {@code synchronized} modifier flag to this creator.
+     *
+     * @throws IllegalArgumentException if this creator does not support the {@code synchronized} modifier flag
+     */
+    default void synchronized_() {
+        withFlag(ModifierFlag.SYNCHRONIZED);
+    }
 }

--- a/src/main/java/io/quarkus/gizmo2/creator/ModifiableCreator.java
+++ b/src/main/java/io/quarkus/gizmo2/creator/ModifiableCreator.java
@@ -1,0 +1,141 @@
+package io.quarkus.gizmo2.creator;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+/**
+ * A creator for something which can have modifiers.
+ */
+public sealed interface ModifiableCreator permits AnnotatableCreator, ExecutableCreator {
+    /**
+     * {@return the modifier location constant for this creator (not {@code null})}
+     */
+    ModifierLocation modifierLocation();
+
+    /**
+     * Add the given modifier flag to this creator.
+     *
+     * @param flag the flag to add (must not be {@code null})
+     * @throws IllegalArgumentException if this creator does not support the given flag
+     */
+    void withFlag(ModifierFlag flag);
+
+    /**
+     * Add the given modifier flags to this creator.
+     *
+     * @param flags the flags to add (must not be {@code null})
+     * @throws IllegalArgumentException if this creator does not support one of the given flags
+     */
+    default void withFlags(Collection<ModifierFlag> flags) {
+        flags.forEach(this::withFlag);
+    }
+
+    /**
+     * Add the given modifier flags to this creator.
+     *
+     * @param flags the flags to add (must not be {@code null})
+     * @throws IllegalArgumentException if this creator does not support one of the given flags
+     */
+    default void withFlags(ModifierFlag... flags) {
+        withFlags(Arrays.asList(flags));
+    }
+
+    /**
+     * Remove the given modifier flag from this creator.
+     *
+     * @param flag the flag to remove (must not be {@code null})
+     * @throws IllegalArgumentException if this creator does not support the given flag
+     */
+    void withoutFlag(ModifierFlag flag);
+
+    /**
+     * Remove the given modifier flags from this creator.
+     *
+     * @param flags the flags to remove (must not be {@code null})
+     * @throws IllegalArgumentException if this creator does not support one of the given flags
+     */
+    default void withoutFlag(Collection<ModifierFlag> flags) {
+        flags.forEach(this::withoutFlag);
+    }
+
+    /**
+     * Remove the given modifier flags from this creator.
+     *
+     * @param flags the flags to remove (must not be {@code null})
+     * @throws IllegalArgumentException if this creator does not support one of the given flags
+     */
+    default void withoutFlag(ModifierFlag... flags) {
+        withFlags(Arrays.asList(flags));
+    }
+
+    /**
+     * {@return {@code true} if the given modifier is supported by this creator, or {@code false} if it is not}
+     *
+     * @param modifier the modifier to test (must not be {@code null})
+     */
+    default boolean supports(Modifier modifier) {
+        return modifier.validIn(modifierLocation());
+    }
+
+    /**
+     * Set the access level of this creator.
+     *
+     * @param access the access level to set (must not be {@code null})
+     * @throws IllegalArgumentException if this creator does not support the given access level
+     */
+    void withAccess(Access access);
+
+    /**
+     * Set the access level of this creator to {@code public}.
+     *
+     * @throws IllegalArgumentException if this creator does not support the {@code public} access level
+     */
+    default void public_() {
+        withAccess(Access.PUBLIC);
+    }
+
+    /**
+     * Set the access level of this creator to {@code protected}.
+     *
+     * @throws IllegalArgumentException if this creator does not support the {@code protected} access level
+     */
+    default void protected_() {
+        withAccess(Access.PROTECTED);
+    }
+
+    /**
+     * Set the access level of this creator to package-private.
+     *
+     * @throws IllegalArgumentException if this creator does not support the package-private access level
+     */
+    default void packagePrivate() {
+        withAccess(Access.PACKAGE_PRIVATE);
+    }
+
+    /**
+     * Set the access level of this creator to {@code private}.
+     *
+     * @throws IllegalArgumentException if this creator does not support the {@code private} access level
+     */
+    default void private_() {
+        withAccess(Access.PRIVATE);
+    }
+
+    /**
+     * Add the {@code final} modifier flag to this creator.
+     *
+     * @throws IllegalArgumentException if this creator does not support the {@code final} modifier flag
+     */
+    default void final_() {
+        withFlag(ModifierFlag.FINAL);
+    }
+
+    /**
+     * Add the "synthetic" modifier flag to this creator.
+     *
+     * @throws IllegalArgumentException if this creator does not support the "synthetic" modifier flag
+     */
+    default void synthetic() {
+        withFlag(ModifierFlag.SYNTHETIC);
+    }
+}

--- a/src/main/java/io/quarkus/gizmo2/creator/ModifiableCreator.java
+++ b/src/main/java/io/quarkus/gizmo2/creator/ModifiableCreator.java
@@ -65,7 +65,7 @@ public sealed interface ModifiableCreator permits AnnotatableCreator, Executable
      * @throws IllegalArgumentException if this creator does not support one of the given flags
      */
     default void withoutFlags(ModifierFlag... flags) {
-        withFlags(Arrays.asList(flags));
+        withoutFlags(Arrays.asList(flags));
     }
 
     /**

--- a/src/main/java/io/quarkus/gizmo2/creator/ModifiableCreator.java
+++ b/src/main/java/io/quarkus/gizmo2/creator/ModifiableCreator.java
@@ -54,7 +54,7 @@ public sealed interface ModifiableCreator permits AnnotatableCreator, Executable
      * @param flags the flags to remove (must not be {@code null})
      * @throws IllegalArgumentException if this creator does not support one of the given flags
      */
-    default void withoutFlag(Collection<ModifierFlag> flags) {
+    default void withoutFlags(Collection<ModifierFlag> flags) {
         flags.forEach(this::withoutFlag);
     }
 
@@ -64,7 +64,7 @@ public sealed interface ModifiableCreator permits AnnotatableCreator, Executable
      * @param flags the flags to remove (must not be {@code null})
      * @throws IllegalArgumentException if this creator does not support one of the given flags
      */
-    default void withoutFlag(ModifierFlag... flags) {
+    default void withoutFlags(ModifierFlag... flags) {
         withFlags(Arrays.asList(flags));
     }
 
@@ -83,7 +83,7 @@ public sealed interface ModifiableCreator permits AnnotatableCreator, Executable
      * @param access the access level to set (must not be {@code null})
      * @throws IllegalArgumentException if this creator does not support the given access level
      */
-    void withAccess(Access access);
+    void withAccess(AccessLevel access);
 
     /**
      * Set the access level of this creator to {@code public}.
@@ -91,7 +91,7 @@ public sealed interface ModifiableCreator permits AnnotatableCreator, Executable
      * @throws IllegalArgumentException if this creator does not support the {@code public} access level
      */
     default void public_() {
-        withAccess(Access.PUBLIC);
+        withAccess(AccessLevel.PUBLIC);
     }
 
     /**
@@ -100,7 +100,7 @@ public sealed interface ModifiableCreator permits AnnotatableCreator, Executable
      * @throws IllegalArgumentException if this creator does not support the {@code protected} access level
      */
     default void protected_() {
-        withAccess(Access.PROTECTED);
+        withAccess(AccessLevel.PROTECTED);
     }
 
     /**
@@ -109,7 +109,7 @@ public sealed interface ModifiableCreator permits AnnotatableCreator, Executable
      * @throws IllegalArgumentException if this creator does not support the package-private access level
      */
     default void packagePrivate() {
-        withAccess(Access.PACKAGE_PRIVATE);
+        withAccess(AccessLevel.PACKAGE_PRIVATE);
     }
 
     /**
@@ -118,7 +118,7 @@ public sealed interface ModifiableCreator permits AnnotatableCreator, Executable
      * @throws IllegalArgumentException if this creator does not support the {@code private} access level
      */
     default void private_() {
-        withAccess(Access.PRIVATE);
+        withAccess(AccessLevel.PRIVATE);
     }
 
     /**

--- a/src/main/java/io/quarkus/gizmo2/creator/ModifiableCreator.java
+++ b/src/main/java/io/quarkus/gizmo2/creator/ModifiableCreator.java
@@ -3,10 +3,13 @@ package io.quarkus.gizmo2.creator;
 import java.util.Arrays;
 import java.util.Collection;
 
+import io.quarkus.gizmo2.impl.ModifiableCreatorImpl;
+
 /**
  * A creator for something which can have modifiers.
  */
-public sealed interface ModifiableCreator permits AnnotatableCreator, ExecutableCreator {
+public sealed interface ModifiableCreator extends AnnotatableCreator
+        permits ExecutableCreator, MemberCreator, ParamCreator, TypeCreator, ModifiableCreatorImpl {
     /**
      * {@return the modifier location constant for this creator (not {@code null})}
      */

--- a/src/main/java/io/quarkus/gizmo2/creator/Modifier.java
+++ b/src/main/java/io/quarkus/gizmo2/creator/Modifier.java
@@ -3,7 +3,7 @@ package io.quarkus.gizmo2.creator;
 /**
  * Some kind of modifier (flag or access level).
  */
-public sealed interface Modifier permits Access, ModifierFlag {
+public sealed interface Modifier permits AccessLevel, ModifierFlag {
     /**
      * {@return {@code true} if this modifier is valid in the given location, or {@code false} if it is invalid}
      */

--- a/src/main/java/io/quarkus/gizmo2/creator/Modifier.java
+++ b/src/main/java/io/quarkus/gizmo2/creator/Modifier.java
@@ -1,0 +1,16 @@
+package io.quarkus.gizmo2.creator;
+
+/**
+ * Some kind of modifier (flag or access level).
+ */
+public sealed interface Modifier permits Access, ModifierFlag {
+    /**
+     * {@return {@code true} if this modifier is valid in the given location, or {@code false} if it is invalid}
+     */
+    boolean validIn(ModifierLocation location);
+
+    /**
+     * {@return the bitmask of this modifier}
+     */
+    int mask();
+}

--- a/src/main/java/io/quarkus/gizmo2/creator/ModifierFlag.java
+++ b/src/main/java/io/quarkus/gizmo2/creator/ModifierFlag.java
@@ -1,0 +1,107 @@
+package io.quarkus.gizmo2.creator;
+
+import static io.github.dmlloyd.classfile.ClassFile.*;
+import static io.quarkus.gizmo2.creator.ModifierLocation.*;
+
+import java.util.EnumSet;
+
+/**
+ * A modifier for a type or member.
+ */
+public enum ModifierFlag implements Modifier {
+    /**
+     * The {@code abstract} modifier.
+     */
+    ABSTRACT(ACC_ABSTRACT, EnumSet.of(
+            CLASS,
+            NESTED_CLASS)),
+    /**
+     * The {@code final} modifier.
+     */
+    FINAL(ACC_FINAL, EnumSet.of(
+            CLASS_CONCRETE_METHOD,
+            CLASS_NATIVE_METHOD,
+            CLASS_STATIC_METHOD,
+            CLASS_INSTANCE_FIELD,
+            CLASS_STATIC_FIELD,
+            CLASS,
+            NESTED_CLASS,
+            PARAMETER,
+            LOCAL_VARIABLE)),
+    /**
+     * The "mandated" modifier.
+     */
+    MANDATED(ACC_MANDATED, EnumSet.of(
+            PARAMETER)),
+    /**
+     * The {@code synchronized} modifier.
+     */
+    SYNCHRONIZED(ACC_SYNCHRONIZED, EnumSet.of(
+            CLASS_CONCRETE_METHOD,
+            CLASS_STATIC_METHOD)),
+    /**
+     * The "synthetic" modifier.
+     */
+    SYNTHETIC(ACC_SYNTHETIC, EnumSet.of(
+            INTERFACE_CONCRETE_METHOD,
+            INTERFACE_ABSTRACT_METHOD,
+            INTERFACE_STATIC_FIELD,
+            INTERFACE_STATIC_METHOD,
+            CLASS_CONSTRUCTOR,
+            CLASS_CONCRETE_METHOD,
+            CLASS_ABSTRACT_METHOD,
+            CLASS_NATIVE_METHOD,
+            CLASS_STATIC_METHOD,
+            CLASS_INSTANCE_FIELD,
+            CLASS_STATIC_FIELD,
+            CLASS,
+            INTERFACE,
+            NESTED_CLASS,
+            NESTED_INTERFACE,
+            PARAMETER)),
+    /**
+     * The {@code transient} modifier.
+     */
+    TRANSIENT(ACC_TRANSIENT, EnumSet.of(
+            CLASS_INSTANCE_FIELD)),
+    /**
+     * The variable-argument modifier.
+     */
+    VARARGS(ACC_VARARGS, EnumSet.of(
+            INTERFACE_CONCRETE_METHOD,
+            INTERFACE_ABSTRACT_METHOD,
+            INTERFACE_STATIC_METHOD,
+            CLASS_CONSTRUCTOR,
+            CLASS_CONCRETE_METHOD,
+            CLASS_ABSTRACT_METHOD,
+            CLASS_NATIVE_METHOD,
+            CLASS_STATIC_METHOD)),
+    /**
+     * The {@code volatile} modifier.
+     */
+    VOLATILE(ACC_VOLATILE, EnumSet.of(
+            CLASS_INSTANCE_FIELD,
+            CLASS_STATIC_FIELD)),
+            ;
+
+    private final int mask;
+    /**
+     * The valid locations.
+     * Note that this includes not only locations where the flag may be added, but
+     * also locations where it may be <em>removed</em>.
+     */
+    private final EnumSet<ModifierLocation> validLocations;
+
+    ModifierFlag(final int mask, final EnumSet<ModifierLocation> validLocations) {
+        this.mask = mask;
+        this.validLocations = validLocations;
+    }
+
+    public boolean validIn(final ModifierLocation location) {
+        return validLocations.contains(location);
+    }
+
+    public int mask() {
+        return mask;
+    }
+}

--- a/src/main/java/io/quarkus/gizmo2/creator/ModifierLocation.java
+++ b/src/main/java/io/quarkus/gizmo2/creator/ModifierLocation.java
@@ -4,24 +4,81 @@ package io.quarkus.gizmo2.creator;
  * The possible locations for a modifier or access level to do.
  */
 public enum ModifierLocation {
+    /**
+     * A concrete (private or default) interface method.
+     */
     INTERFACE_CONCRETE_METHOD,
+    /**
+     * A regular (abstract) interface method.
+     */
     INTERFACE_ABSTRACT_METHOD,
+    /**
+     * A static field on an interface.
+     */
     INTERFACE_STATIC_FIELD,
+    /**
+     * A static method on an interface.
+     */
     INTERFACE_STATIC_METHOD,
+    /**
+     * A constructor of a class.
+     */
     CLASS_CONSTRUCTOR,
+    /**
+     * A concrete instance method of a class.
+     */
     CLASS_CONCRETE_METHOD,
+    /**
+     * An abstract method of a class.
+     */
     CLASS_ABSTRACT_METHOD,
+    /**
+     * A native method of a class.
+     */
     CLASS_NATIVE_METHOD,
+    /**
+     * A non-native static method of a class.
+     */
     CLASS_STATIC_METHOD,
+    /**
+     * An instance field of a class.
+     */
     CLASS_INSTANCE_FIELD,
+    /**
+     * A static field of a class.
+     */
     CLASS_STATIC_FIELD,
+    /**
+     * A top-level class.
+     */
     CLASS,
+    /**
+     * A top-level interface.
+     */
     INTERFACE,
+    /**
+     * A nested class.
+     */
     NESTED_CLASS,
+    /**
+     * A nested interface.
+     */
     NESTED_INTERFACE,
+    /**
+     * An anonymous class.
+     */
     ANONYMOUS_CLASS,
+    /**
+     * A parameter of a method or constructor.
+     */
     PARAMETER,
+    /**
+     * A local variable.
+     */
     LOCAL_VARIABLE,
+    /**
+     * No location.
+     */
     // always last
     NONE,
     ;

--- a/src/main/java/io/quarkus/gizmo2/creator/ModifierLocation.java
+++ b/src/main/java/io/quarkus/gizmo2/creator/ModifierLocation.java
@@ -1,0 +1,28 @@
+package io.quarkus.gizmo2.creator;
+
+/**
+ * The possible locations for a modifier or access level to do.
+ */
+public enum ModifierLocation {
+    INTERFACE_CONCRETE_METHOD,
+    INTERFACE_ABSTRACT_METHOD,
+    INTERFACE_STATIC_FIELD,
+    INTERFACE_STATIC_METHOD,
+    CLASS_CONSTRUCTOR,
+    CLASS_CONCRETE_METHOD,
+    CLASS_ABSTRACT_METHOD,
+    CLASS_NATIVE_METHOD,
+    CLASS_STATIC_METHOD,
+    CLASS_INSTANCE_FIELD,
+    CLASS_STATIC_FIELD,
+    CLASS,
+    INTERFACE,
+    NESTED_CLASS,
+    NESTED_INTERFACE,
+    ANONYMOUS_CLASS,
+    PARAMETER,
+    LOCAL_VARIABLE,
+    // always last
+    NONE,
+    ;
+}

--- a/src/main/java/io/quarkus/gizmo2/creator/ModifierLocation.java
+++ b/src/main/java/io/quarkus/gizmo2/creator/ModifierLocation.java
@@ -76,10 +76,5 @@ public enum ModifierLocation {
      * A local variable.
      */
     LOCAL_VARIABLE,
-    /**
-     * No location.
-     */
-    // always last
-    NONE,
     ;
 }

--- a/src/main/java/io/quarkus/gizmo2/creator/ParamCreator.java
+++ b/src/main/java/io/quarkus/gizmo2/creator/ParamCreator.java
@@ -44,7 +44,7 @@ public sealed interface ParamCreator extends ModifiableCreator, GenericTyped per
     /**
      * Add the "mandated" modifier flag to this creator.
      */
-    default void mandated_() {
+    default void mandated() {
         withFlag(ModifierFlag.MANDATED);
     }
 }

--- a/src/main/java/io/quarkus/gizmo2/creator/ParamCreator.java
+++ b/src/main/java/io/quarkus/gizmo2/creator/ParamCreator.java
@@ -10,7 +10,7 @@ import io.quarkus.gizmo2.impl.Util;
 /**
  * A creator interface for parameters.
  */
-public sealed interface ParamCreator extends AnnotatableCreator, GenericTyped permits ParamCreatorImpl {
+public sealed interface ParamCreator extends ModifiableCreator, GenericTyped permits ParamCreatorImpl {
     /**
      * Change the type of this parameter.
      *

--- a/src/main/java/io/quarkus/gizmo2/creator/ParamCreator.java
+++ b/src/main/java/io/quarkus/gizmo2/creator/ParamCreator.java
@@ -2,8 +2,6 @@ package io.quarkus.gizmo2.creator;
 
 import java.lang.constant.ClassDesc;
 
-import io.github.dmlloyd.classfile.extras.reflect.AccessFlag;
-import io.quarkus.gizmo2.AnnotatableCreator;
 import io.quarkus.gizmo2.GenericType;
 import io.quarkus.gizmo2.GenericTyped;
 import io.quarkus.gizmo2.impl.ParamCreatorImpl;
@@ -13,13 +11,6 @@ import io.quarkus.gizmo2.impl.Util;
  * A creator interface for parameters.
  */
 public sealed interface ParamCreator extends AnnotatableCreator, GenericTyped permits ParamCreatorImpl {
-    /**
-     * Add a flag to this parameter.
-     *
-     * @param flag the flag to add (must not be {@code null})
-     */
-    void withFlag(AccessFlag flag);
-
     /**
      * Change the type of this parameter.
      *
@@ -48,5 +39,12 @@ public sealed interface ParamCreator extends AnnotatableCreator, GenericTyped pe
      */
     default void withType(Class<?> type) {
         withType(Util.classDesc(type));
+    }
+
+    /**
+     * Add the "mandated" modifier flag to this creator.
+     */
+    default void mandated_() {
+        withFlag(ModifierFlag.MANDATED);
     }
 }

--- a/src/main/java/io/quarkus/gizmo2/creator/TypeCreator.java
+++ b/src/main/java/io/quarkus/gizmo2/creator/TypeCreator.java
@@ -2,14 +2,11 @@ package io.quarkus.gizmo2.creator;
 
 import java.lang.constant.ClassDesc;
 import java.lang.constant.MethodTypeDesc;
-import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
 
-import io.github.dmlloyd.classfile.extras.reflect.AccessFlag;
-import io.quarkus.gizmo2.AnnotatableCreator;
 import io.quarkus.gizmo2.ClassVersion;
 import io.quarkus.gizmo2.Const;
 import io.quarkus.gizmo2.GenericType;
@@ -42,43 +39,6 @@ public sealed interface TypeCreator extends AnnotatableCreator, GenericTyped
      * @param version the class file version (must not be {@code null})
      */
     void withVersion(ClassVersion version);
-
-    /**
-     * Add a flag to the type.
-     *
-     * @param flag the flag to add (must not be {@code null})
-     */
-    void withFlag(AccessFlag flag);
-
-    /**
-     * Add several flags to the type.
-     *
-     * @param flags the flags to add
-     */
-    default void withFlags(Collection<AccessFlag> flags) {
-        flags.forEach(this::withFlag);
-    }
-
-    /**
-     * Add several flags to the type.
-     *
-     * @param flags the flags to add
-     */
-    default void withFlags(AccessFlag... flags) {
-        for (AccessFlag flag : flags) {
-            withFlag(flag);
-        }
-    }
-
-    /**
-     * Add the {@code public} access flag to the type.
-     */
-    void public_();
-
-    /**
-     * Remove the {@code public} access flag.
-     */
-    void packagePrivate();
 
     /**
      * Set the source file name for this type.
@@ -206,8 +166,8 @@ public sealed interface TypeCreator extends AnnotatableCreator, GenericTyped
      */
     default StaticFieldVar constantField(String name, Const value) {
         return staticField(name, sfc -> {
-            sfc.public_();
-            sfc.final_();
+            sfc.withAccess(Access.PUBLIC);
+            sfc.withFlag(ModifierFlag.FINAL);
             sfc.withInitial(value);
         });
     }

--- a/src/main/java/io/quarkus/gizmo2/creator/TypeCreator.java
+++ b/src/main/java/io/quarkus/gizmo2/creator/TypeCreator.java
@@ -22,7 +22,7 @@ import io.quarkus.gizmo2.impl.Util;
 /**
  * A creator for a type.
  */
-public sealed interface TypeCreator extends AnnotatableCreator, GenericTyped
+public sealed interface TypeCreator extends ModifiableCreator, GenericTyped
         permits ClassCreator, InterfaceCreator, TypeCreatorImpl {
     /**
      * Set the class file version to correspond with a run time version.

--- a/src/main/java/io/quarkus/gizmo2/creator/TypeCreator.java
+++ b/src/main/java/io/quarkus/gizmo2/creator/TypeCreator.java
@@ -166,7 +166,7 @@ public sealed interface TypeCreator extends AnnotatableCreator, GenericTyped
      */
     default StaticFieldVar constantField(String name, Const value) {
         return staticField(name, sfc -> {
-            sfc.withAccess(Access.PUBLIC);
+            sfc.withAccess(AccessLevel.PUBLIC);
             sfc.withFlag(ModifierFlag.FINAL);
             sfc.withInitial(value);
         });

--- a/src/main/java/io/quarkus/gizmo2/creator/TypeParameterizedCreator.java
+++ b/src/main/java/io/quarkus/gizmo2/creator/TypeParameterizedCreator.java
@@ -3,7 +3,6 @@ package io.quarkus.gizmo2.creator;
 import java.util.function.Consumer;
 
 import io.quarkus.gizmo2.TypeVariable;
-import io.quarkus.gizmo2.TypeVariableCreator;
 
 /**
  * A creator for things which can have type parameters.

--- a/src/main/java/io/quarkus/gizmo2/creator/TypeVariableCreator.java
+++ b/src/main/java/io/quarkus/gizmo2/creator/TypeVariableCreator.java
@@ -1,7 +1,8 @@
-package io.quarkus.gizmo2;
+package io.quarkus.gizmo2.creator;
 
 import java.util.List;
 
+import io.quarkus.gizmo2.GenericType;
 import io.quarkus.gizmo2.impl.TypeVariableCreatorImpl;
 
 /**

--- a/src/main/java/io/quarkus/gizmo2/impl/AbstractMethodCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/AbstractMethodCreatorImpl.java
@@ -10,7 +10,7 @@ import io.quarkus.gizmo2.creator.ModifierLocation;
 public final class AbstractMethodCreatorImpl extends MethodCreatorImpl implements AbstractMethodCreator {
     AbstractMethodCreatorImpl(final TypeCreatorImpl owner, final String name) {
         super(owner, name);
-        flags |= ACC_PUBLIC | ACC_ABSTRACT;
+        flags |= ACC_ABSTRACT;
     }
 
     public ModifierLocation modifierLocation() {

--- a/src/main/java/io/quarkus/gizmo2/impl/AbstractMethodCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/AbstractMethodCreatorImpl.java
@@ -1,21 +1,20 @@
 package io.quarkus.gizmo2.impl;
 
-import static io.github.dmlloyd.classfile.extras.reflect.AccessFlag.ABSTRACT;
-import static io.github.dmlloyd.classfile.extras.reflect.AccessFlag.BRIDGE;
-import static io.github.dmlloyd.classfile.extras.reflect.AccessFlag.PROTECTED;
-import static io.github.dmlloyd.classfile.extras.reflect.AccessFlag.PUBLIC;
-import static io.github.dmlloyd.classfile.extras.reflect.AccessFlag.SYNCHRONIZED;
-import static io.github.dmlloyd.classfile.extras.reflect.AccessFlag.SYNTHETIC;
-import static io.github.dmlloyd.classfile.extras.reflect.AccessFlag.VARARGS;
+import static io.github.dmlloyd.classfile.ClassFile.*;
 
-import java.util.Set;
 import java.util.function.Consumer;
 
 import io.quarkus.gizmo2.creator.AbstractMethodCreator;
+import io.quarkus.gizmo2.creator.ModifierLocation;
 
 public final class AbstractMethodCreatorImpl extends MethodCreatorImpl implements AbstractMethodCreator {
     AbstractMethodCreatorImpl(final TypeCreatorImpl owner, final String name) {
-        super(owner, name, Set.of(ABSTRACT), Set.of(PUBLIC, PROTECTED, SYNCHRONIZED, SYNTHETIC, BRIDGE, ABSTRACT, VARARGS));
+        super(owner, name);
+        flags |= ACC_PUBLIC | ACC_ABSTRACT;
+    }
+
+    public ModifierLocation modifierLocation() {
+        return ModifierLocation.CLASS_ABSTRACT_METHOD;
     }
 
     void accept(final Consumer<? super AbstractMethodCreatorImpl> builder) {

--- a/src/main/java/io/quarkus/gizmo2/impl/AbstractMethodCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/AbstractMethodCreatorImpl.java
@@ -10,7 +10,7 @@ import io.quarkus.gizmo2.creator.ModifierLocation;
 public final class AbstractMethodCreatorImpl extends MethodCreatorImpl implements AbstractMethodCreator {
     AbstractMethodCreatorImpl(final TypeCreatorImpl owner, final String name) {
         super(owner, name);
-        flags |= ACC_ABSTRACT;
+        modifiers |= ACC_ABSTRACT;
     }
 
     public ModifierLocation modifierLocation() {
@@ -19,7 +19,7 @@ public final class AbstractMethodCreatorImpl extends MethodCreatorImpl implement
 
     void accept(final Consumer<? super AbstractMethodCreatorImpl> builder) {
         builder.accept(this);
-        typeCreator.zb.withMethod(name(), type(), flags, mb -> {
+        typeCreator.zb.withMethod(name(), type(), modifiers, mb -> {
             doBody(null, mb);
         });
     }

--- a/src/main/java/io/quarkus/gizmo2/impl/AnnotatableCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/AnnotatableCreatorImpl.java
@@ -22,7 +22,7 @@ import io.github.dmlloyd.classfile.AnnotationElement;
 import io.github.dmlloyd.classfile.AnnotationValue;
 import io.github.dmlloyd.classfile.attribute.RuntimeInvisibleAnnotationsAttribute;
 import io.github.dmlloyd.classfile.attribute.RuntimeVisibleAnnotationsAttribute;
-import io.quarkus.gizmo2.creator.Access;
+import io.quarkus.gizmo2.creator.AccessLevel;
 import io.quarkus.gizmo2.creator.AnnotatableCreator;
 import io.quarkus.gizmo2.creator.AnnotationCreator;
 import io.quarkus.gizmo2.creator.Modifier;
@@ -70,9 +70,9 @@ public abstract sealed class AnnotatableCreatorImpl implements AnnotatableCreato
         }
     }
 
-    public void withAccess(final Access access) {
+    public void withAccess(final AccessLevel access) {
         if (supports(access)) {
-            flags = flags & ~Access.fullMask() | access.mask();
+            flags = flags & ~AccessLevel.fullMask() | access.mask();
         } else {
             throw modifierUnsupported(access);
         }

--- a/src/main/java/io/quarkus/gizmo2/impl/AnnotatableCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/AnnotatableCreatorImpl.java
@@ -22,21 +22,16 @@ import io.github.dmlloyd.classfile.AnnotationElement;
 import io.github.dmlloyd.classfile.AnnotationValue;
 import io.github.dmlloyd.classfile.attribute.RuntimeInvisibleAnnotationsAttribute;
 import io.github.dmlloyd.classfile.attribute.RuntimeVisibleAnnotationsAttribute;
-import io.quarkus.gizmo2.creator.AccessLevel;
 import io.quarkus.gizmo2.creator.AnnotatableCreator;
 import io.quarkus.gizmo2.creator.AnnotationCreator;
-import io.quarkus.gizmo2.creator.Modifier;
-import io.quarkus.gizmo2.creator.ModifierFlag;
 import io.smallrye.common.constraint.Assert;
 
 public abstract sealed class AnnotatableCreatorImpl implements AnnotatableCreator
-        permits ExecutableCreatorImpl, FieldCreatorImpl, ParamCreatorImpl, TypeAnnotatableCreatorImpl, TypeCreatorImpl,
-        TypeVariableCreatorImpl {
+        permits ModifiableCreatorImpl, TypeAnnotatableCreatorImpl, TypeVariableCreatorImpl {
     protected final String creationSite = Util.trackCaller();
 
     Map<ClassDesc, Annotation> invisible;
     Map<ClassDesc, Annotation> visible;
-    int flags;
 
     protected AnnotatableCreatorImpl() {
         invisible = Map.of();
@@ -52,34 +47,6 @@ public abstract sealed class AnnotatableCreatorImpl implements AnnotatableCreato
                 : visible.stream().collect(Collectors.toMap(Annotation::classSymbol, Function.identity(), (a, b) -> {
                     throw new IllegalStateException();
                 }, LinkedHashMap::new));
-    }
-
-    public void withFlag(final ModifierFlag flag) {
-        if (supports(flag)) {
-            flags |= flag.mask();
-        } else {
-            throw modifierUnsupported(flag);
-        }
-    }
-
-    public void withoutFlag(final ModifierFlag flag) {
-        if (supports(flag)) {
-            flags &= ~flag.mask();
-        } else {
-            throw modifierUnsupported(flag);
-        }
-    }
-
-    public void withAccess(final AccessLevel access) {
-        if (supports(access)) {
-            flags = flags & ~AccessLevel.fullMask() | access.mask();
-        } else {
-            throw modifierUnsupported(access);
-        }
-    }
-
-    private static IllegalArgumentException modifierUnsupported(final Modifier modifier) {
-        return new IllegalArgumentException("Modifier \"%s\" is not supported here".formatted(modifier));
     }
 
     private Map<ClassDesc, Annotation> visibleMap() {

--- a/src/main/java/io/quarkus/gizmo2/impl/AnonymousClassCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/AnonymousClassCreatorImpl.java
@@ -13,7 +13,7 @@ import io.quarkus.gizmo2.Expr;
 import io.quarkus.gizmo2.InstanceFieldVar;
 import io.quarkus.gizmo2.ParamVar;
 import io.quarkus.gizmo2.Var;
-import io.quarkus.gizmo2.creator.Access;
+import io.quarkus.gizmo2.creator.AccessLevel;
 import io.quarkus.gizmo2.creator.AnonymousClassCreator;
 import io.quarkus.gizmo2.creator.BlockCreator;
 import io.quarkus.gizmo2.creator.ConstructorCreator;
@@ -61,7 +61,7 @@ public final class AnonymousClassCreatorImpl extends ClassCreatorImpl implements
             ParamVar param = cc.parameter(name, value.type());
             FieldDesc desc = field(name, ifc -> {
                 ifc.withType(value.type());
-                ifc.withAccess(Access.PRIVATE);
+                ifc.withAccess(AccessLevel.PRIVATE);
                 ifc.withFlag(ModifierFlag.FINAL);
             });
             InstanceFieldVar fv = this_().field(desc);

--- a/src/main/java/io/quarkus/gizmo2/impl/AnonymousClassCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/AnonymousClassCreatorImpl.java
@@ -1,20 +1,24 @@
 package io.quarkus.gizmo2.impl;
 
+import static io.github.dmlloyd.classfile.ClassFile.*;
+
 import java.lang.constant.ClassDesc;
 import java.lang.constant.MethodTypeDesc;
 import java.util.ArrayList;
 import java.util.function.Consumer;
 
 import io.github.dmlloyd.classfile.ClassBuilder;
-import io.github.dmlloyd.classfile.extras.reflect.AccessFlag;
 import io.quarkus.gizmo2.ClassOutput;
 import io.quarkus.gizmo2.Expr;
 import io.quarkus.gizmo2.InstanceFieldVar;
 import io.quarkus.gizmo2.ParamVar;
 import io.quarkus.gizmo2.Var;
+import io.quarkus.gizmo2.creator.Access;
 import io.quarkus.gizmo2.creator.AnonymousClassCreator;
 import io.quarkus.gizmo2.creator.BlockCreator;
 import io.quarkus.gizmo2.creator.ConstructorCreator;
+import io.quarkus.gizmo2.creator.ModifierFlag;
+import io.quarkus.gizmo2.creator.ModifierLocation;
 import io.quarkus.gizmo2.desc.ConstructorDesc;
 import io.quarkus.gizmo2.desc.FieldDesc;
 
@@ -32,6 +36,7 @@ public final class AnonymousClassCreatorImpl extends ClassCreatorImpl implements
     AnonymousClassCreatorImpl(final ClassDesc type, final ClassOutput output, final ClassBuilder zb,
             final ConstructorDesc superCtor, final ArrayList<Expr> captureExprs) {
         super(type, output, zb);
+        flags |= ACC_FINAL;
         this.superCtor = superCtor;
         extends_(superCtor.owner());
         superArgs = new ArrayList<>(superCtor.type().parameterCount());
@@ -46,14 +51,18 @@ public final class AnonymousClassCreatorImpl extends ClassCreatorImpl implements
         this_ = new ThisExpr(genericType());
     }
 
+    public ModifierLocation modifierLocation() {
+        return ModifierLocation.ANONYMOUS_CLASS;
+    }
+
     public Var capture(final String name, final Expr value) {
         ctorSetups.add(cc -> {
             // define additional parameters
             ParamVar param = cc.parameter(name, value.type());
             FieldDesc desc = field(name, ifc -> {
                 ifc.withType(value.type());
-                ifc.withFlag(AccessFlag.PRIVATE);
-                ifc.withFlag(AccessFlag.FINAL);
+                ifc.withAccess(Access.PRIVATE);
+                ifc.withFlag(ModifierFlag.FINAL);
             });
             InstanceFieldVar fv = this_().field(desc);
             captures.add(b0 -> {

--- a/src/main/java/io/quarkus/gizmo2/impl/AnonymousClassCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/AnonymousClassCreatorImpl.java
@@ -36,7 +36,7 @@ public final class AnonymousClassCreatorImpl extends ClassCreatorImpl implements
     AnonymousClassCreatorImpl(final ClassDesc type, final ClassOutput output, final ClassBuilder zb,
             final ConstructorDesc superCtor, final ArrayList<Expr> captureExprs) {
         super(type, output, zb);
-        flags |= ACC_FINAL;
+        modifiers |= ACC_FINAL;
         this.superCtor = superCtor;
         extends_(superCtor.owner());
         superArgs = new ArrayList<>(superCtor.type().parameterCount());

--- a/src/main/java/io/quarkus/gizmo2/impl/BlockCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/BlockCreatorImpl.java
@@ -565,7 +565,6 @@ public final class BlockCreatorImpl extends Item implements BlockCreator {
                 // implement the interface too
                 tc.implements_(imd.owner());
             }
-            tc.final_();
             tc.method(sam, imc -> {
                 imc.public_();
                 LambdaCreatorImpl lc = new LambdaCreatorImpl(tc, (InstanceMethodCreatorImpl) imc);

--- a/src/main/java/io/quarkus/gizmo2/impl/ClassCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/ClassCreatorImpl.java
@@ -24,7 +24,7 @@ import io.quarkus.gizmo2.desc.MethodDesc;
 public sealed class ClassCreatorImpl extends TypeCreatorImpl implements ClassCreator permits AnonymousClassCreatorImpl {
     public ClassCreatorImpl(final ClassDesc type, final ClassOutput output, final ClassBuilder zb) {
         super(type, output, zb);
-        flags |= ACC_PUBLIC | ACC_SYNTHETIC;
+        modifiers |= ACC_PUBLIC | ACC_SYNTHETIC;
     }
 
     public ModifierLocation modifierLocation() {

--- a/src/main/java/io/quarkus/gizmo2/impl/ClassCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/ClassCreatorImpl.java
@@ -1,5 +1,6 @@
 package io.quarkus.gizmo2.impl;
 
+import static io.github.dmlloyd.classfile.ClassFile.*;
 import static io.smallrye.common.constraint.Assert.*;
 
 import java.lang.constant.ClassDesc;
@@ -7,7 +8,6 @@ import java.lang.constant.MethodTypeDesc;
 import java.util.function.Consumer;
 
 import io.github.dmlloyd.classfile.ClassBuilder;
-import io.github.dmlloyd.classfile.extras.reflect.AccessFlag;
 import io.quarkus.gizmo2.ClassOutput;
 import io.quarkus.gizmo2.GenericType;
 import io.quarkus.gizmo2.creator.AbstractMethodCreator;
@@ -15,6 +15,7 @@ import io.quarkus.gizmo2.creator.ClassCreator;
 import io.quarkus.gizmo2.creator.ConstructorCreator;
 import io.quarkus.gizmo2.creator.InstanceFieldCreator;
 import io.quarkus.gizmo2.creator.InstanceMethodCreator;
+import io.quarkus.gizmo2.creator.ModifierLocation;
 import io.quarkus.gizmo2.desc.ClassMethodDesc;
 import io.quarkus.gizmo2.desc.ConstructorDesc;
 import io.quarkus.gizmo2.desc.FieldDesc;
@@ -22,14 +23,12 @@ import io.quarkus.gizmo2.desc.MethodDesc;
 
 public sealed class ClassCreatorImpl extends TypeCreatorImpl implements ClassCreator permits AnonymousClassCreatorImpl {
     public ClassCreatorImpl(final ClassDesc type, final ClassOutput output, final ClassBuilder zb) {
-        super(type, output, zb, AccessFlag.SYNTHETIC.mask() | AccessFlag.PUBLIC.mask());
+        super(type, output, zb);
+        flags |= ACC_PUBLIC | ACC_SYNTHETIC;
     }
 
-    public void withFlag(final AccessFlag flag) {
-        if (flag == AccessFlag.INTERFACE) {
-            throw new IllegalArgumentException("Flag " + flag + " not allowed here");
-        }
-        super.withFlag(flag);
+    public ModifierLocation modifierLocation() {
+        return ModifierLocation.CLASS;
     }
 
     public void extends_(final GenericType.OfClass genericType) {
@@ -117,15 +116,5 @@ public sealed class ClassCreatorImpl extends TypeCreatorImpl implements ClassCre
             throw new IllegalArgumentException("Duplicate constructor added: %s".formatted(desc));
         }
         return desc;
-    }
-
-    @Override
-    public void abstract_() {
-        withFlag(AccessFlag.ABSTRACT);
-    }
-
-    @Override
-    public void final_() {
-        withFlag(AccessFlag.FINAL);
     }
 }

--- a/src/main/java/io/quarkus/gizmo2/impl/ConstructorCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/ConstructorCreatorImpl.java
@@ -1,23 +1,17 @@
 package io.quarkus.gizmo2.impl;
 
-import static io.github.dmlloyd.classfile.extras.reflect.AccessFlag.BRIDGE;
-import static io.github.dmlloyd.classfile.extras.reflect.AccessFlag.PRIVATE;
-import static io.github.dmlloyd.classfile.extras.reflect.AccessFlag.PROTECTED;
-import static io.github.dmlloyd.classfile.extras.reflect.AccessFlag.PUBLIC;
-import static io.github.dmlloyd.classfile.extras.reflect.AccessFlag.SYNTHETIC;
-import static io.github.dmlloyd.classfile.extras.reflect.AccessFlag.VARARGS;
-import static java.lang.constant.ConstantDescs.CD_void;
+import static java.lang.constant.ConstantDescs.*;
 
 import java.lang.annotation.ElementType;
 import java.lang.constant.MethodTypeDesc;
 import java.util.List;
-import java.util.Set;
 import java.util.function.Consumer;
 
 import io.quarkus.gizmo2.TypeVariable;
-import io.quarkus.gizmo2.TypeVariableCreator;
 import io.quarkus.gizmo2.creator.BlockCreator;
 import io.quarkus.gizmo2.creator.ConstructorCreator;
+import io.quarkus.gizmo2.creator.ModifierLocation;
+import io.quarkus.gizmo2.creator.TypeVariableCreator;
 import io.quarkus.gizmo2.desc.ConstructorDesc;
 
 public final class ConstructorCreatorImpl extends ExecutableCreatorImpl implements ConstructorCreator {
@@ -27,9 +21,13 @@ public final class ConstructorCreatorImpl extends ExecutableCreatorImpl implemen
 
     ConstructorCreatorImpl(final TypeCreatorImpl owner, final List<Consumer<BlockCreator>> preInits,
             final List<Consumer<BlockCreator>> postInits) {
-        super(owner, Set.of(), Set.of(PUBLIC, PRIVATE, PROTECTED, SYNTHETIC, BRIDGE, VARARGS));
+        super(owner);
         this.preInits = preInits;
         this.postInits = postInits;
+    }
+
+    public ModifierLocation modifierLocation() {
+        return ModifierLocation.CLASS_CONSTRUCTOR;
     }
 
     public ConstructorDesc desc() {

--- a/src/main/java/io/quarkus/gizmo2/impl/DefaultMethodCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/DefaultMethodCreatorImpl.java
@@ -11,7 +11,7 @@ import io.quarkus.gizmo2.creator.ModifierLocation;
 public final class DefaultMethodCreatorImpl extends MethodCreatorImpl implements InstanceMethodCreator {
     DefaultMethodCreatorImpl(final TypeCreatorImpl owner, final String name) {
         super(owner, name);
-        flags |= ACC_PUBLIC;
+        modifiers |= ACC_PUBLIC;
     }
 
     public ModifierLocation modifierLocation() {

--- a/src/main/java/io/quarkus/gizmo2/impl/DefaultMethodCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/DefaultMethodCreatorImpl.java
@@ -1,20 +1,21 @@
 package io.quarkus.gizmo2.impl;
 
-import static io.github.dmlloyd.classfile.extras.reflect.AccessFlag.BRIDGE;
-import static io.github.dmlloyd.classfile.extras.reflect.AccessFlag.PUBLIC;
-import static io.github.dmlloyd.classfile.extras.reflect.AccessFlag.SYNCHRONIZED;
-import static io.github.dmlloyd.classfile.extras.reflect.AccessFlag.SYNTHETIC;
-import static io.github.dmlloyd.classfile.extras.reflect.AccessFlag.VARARGS;
+import static io.github.dmlloyd.classfile.ClassFile.*;
 
-import java.util.Set;
 import java.util.function.Consumer;
 
 import io.quarkus.gizmo2.creator.BlockCreator;
 import io.quarkus.gizmo2.creator.InstanceMethodCreator;
+import io.quarkus.gizmo2.creator.ModifierLocation;
 
 public final class DefaultMethodCreatorImpl extends MethodCreatorImpl implements InstanceMethodCreator {
     DefaultMethodCreatorImpl(final TypeCreatorImpl owner, final String name) {
-        super(owner, name, Set.of(PUBLIC), Set.of(PUBLIC, SYNCHRONIZED, SYNTHETIC, BRIDGE, VARARGS));
+        super(owner, name);
+        flags |= ACC_PUBLIC;
+    }
+
+    public ModifierLocation modifierLocation() {
+        return ModifierLocation.INTERFACE_CONCRETE_METHOD;
     }
 
     public void body(final Consumer<BlockCreator> builder) {

--- a/src/main/java/io/quarkus/gizmo2/impl/ExecutableCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/ExecutableCreatorImpl.java
@@ -37,7 +37,7 @@ import io.quarkus.gizmo2.creator.BlockCreator;
 import io.quarkus.gizmo2.creator.ExecutableCreator;
 import io.quarkus.gizmo2.creator.ParamCreator;
 
-public sealed abstract class ExecutableCreatorImpl extends AnnotatableCreatorImpl implements ExecutableCreator
+public sealed abstract class ExecutableCreatorImpl extends ModifiableCreatorImpl implements ExecutableCreator
         permits ConstructorCreatorImpl, MethodCreatorImpl {
 
     private static final MethodParameterInfo EMPTY_PI = MethodParameterInfo.of(Optional.empty(), 0);
@@ -161,7 +161,7 @@ public sealed abstract class ExecutableCreatorImpl extends AnnotatableCreatorImp
         ArrayList<TypeAnnotation> visible = new ArrayList<>();
         ArrayList<TypeAnnotation> invisible = new ArrayList<>();
         mb.with(SignatureAttribute.of(computeSignature()));
-        mb.withFlags(flags);
+        mb.withFlags(modifiers);
         addVisible(mb);
         addInvisible(mb);
         List<GenericType.OfThrows> throws_ = this.throws_;
@@ -238,7 +238,7 @@ public sealed abstract class ExecutableCreatorImpl extends AnnotatableCreatorImp
         ArrayList<TypeAnnotation> visible = new ArrayList<>();
         ArrayList<TypeAnnotation> invisible = new ArrayList<>();
         BlockCreatorImpl bc = new BlockCreatorImpl(typeCreator, cb, returnType());
-        if ((flags & ACC_STATIC) == 0) {
+        if ((modifiers & ACC_STATIC) == 0) {
             // reserve `this` for all instance methods
             cb.localVariable(0, "this", typeCreator.type(), bc.startLabel(), bc.endLabel());
             GenericType.OfClass genericType = typeCreator.genericType();
@@ -309,7 +309,7 @@ public sealed abstract class ExecutableCreatorImpl extends AnnotatableCreatorImp
         }
         state = ST_BODY;
         try {
-            typeCreator.zb.withMethod(name(), type(), flags, mb -> {
+            typeCreator.zb.withMethod(name(), type(), modifiers, mb -> {
                 doBody(builder, mb);
             });
         } finally {

--- a/src/main/java/io/quarkus/gizmo2/impl/FieldCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/FieldCreatorImpl.java
@@ -17,7 +17,7 @@ import io.quarkus.gizmo2.GenericType;
 import io.quarkus.gizmo2.creator.FieldCreator;
 import io.quarkus.gizmo2.desc.FieldDesc;
 
-public abstract sealed class FieldCreatorImpl extends AnnotatableCreatorImpl implements FieldCreator
+public abstract sealed class FieldCreatorImpl extends ModifiableCreatorImpl implements FieldCreator
         permits StaticFieldCreatorImpl, InstanceFieldCreatorImpl {
     final ClassDesc owner;
     final String name;

--- a/src/main/java/io/quarkus/gizmo2/impl/FieldCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/FieldCreatorImpl.java
@@ -8,13 +8,11 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.constant.ClassDesc;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
-import java.util.Set;
 
 import io.github.dmlloyd.classfile.FieldBuilder;
 import io.github.dmlloyd.classfile.TypeAnnotation;
 import io.github.dmlloyd.classfile.attribute.RuntimeInvisibleTypeAnnotationsAttribute;
 import io.github.dmlloyd.classfile.attribute.RuntimeVisibleTypeAnnotationsAttribute;
-import io.github.dmlloyd.classfile.extras.reflect.AccessFlag;
 import io.quarkus.gizmo2.GenericType;
 import io.quarkus.gizmo2.creator.FieldCreator;
 import io.quarkus.gizmo2.desc.FieldDesc;
@@ -24,23 +22,13 @@ public abstract sealed class FieldCreatorImpl extends AnnotatableCreatorImpl imp
     final ClassDesc owner;
     final String name;
     final TypeCreatorImpl tc;
-    final Set<AccessFlag> unremovableFlags;
     GenericType genericType = GenericType.of(CD_int);
-    int flags;
     private FieldDesc desc;
 
-    // `defaultFlags` are also flags that cannot be removed
-    public FieldCreatorImpl(final ClassDesc owner, final String name, final TypeCreatorImpl tc,
-            final Set<AccessFlag> defaultFlags) {
+    public FieldCreatorImpl(final ClassDesc owner, final String name, final TypeCreatorImpl tc) {
         this.owner = owner;
         this.name = name;
         this.tc = tc;
-        this.unremovableFlags = defaultFlags;
-        int flags = 0;
-        for (AccessFlag defaultFlag : defaultFlags) {
-            flags |= defaultFlag.mask();
-        }
-        this.flags = flags;
     }
 
     public FieldDesc desc() {
@@ -67,56 +55,6 @@ public abstract sealed class FieldCreatorImpl extends AnnotatableCreatorImpl imp
         }
         genericType = GenericType.of(type);
         desc = null;
-    }
-
-    public final void withFlag(final AccessFlag flag) {
-        if (flag.locations().contains(AccessFlag.Location.FIELD) && flag != AccessFlag.STATIC) {
-            flags |= flag.mask();
-        } else {
-            throw new IllegalArgumentException("Cannot add flag " + flag);
-        }
-    }
-
-    final void withoutFlag(AccessFlag flag) {
-        if (unremovableFlags.contains(flag)) {
-            throw new IllegalArgumentException("Cannot remove flag " + flag);
-        } else {
-            flags &= ~flag.mask();
-        }
-    }
-
-    final void withoutFlags(AccessFlag... flags) {
-        for (AccessFlag flag : flags) {
-            withoutFlag(flag);
-        }
-    }
-
-    @Override
-    public final void public_() {
-        withFlag(AccessFlag.PUBLIC);
-        withoutFlags(AccessFlag.PRIVATE, AccessFlag.PROTECTED);
-    }
-
-    @Override
-    public final void packagePrivate() {
-        withoutFlags(AccessFlag.PUBLIC, AccessFlag.PRIVATE, AccessFlag.PROTECTED);
-    }
-
-    @Override
-    public final void private_() {
-        withFlag(AccessFlag.PRIVATE);
-        withoutFlags(AccessFlag.PUBLIC, AccessFlag.PROTECTED);
-    }
-
-    @Override
-    public final void protected_() {
-        withFlag(AccessFlag.PROTECTED);
-        withoutFlags(AccessFlag.PUBLIC, AccessFlag.PRIVATE);
-    }
-
-    @Override
-    public final void final_() {
-        withFlag(AccessFlag.FINAL);
     }
 
     public ClassDesc owner() {

--- a/src/main/java/io/quarkus/gizmo2/impl/InstanceFieldCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/InstanceFieldCreatorImpl.java
@@ -54,7 +54,7 @@ public final class InstanceFieldCreatorImpl extends FieldCreatorImpl implements 
             tc.instanceInitializer(initializer);
         }
         tc.zb.withField(name(), desc().type(), fb -> {
-            fb.withFlags(flags);
+            fb.withFlags(modifiers);
             fb.with(SignatureAttribute.of(Util.signatureOf(genericType())));
             addVisible(fb);
             addInvisible(fb);

--- a/src/main/java/io/quarkus/gizmo2/impl/InstanceFieldCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/InstanceFieldCreatorImpl.java
@@ -1,13 +1,13 @@
 package io.quarkus.gizmo2.impl;
 
 import java.lang.constant.ClassDesc;
-import java.util.Set;
 import java.util.function.Consumer;
 
 import io.github.dmlloyd.classfile.attribute.SignatureAttribute;
 import io.quarkus.gizmo2.Const;
 import io.quarkus.gizmo2.creator.BlockCreator;
 import io.quarkus.gizmo2.creator.InstanceFieldCreator;
+import io.quarkus.gizmo2.creator.ModifierLocation;
 import io.quarkus.gizmo2.desc.FieldDesc;
 import io.smallrye.common.constraint.Assert;
 
@@ -17,7 +17,11 @@ public final class InstanceFieldCreatorImpl extends FieldCreatorImpl implements 
     private Consumer<BlockCreator> initializer;
 
     public InstanceFieldCreatorImpl(final TypeCreatorImpl tc, final ClassDesc owner, final String name) {
-        super(owner, name, tc, Set.of());
+        super(owner, name, tc);
+    }
+
+    public ModifierLocation modifierLocation() {
+        return ModifierLocation.CLASS_INSTANCE_FIELD;
     }
 
     public void withInitial(final Const initial) {

--- a/src/main/java/io/quarkus/gizmo2/impl/InstanceMethodCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/InstanceMethodCreatorImpl.java
@@ -1,23 +1,14 @@
 package io.quarkus.gizmo2.impl;
 
-import static io.github.dmlloyd.classfile.extras.reflect.AccessFlag.BRIDGE;
-import static io.github.dmlloyd.classfile.extras.reflect.AccessFlag.FINAL;
-import static io.github.dmlloyd.classfile.extras.reflect.AccessFlag.PRIVATE;
-import static io.github.dmlloyd.classfile.extras.reflect.AccessFlag.PROTECTED;
-import static io.github.dmlloyd.classfile.extras.reflect.AccessFlag.PUBLIC;
-import static io.github.dmlloyd.classfile.extras.reflect.AccessFlag.SYNCHRONIZED;
-import static io.github.dmlloyd.classfile.extras.reflect.AccessFlag.SYNTHETIC;
-import static io.github.dmlloyd.classfile.extras.reflect.AccessFlag.VARARGS;
-
-import java.util.Set;
 import java.util.function.Consumer;
 
 import io.quarkus.gizmo2.creator.BlockCreator;
 import io.quarkus.gizmo2.creator.InstanceMethodCreator;
+import io.quarkus.gizmo2.creator.ModifierLocation;
 
 public final class InstanceMethodCreatorImpl extends MethodCreatorImpl implements InstanceMethodCreator {
     InstanceMethodCreatorImpl(final TypeCreatorImpl owner, final String name) {
-        super(owner, name, Set.of(), Set.of(PUBLIC, PRIVATE, PROTECTED, SYNCHRONIZED, SYNTHETIC, BRIDGE, FINAL, VARARGS));
+        super(owner, name);
     }
 
     public void body(final Consumer<BlockCreator> builder) {
@@ -26,5 +17,9 @@ public final class InstanceMethodCreatorImpl extends MethodCreatorImpl implement
 
     void accept(final Consumer<? super InstanceMethodCreatorImpl> builder) {
         builder.accept(this);
+    }
+
+    public ModifierLocation modifierLocation() {
+        return ModifierLocation.CLASS_CONCRETE_METHOD;
     }
 }

--- a/src/main/java/io/quarkus/gizmo2/impl/InterfaceCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/InterfaceCreatorImpl.java
@@ -20,7 +20,7 @@ public final class InterfaceCreatorImpl extends TypeCreatorImpl implements Inter
 
     InterfaceCreatorImpl(final ClassDesc type, final ClassOutput output, final ClassBuilder zb) {
         super(type, output, zb);
-        flags |= ACC_INTERFACE | ACC_ABSTRACT | ACC_SYNTHETIC | ACC_PUBLIC;
+        modifiers |= ACC_INTERFACE | ACC_ABSTRACT | ACC_SYNTHETIC | ACC_PUBLIC;
     }
 
     public ModifierLocation modifierLocation() {

--- a/src/main/java/io/quarkus/gizmo2/impl/InterfaceCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/InterfaceCreatorImpl.java
@@ -1,5 +1,6 @@
 package io.quarkus.gizmo2.impl;
 
+import static io.github.dmlloyd.classfile.ClassFile.*;
 import static io.smallrye.common.constraint.Assert.*;
 
 import java.lang.constant.ClassDesc;
@@ -7,28 +8,23 @@ import java.lang.constant.MethodTypeDesc;
 import java.util.function.Consumer;
 
 import io.github.dmlloyd.classfile.ClassBuilder;
-import io.github.dmlloyd.classfile.extras.reflect.AccessFlag;
 import io.quarkus.gizmo2.ClassOutput;
 import io.quarkus.gizmo2.creator.AbstractMethodCreator;
 import io.quarkus.gizmo2.creator.InstanceMethodCreator;
 import io.quarkus.gizmo2.creator.InterfaceCreator;
+import io.quarkus.gizmo2.creator.ModifierLocation;
 import io.quarkus.gizmo2.desc.InterfaceMethodDesc;
 import io.quarkus.gizmo2.desc.MethodDesc;
 
 public final class InterfaceCreatorImpl extends TypeCreatorImpl implements InterfaceCreator {
 
     InterfaceCreatorImpl(final ClassDesc type, final ClassOutput output, final ClassBuilder zb) {
-        super(type, output, zb, AccessFlag.INTERFACE.mask()
-                | AccessFlag.ABSTRACT.mask()
-                | AccessFlag.SYNTHETIC.mask()
-                | AccessFlag.PUBLIC.mask());
+        super(type, output, zb);
+        flags |= ACC_INTERFACE | ACC_ABSTRACT | ACC_SYNTHETIC | ACC_PUBLIC;
     }
 
-    public void withFlag(final AccessFlag flag) {
-        switch (flag) {
-            case INTERFACE, PUBLIC -> super.withFlag(flag);
-            default -> throw new IllegalArgumentException(flag.toString());
-        }
+    public ModifierLocation modifierLocation() {
+        return ModifierLocation.INTERFACE;
     }
 
     MethodDesc methodDesc(final String name, final MethodTypeDesc type) {

--- a/src/main/java/io/quarkus/gizmo2/impl/InterfaceMethodCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/InterfaceMethodCreatorImpl.java
@@ -1,20 +1,20 @@
 package io.quarkus.gizmo2.impl;
 
-import static io.github.dmlloyd.classfile.extras.reflect.AccessFlag.ABSTRACT;
-import static io.github.dmlloyd.classfile.extras.reflect.AccessFlag.BRIDGE;
-import static io.github.dmlloyd.classfile.extras.reflect.AccessFlag.PUBLIC;
-import static io.github.dmlloyd.classfile.extras.reflect.AccessFlag.SYNCHRONIZED;
-import static io.github.dmlloyd.classfile.extras.reflect.AccessFlag.SYNTHETIC;
-import static io.github.dmlloyd.classfile.extras.reflect.AccessFlag.VARARGS;
+import static io.github.dmlloyd.classfile.ClassFile.*;
 
-import java.util.Set;
 import java.util.function.Consumer;
 
 import io.quarkus.gizmo2.creator.AbstractMethodCreator;
+import io.quarkus.gizmo2.creator.ModifierLocation;
 
 public final class InterfaceMethodCreatorImpl extends MethodCreatorImpl implements AbstractMethodCreator {
     InterfaceMethodCreatorImpl(final TypeCreatorImpl owner, final String name) {
-        super(owner, name, Set.of(ABSTRACT, PUBLIC), Set.of(ABSTRACT, PUBLIC, SYNCHRONIZED, SYNTHETIC, BRIDGE, VARARGS));
+        super(owner, name);
+        flags |= ACC_PUBLIC | ACC_ABSTRACT;
+    }
+
+    public ModifierLocation modifierLocation() {
+        return ModifierLocation.INTERFACE_ABSTRACT_METHOD;
     }
 
     void accept(final Consumer<? super InterfaceMethodCreatorImpl> builder) {

--- a/src/main/java/io/quarkus/gizmo2/impl/InterfaceMethodCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/InterfaceMethodCreatorImpl.java
@@ -10,7 +10,7 @@ import io.quarkus.gizmo2.creator.ModifierLocation;
 public final class InterfaceMethodCreatorImpl extends MethodCreatorImpl implements AbstractMethodCreator {
     InterfaceMethodCreatorImpl(final TypeCreatorImpl owner, final String name) {
         super(owner, name);
-        flags |= ACC_PUBLIC | ACC_ABSTRACT;
+        modifiers |= ACC_PUBLIC | ACC_ABSTRACT;
     }
 
     public ModifierLocation modifierLocation() {
@@ -19,7 +19,7 @@ public final class InterfaceMethodCreatorImpl extends MethodCreatorImpl implemen
 
     void accept(final Consumer<? super InterfaceMethodCreatorImpl> builder) {
         builder.accept(this);
-        typeCreator.zb.withMethod(name(), type(), flags, mb -> {
+        typeCreator.zb.withMethod(name(), type(), modifiers, mb -> {
             doBody(null, mb);
         });
     }

--- a/src/main/java/io/quarkus/gizmo2/impl/MethodCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/MethodCreatorImpl.java
@@ -2,14 +2,12 @@ package io.quarkus.gizmo2.impl;
 
 import java.lang.annotation.ElementType;
 import java.lang.constant.ClassDesc;
-import java.util.Set;
 import java.util.function.Consumer;
 
-import io.github.dmlloyd.classfile.extras.reflect.AccessFlag;
 import io.quarkus.gizmo2.GenericType;
 import io.quarkus.gizmo2.TypeVariable;
-import io.quarkus.gizmo2.TypeVariableCreator;
 import io.quarkus.gizmo2.creator.MethodCreator;
+import io.quarkus.gizmo2.creator.TypeVariableCreator;
 import io.quarkus.gizmo2.desc.MethodDesc;
 
 public abstract sealed class MethodCreatorImpl extends ExecutableCreatorImpl implements MethodCreator
@@ -19,9 +17,8 @@ public abstract sealed class MethodCreatorImpl extends ExecutableCreatorImpl imp
     final String name;
     private MethodDesc desc;
 
-    MethodCreatorImpl(final TypeCreatorImpl owner, final String name, final Set<AccessFlag> defaultFlags,
-            Set<AccessFlag> allowedFlags) {
-        super(owner, defaultFlags, allowedFlags);
+    MethodCreatorImpl(final TypeCreatorImpl owner, final String name) {
+        super(owner);
         this.name = name;
     }
 

--- a/src/main/java/io/quarkus/gizmo2/impl/ModifiableCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/ModifiableCreatorImpl.java
@@ -1,0 +1,50 @@
+package io.quarkus.gizmo2.impl;
+
+import java.util.List;
+
+import io.github.dmlloyd.classfile.Annotation;
+import io.quarkus.gizmo2.creator.AccessLevel;
+import io.quarkus.gizmo2.creator.ModifiableCreator;
+import io.quarkus.gizmo2.creator.Modifier;
+import io.quarkus.gizmo2.creator.ModifierFlag;
+
+public abstract sealed class ModifiableCreatorImpl extends AnnotatableCreatorImpl implements ModifiableCreator
+        permits ExecutableCreatorImpl, FieldCreatorImpl, ParamCreatorImpl, TypeCreatorImpl {
+    int modifiers;
+
+    ModifiableCreatorImpl() {
+    }
+
+    ModifiableCreatorImpl(final List<Annotation> visible, final List<Annotation> invisible) {
+        super(visible, invisible);
+    }
+
+    public void withFlag(final ModifierFlag flag) {
+        if (supports(flag)) {
+            modifiers |= flag.mask();
+        } else {
+            throw modifierUnsupported(flag);
+        }
+    }
+
+    public void withoutFlag(final ModifierFlag flag) {
+        if (supports(flag)) {
+            modifiers &= ~flag.mask();
+        } else {
+            throw modifierUnsupported(flag);
+        }
+    }
+
+    public void withAccess(final AccessLevel access) {
+        if (supports(access)) {
+            modifiers = modifiers & ~AccessLevel.fullMask() | access.mask();
+        } else {
+            throw modifierUnsupported(access);
+        }
+    }
+
+    private static IllegalArgumentException modifierUnsupported(final Modifier modifier) {
+        return new IllegalArgumentException("Modifier \"%s\" is not supported here".formatted(modifier));
+    }
+
+}

--- a/src/main/java/io/quarkus/gizmo2/impl/NativeMethodCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/NativeMethodCreatorImpl.java
@@ -1,21 +1,20 @@
 package io.quarkus.gizmo2.impl;
 
-import static io.github.dmlloyd.classfile.extras.reflect.AccessFlag.BRIDGE;
-import static io.github.dmlloyd.classfile.extras.reflect.AccessFlag.NATIVE;
-import static io.github.dmlloyd.classfile.extras.reflect.AccessFlag.PRIVATE;
-import static io.github.dmlloyd.classfile.extras.reflect.AccessFlag.PROTECTED;
-import static io.github.dmlloyd.classfile.extras.reflect.AccessFlag.PUBLIC;
-import static io.github.dmlloyd.classfile.extras.reflect.AccessFlag.SYNTHETIC;
-import static io.github.dmlloyd.classfile.extras.reflect.AccessFlag.VARARGS;
+import static io.github.dmlloyd.classfile.ClassFile.*;
 
-import java.util.Set;
 import java.util.function.Consumer;
 
 import io.quarkus.gizmo2.creator.AbstractMethodCreator;
+import io.quarkus.gizmo2.creator.ModifierLocation;
 
 public final class NativeMethodCreatorImpl extends MethodCreatorImpl implements AbstractMethodCreator {
     NativeMethodCreatorImpl(final TypeCreatorImpl owner, final String name) {
-        super(owner, name, Set.of(NATIVE), Set.of(PUBLIC, PRIVATE, PROTECTED, SYNTHETIC, BRIDGE, NATIVE, VARARGS));
+        super(owner, name);
+        flags |= ACC_NATIVE;
+    }
+
+    public ModifierLocation modifierLocation() {
+        return ModifierLocation.CLASS_NATIVE_METHOD;
     }
 
     void accept(final Consumer<? super NativeMethodCreatorImpl> builder) {

--- a/src/main/java/io/quarkus/gizmo2/impl/NativeMethodCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/NativeMethodCreatorImpl.java
@@ -10,7 +10,7 @@ import io.quarkus.gizmo2.creator.ModifierLocation;
 public final class NativeMethodCreatorImpl extends MethodCreatorImpl implements AbstractMethodCreator {
     NativeMethodCreatorImpl(final TypeCreatorImpl owner, final String name) {
         super(owner, name);
-        flags |= ACC_NATIVE;
+        modifiers |= ACC_NATIVE;
     }
 
     public ModifierLocation modifierLocation() {
@@ -19,7 +19,7 @@ public final class NativeMethodCreatorImpl extends MethodCreatorImpl implements 
 
     void accept(final Consumer<? super NativeMethodCreatorImpl> builder) {
         builder.accept(this);
-        typeCreator.zb.withMethod(name(), type(), flags, mb -> {
+        typeCreator.zb.withMethod(name(), type(), modifiers, mb -> {
             doBody(null, mb);
         });
     }

--- a/src/main/java/io/quarkus/gizmo2/impl/ParamCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/ParamCreatorImpl.java
@@ -12,7 +12,7 @@ import io.quarkus.gizmo2.GenericType;
 import io.quarkus.gizmo2.creator.ModifierLocation;
 import io.quarkus.gizmo2.creator.ParamCreator;
 
-public final class ParamCreatorImpl extends AnnotatableCreatorImpl implements ParamCreator {
+public final class ParamCreatorImpl extends ModifiableCreatorImpl implements ParamCreator {
     boolean typeEstablished;
     GenericType genericType;
 
@@ -34,7 +34,7 @@ public final class ParamCreatorImpl extends AnnotatableCreatorImpl implements Pa
             throw new IllegalStateException("Parameter type was not set");
         }
         typeEstablished = true;
-        return new ParamVarImpl(genericType, name, index, slot, flags, List.copyOf(invisible.values()),
+        return new ParamVarImpl(genericType, name, index, slot, modifiers, List.copyOf(invisible.values()),
                 List.copyOf(visible.values()));
     }
 

--- a/src/main/java/io/quarkus/gizmo2/impl/ParamCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/ParamCreatorImpl.java
@@ -1,6 +1,6 @@
 package io.quarkus.gizmo2.impl;
 
-import static io.smallrye.common.constraint.Assert.checkNotNullParam;
+import static io.smallrye.common.constraint.Assert.*;
 
 import java.lang.annotation.ElementType;
 import java.lang.constant.ClassDesc;
@@ -8,12 +8,11 @@ import java.lang.constant.ConstantDescs;
 import java.util.List;
 import java.util.function.Consumer;
 
-import io.github.dmlloyd.classfile.extras.reflect.AccessFlag;
 import io.quarkus.gizmo2.GenericType;
+import io.quarkus.gizmo2.creator.ModifierLocation;
 import io.quarkus.gizmo2.creator.ParamCreator;
 
 public final class ParamCreatorImpl extends AnnotatableCreatorImpl implements ParamCreator {
-    int flags = 0;
     boolean typeEstablished;
     GenericType genericType;
 
@@ -25,6 +24,10 @@ public final class ParamCreatorImpl extends AnnotatableCreatorImpl implements Pa
         typeEstablished = true;
     }
 
+    public ModifierLocation modifierLocation() {
+        return ModifierLocation.PARAMETER;
+    }
+
     ParamVarImpl apply(final Consumer<ParamCreator> builder, final String name, final int index, final int slot) {
         builder.accept(this);
         if (genericType == null) {
@@ -33,14 +36,6 @@ public final class ParamCreatorImpl extends AnnotatableCreatorImpl implements Pa
         typeEstablished = true;
         return new ParamVarImpl(genericType, name, index, slot, flags, List.copyOf(invisible.values()),
                 List.copyOf(visible.values()));
-    }
-
-    public void withFlag(final AccessFlag flag) {
-        if (flag.locations().contains(AccessFlag.Location.METHOD_PARAMETER)) {
-            flags |= flag.mask();
-        } else {
-            throw new IllegalArgumentException("Invalid flag for parameter: " + flag);
-        }
     }
 
     public void withType(final GenericType genericType) {

--- a/src/main/java/io/quarkus/gizmo2/impl/PrivateInterfaceMethodCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/PrivateInterfaceMethodCreatorImpl.java
@@ -11,7 +11,7 @@ import io.quarkus.gizmo2.creator.ModifierLocation;
 public final class PrivateInterfaceMethodCreatorImpl extends MethodCreatorImpl implements InstanceMethodCreator {
     PrivateInterfaceMethodCreatorImpl(final TypeCreatorImpl owner, final String name) {
         super(owner, name);
-        flags |= ACC_PRIVATE;
+        modifiers |= ACC_PRIVATE;
     }
 
     public ModifierLocation modifierLocation() {

--- a/src/main/java/io/quarkus/gizmo2/impl/PrivateInterfaceMethodCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/PrivateInterfaceMethodCreatorImpl.java
@@ -1,20 +1,21 @@
 package io.quarkus.gizmo2.impl;
 
-import static io.github.dmlloyd.classfile.extras.reflect.AccessFlag.BRIDGE;
-import static io.github.dmlloyd.classfile.extras.reflect.AccessFlag.PRIVATE;
-import static io.github.dmlloyd.classfile.extras.reflect.AccessFlag.SYNCHRONIZED;
-import static io.github.dmlloyd.classfile.extras.reflect.AccessFlag.SYNTHETIC;
-import static io.github.dmlloyd.classfile.extras.reflect.AccessFlag.VARARGS;
+import static io.github.dmlloyd.classfile.ClassFile.*;
 
-import java.util.Set;
 import java.util.function.Consumer;
 
 import io.quarkus.gizmo2.creator.BlockCreator;
 import io.quarkus.gizmo2.creator.InstanceMethodCreator;
+import io.quarkus.gizmo2.creator.ModifierLocation;
 
 public final class PrivateInterfaceMethodCreatorImpl extends MethodCreatorImpl implements InstanceMethodCreator {
     PrivateInterfaceMethodCreatorImpl(final TypeCreatorImpl owner, final String name) {
-        super(owner, name, Set.of(PRIVATE), Set.of(PRIVATE, SYNCHRONIZED, SYNTHETIC, BRIDGE, VARARGS));
+        super(owner, name);
+        flags |= ACC_PRIVATE;
+    }
+
+    public ModifierLocation modifierLocation() {
+        return ModifierLocation.INTERFACE_CONCRETE_METHOD;
     }
 
     public void body(final Consumer<BlockCreator> builder) {

--- a/src/main/java/io/quarkus/gizmo2/impl/StaticFieldCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/StaticFieldCreatorImpl.java
@@ -24,9 +24,9 @@ public final class StaticFieldCreatorImpl extends FieldCreatorImpl implements St
             final boolean isInterface) {
         super(owner, name, tc);
         this.isInterface = isInterface;
-        flags |= ACC_STATIC;
+        modifiers |= ACC_STATIC;
         if (isInterface) {
-            flags |= ACC_PUBLIC | ACC_FINAL;
+            modifiers |= ACC_PUBLIC | ACC_FINAL;
         }
     }
 
@@ -66,7 +66,7 @@ public final class StaticFieldCreatorImpl extends FieldCreatorImpl implements St
             tc.staticInitializer(initializer);
         }
         tc.zb.withField(name(), desc().type(), fb -> {
-            fb.withFlags(flags);
+            fb.withFlags(modifiers);
             fb.with(SignatureAttribute.of(Util.signatureOf(genericType())));
             addVisible(fb);
             addInvisible(fb);

--- a/src/main/java/io/quarkus/gizmo2/impl/StaticFieldCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/StaticFieldCreatorImpl.java
@@ -1,29 +1,37 @@
 package io.quarkus.gizmo2.impl;
 
-import static io.github.dmlloyd.classfile.extras.reflect.AccessFlag.FINAL;
-import static io.github.dmlloyd.classfile.extras.reflect.AccessFlag.PUBLIC;
-import static io.github.dmlloyd.classfile.extras.reflect.AccessFlag.STATIC;
+import static io.github.dmlloyd.classfile.ClassFile.*;
 import static java.lang.constant.ConstantDescs.*;
 
 import java.lang.constant.ClassDesc;
-import java.util.Set;
 import java.util.function.Consumer;
 
 import io.github.dmlloyd.classfile.attribute.ConstantValueAttribute;
 import io.github.dmlloyd.classfile.attribute.SignatureAttribute;
 import io.quarkus.gizmo2.Const;
 import io.quarkus.gizmo2.creator.BlockCreator;
+import io.quarkus.gizmo2.creator.ModifierLocation;
 import io.quarkus.gizmo2.creator.StaticFieldCreator;
 import io.quarkus.gizmo2.desc.FieldDesc;
 import io.smallrye.common.constraint.Assert;
 
 public final class StaticFieldCreatorImpl extends FieldCreatorImpl implements StaticFieldCreator {
+    private final boolean isInterface;
     private Const initial;
     private Consumer<BlockCreator> initializer;
 
     public StaticFieldCreatorImpl(final TypeCreatorImpl tc, final ClassDesc owner, final String name,
             final boolean isInterface) {
-        super(owner, name, tc, isInterface ? Set.of(PUBLIC, STATIC, FINAL) : Set.of(STATIC));
+        super(owner, name, tc);
+        this.isInterface = isInterface;
+        flags |= ACC_STATIC;
+        if (isInterface) {
+            flags |= ACC_PUBLIC | ACC_FINAL;
+        }
+    }
+
+    public ModifierLocation modifierLocation() {
+        return isInterface ? ModifierLocation.INTERFACE_STATIC_FIELD : ModifierLocation.CLASS_STATIC_FIELD;
     }
 
     public void withInitial(final Const initial) {

--- a/src/main/java/io/quarkus/gizmo2/impl/StaticInterfaceMethodCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/StaticInterfaceMethodCreatorImpl.java
@@ -1,22 +1,21 @@
 package io.quarkus.gizmo2.impl;
 
-import static io.github.dmlloyd.classfile.extras.reflect.AccessFlag.BRIDGE;
-import static io.github.dmlloyd.classfile.extras.reflect.AccessFlag.FINAL;
-import static io.github.dmlloyd.classfile.extras.reflect.AccessFlag.PUBLIC;
-import static io.github.dmlloyd.classfile.extras.reflect.AccessFlag.STATIC;
-import static io.github.dmlloyd.classfile.extras.reflect.AccessFlag.SYNCHRONIZED;
-import static io.github.dmlloyd.classfile.extras.reflect.AccessFlag.SYNTHETIC;
-import static io.github.dmlloyd.classfile.extras.reflect.AccessFlag.VARARGS;
+import static io.github.dmlloyd.classfile.ClassFile.*;
 
-import java.util.Set;
 import java.util.function.Consumer;
 
 import io.quarkus.gizmo2.creator.BlockCreator;
+import io.quarkus.gizmo2.creator.ModifierLocation;
 import io.quarkus.gizmo2.creator.StaticMethodCreator;
 
 public final class StaticInterfaceMethodCreatorImpl extends MethodCreatorImpl implements StaticMethodCreator {
     StaticInterfaceMethodCreatorImpl(final TypeCreatorImpl owner, final String name) {
-        super(owner, name, Set.of(STATIC, PUBLIC), Set.of(PUBLIC, STATIC, SYNCHRONIZED, SYNTHETIC, BRIDGE, FINAL, VARARGS));
+        super(owner, name);
+        flags |= ACC_PUBLIC | ACC_STATIC;
+    }
+
+    public ModifierLocation modifierLocation() {
+        return ModifierLocation.INTERFACE_STATIC_METHOD;
     }
 
     public void body(final Consumer<BlockCreator> builder) {

--- a/src/main/java/io/quarkus/gizmo2/impl/StaticInterfaceMethodCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/StaticInterfaceMethodCreatorImpl.java
@@ -11,7 +11,7 @@ import io.quarkus.gizmo2.creator.StaticMethodCreator;
 public final class StaticInterfaceMethodCreatorImpl extends MethodCreatorImpl implements StaticMethodCreator {
     StaticInterfaceMethodCreatorImpl(final TypeCreatorImpl owner, final String name) {
         super(owner, name);
-        flags |= ACC_PUBLIC | ACC_STATIC;
+        modifiers |= ACC_PUBLIC | ACC_STATIC;
     }
 
     public ModifierLocation modifierLocation() {

--- a/src/main/java/io/quarkus/gizmo2/impl/StaticMethodCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/StaticMethodCreatorImpl.java
@@ -11,7 +11,7 @@ import io.quarkus.gizmo2.creator.StaticMethodCreator;
 public final class StaticMethodCreatorImpl extends MethodCreatorImpl implements StaticMethodCreator {
     StaticMethodCreatorImpl(final TypeCreatorImpl owner, final String name) {
         super(owner, name);
-        flags |= ACC_STATIC;
+        modifiers |= ACC_STATIC;
     }
 
     public ModifierLocation modifierLocation() {

--- a/src/main/java/io/quarkus/gizmo2/impl/StaticMethodCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/StaticMethodCreatorImpl.java
@@ -1,25 +1,21 @@
 package io.quarkus.gizmo2.impl;
 
-import static io.github.dmlloyd.classfile.extras.reflect.AccessFlag.BRIDGE;
-import static io.github.dmlloyd.classfile.extras.reflect.AccessFlag.FINAL;
-import static io.github.dmlloyd.classfile.extras.reflect.AccessFlag.PRIVATE;
-import static io.github.dmlloyd.classfile.extras.reflect.AccessFlag.PROTECTED;
-import static io.github.dmlloyd.classfile.extras.reflect.AccessFlag.PUBLIC;
-import static io.github.dmlloyd.classfile.extras.reflect.AccessFlag.STATIC;
-import static io.github.dmlloyd.classfile.extras.reflect.AccessFlag.SYNCHRONIZED;
-import static io.github.dmlloyd.classfile.extras.reflect.AccessFlag.SYNTHETIC;
-import static io.github.dmlloyd.classfile.extras.reflect.AccessFlag.VARARGS;
+import static io.github.dmlloyd.classfile.ClassFile.*;
 
-import java.util.Set;
 import java.util.function.Consumer;
 
 import io.quarkus.gizmo2.creator.BlockCreator;
+import io.quarkus.gizmo2.creator.ModifierLocation;
 import io.quarkus.gizmo2.creator.StaticMethodCreator;
 
 public final class StaticMethodCreatorImpl extends MethodCreatorImpl implements StaticMethodCreator {
     StaticMethodCreatorImpl(final TypeCreatorImpl owner, final String name) {
-        super(owner, name, Set.of(STATIC),
-                Set.of(PUBLIC, PRIVATE, PROTECTED, STATIC, SYNCHRONIZED, SYNTHETIC, BRIDGE, FINAL, VARARGS));
+        super(owner, name);
+        flags |= ACC_STATIC;
+    }
+
+    public ModifierLocation modifierLocation() {
+        return ModifierLocation.CLASS_STATIC_METHOD;
     }
 
     public void body(final Consumer<BlockCreator> builder) {

--- a/src/main/java/io/quarkus/gizmo2/impl/StaticNativeMethodCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/StaticNativeMethodCreatorImpl.java
@@ -10,7 +10,7 @@ import io.quarkus.gizmo2.creator.ModifierLocation;
 public final class StaticNativeMethodCreatorImpl extends MethodCreatorImpl implements AbstractMethodCreator {
     StaticNativeMethodCreatorImpl(final TypeCreatorImpl owner, final String name) {
         super(owner, name);
-        flags |= ACC_STATIC | ACC_NATIVE;
+        modifiers |= ACC_STATIC | ACC_NATIVE;
     }
 
     public ModifierLocation modifierLocation() {
@@ -19,7 +19,7 @@ public final class StaticNativeMethodCreatorImpl extends MethodCreatorImpl imple
 
     void accept(final Consumer<? super StaticNativeMethodCreatorImpl> builder) {
         builder.accept(this);
-        typeCreator.zb.withMethod(name(), type(), flags, mb -> {
+        typeCreator.zb.withMethod(name(), type(), modifiers, mb -> {
             doBody(null, mb);
         });
     }

--- a/src/main/java/io/quarkus/gizmo2/impl/StaticNativeMethodCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/StaticNativeMethodCreatorImpl.java
@@ -1,23 +1,20 @@
 package io.quarkus.gizmo2.impl;
 
-import static io.github.dmlloyd.classfile.extras.reflect.AccessFlag.BRIDGE;
-import static io.github.dmlloyd.classfile.extras.reflect.AccessFlag.NATIVE;
-import static io.github.dmlloyd.classfile.extras.reflect.AccessFlag.PRIVATE;
-import static io.github.dmlloyd.classfile.extras.reflect.AccessFlag.PROTECTED;
-import static io.github.dmlloyd.classfile.extras.reflect.AccessFlag.PUBLIC;
-import static io.github.dmlloyd.classfile.extras.reflect.AccessFlag.STATIC;
-import static io.github.dmlloyd.classfile.extras.reflect.AccessFlag.SYNTHETIC;
-import static io.github.dmlloyd.classfile.extras.reflect.AccessFlag.VARARGS;
+import static io.github.dmlloyd.classfile.ClassFile.*;
 
-import java.util.Set;
 import java.util.function.Consumer;
 
 import io.quarkus.gizmo2.creator.AbstractMethodCreator;
+import io.quarkus.gizmo2.creator.ModifierLocation;
 
 public final class StaticNativeMethodCreatorImpl extends MethodCreatorImpl implements AbstractMethodCreator {
     StaticNativeMethodCreatorImpl(final TypeCreatorImpl owner, final String name) {
-        super(owner, name, Set.of(NATIVE, STATIC),
-                Set.of(PUBLIC, PRIVATE, PROTECTED, SYNTHETIC, BRIDGE, NATIVE, STATIC, VARARGS));
+        super(owner, name);
+        flags |= ACC_STATIC | ACC_NATIVE;
+    }
+
+    public ModifierLocation modifierLocation() {
+        return ModifierLocation.CLASS_NATIVE_METHOD;
     }
 
     void accept(final Consumer<? super StaticNativeMethodCreatorImpl> builder) {

--- a/src/main/java/io/quarkus/gizmo2/impl/TypeAnnotatableCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/TypeAnnotatableCreatorImpl.java
@@ -4,6 +4,7 @@ import java.lang.annotation.ElementType;
 import java.util.List;
 
 import io.github.dmlloyd.classfile.Annotation;
+import io.quarkus.gizmo2.creator.ModifierLocation;
 
 public final class TypeAnnotatableCreatorImpl extends AnnotatableCreatorImpl {
 
@@ -16,5 +17,9 @@ public final class TypeAnnotatableCreatorImpl extends AnnotatableCreatorImpl {
 
     public ElementType annotationTargetType() {
         return ElementType.TYPE_USE;
+    }
+
+    public ModifierLocation modifierLocation() {
+        return ModifierLocation.NONE;
     }
 }

--- a/src/main/java/io/quarkus/gizmo2/impl/TypeAnnotatableCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/TypeAnnotatableCreatorImpl.java
@@ -4,7 +4,6 @@ import java.lang.annotation.ElementType;
 import java.util.List;
 
 import io.github.dmlloyd.classfile.Annotation;
-import io.quarkus.gizmo2.creator.ModifierLocation;
 
 public final class TypeAnnotatableCreatorImpl extends AnnotatableCreatorImpl {
 
@@ -17,9 +16,5 @@ public final class TypeAnnotatableCreatorImpl extends AnnotatableCreatorImpl {
 
     public ElementType annotationTargetType() {
         return ElementType.TYPE_USE;
-    }
-
-    public ModifierLocation modifierLocation() {
-        return ModifierLocation.NONE;
     }
 }

--- a/src/main/java/io/quarkus/gizmo2/impl/TypeCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/TypeCreatorImpl.java
@@ -50,7 +50,7 @@ import io.quarkus.gizmo2.StaticFieldVar;
 import io.quarkus.gizmo2.This;
 import io.quarkus.gizmo2.TypeArgument;
 import io.quarkus.gizmo2.TypeVariable;
-import io.quarkus.gizmo2.creator.Access;
+import io.quarkus.gizmo2.creator.AccessLevel;
 import io.quarkus.gizmo2.creator.BlockCreator;
 import io.quarkus.gizmo2.creator.StaticFieldCreator;
 import io.quarkus.gizmo2.creator.StaticMethodCreator;
@@ -357,7 +357,7 @@ public abstract sealed class TypeCreatorImpl extends AnnotatableCreatorImpl impl
                             CD_String,
                             CD_MethodType),
                     smc -> {
-                        smc.withAccess(Access.PRIVATE);
+                        smc.withAccess(AccessLevel.PRIVATE);
                         ParamVar lookup = smc.parameter("lookup", 0);
                         ParamVar base64 = smc.parameter("base64", 1);
                         ParamVar methodType = smc.parameter("methodType", 2);

--- a/src/main/java/io/quarkus/gizmo2/impl/TypeCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/TypeCreatorImpl.java
@@ -63,7 +63,7 @@ import io.quarkus.gizmo2.desc.InterfaceMethodDesc;
 import io.quarkus.gizmo2.desc.MethodDesc;
 import io.smallrye.common.constraint.Assert;
 
-public abstract sealed class TypeCreatorImpl extends AnnotatableCreatorImpl implements TypeCreator
+public abstract sealed class TypeCreatorImpl extends ModifiableCreatorImpl implements TypeCreator
         permits ClassCreatorImpl, InterfaceCreatorImpl {
 
     private static final ClassDesc CD_InputStream = Util.classDesc(InputStream.class);
@@ -237,7 +237,7 @@ public abstract sealed class TypeCreatorImpl extends AnnotatableCreatorImpl impl
     public MethodDesc staticMethod(final String name, final Consumer<StaticMethodCreator> builder) {
         checkNotNullParam("builder", builder);
         MethodDesc desc;
-        boolean isInterface = (flags & ACC_INTERFACE) != 0;
+        boolean isInterface = (modifiers & ACC_INTERFACE) != 0;
         if (isInterface) {
             StaticInterfaceMethodCreatorImpl smc = new StaticInterfaceMethodCreatorImpl(this, name);
             smc.accept(builder);
@@ -256,7 +256,7 @@ public abstract sealed class TypeCreatorImpl extends AnnotatableCreatorImpl impl
     public StaticFieldVar staticField(final String name, final Consumer<StaticFieldCreator> builder) {
         checkNotNullParam("name", name);
         checkNotNullParam("builder", builder);
-        boolean isInterface = (flags & ACC_INTERFACE) != 0;
+        boolean isInterface = (modifiers & ACC_INTERFACE) != 0;
         var fc = new StaticFieldCreatorImpl(this, type(), name, isInterface);
         fc.accept(builder);
         FieldDesc desc = fc.desc();
@@ -281,7 +281,7 @@ public abstract sealed class TypeCreatorImpl extends AnnotatableCreatorImpl impl
     void postAccept() {
         zb.withSuperclass(superSig.desc());
         zb.withInterfaces(interfaceSigs.stream().map(d -> zb.constantPool().classEntry(d.desc())).toList());
-        zb.withFlags(flags);
+        zb.withFlags(modifiers);
         zb.with(SignatureAttribute.of(computeSignature()));
         addVisible(zb);
         addInvisible(zb);

--- a/src/main/java/io/quarkus/gizmo2/impl/TypeVariableCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/TypeVariableCreatorImpl.java
@@ -12,7 +12,8 @@ import java.util.Optional;
 import io.github.dmlloyd.classfile.Annotation;
 import io.quarkus.gizmo2.GenericType;
 import io.quarkus.gizmo2.TypeVariable;
-import io.quarkus.gizmo2.TypeVariableCreator;
+import io.quarkus.gizmo2.creator.ModifierLocation;
+import io.quarkus.gizmo2.creator.TypeVariableCreator;
 import io.quarkus.gizmo2.desc.ConstructorDesc;
 import io.quarkus.gizmo2.desc.MethodDesc;
 import io.smallrye.common.constraint.Assert;
@@ -29,6 +30,10 @@ public final class TypeVariableCreatorImpl extends AnnotatableCreatorImpl implem
     public TypeVariableCreatorImpl(final List<Annotation> visible, final List<Annotation> invisible, final String name) {
         super(visible, invisible);
         this.name = name;
+    }
+
+    public ModifierLocation modifierLocation() {
+        return ModifierLocation.NONE;
     }
 
     public String name() {

--- a/src/main/java/io/quarkus/gizmo2/impl/TypeVariableCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/TypeVariableCreatorImpl.java
@@ -12,7 +12,6 @@ import java.util.Optional;
 import io.github.dmlloyd.classfile.Annotation;
 import io.quarkus.gizmo2.GenericType;
 import io.quarkus.gizmo2.TypeVariable;
-import io.quarkus.gizmo2.creator.ModifierLocation;
 import io.quarkus.gizmo2.creator.TypeVariableCreator;
 import io.quarkus.gizmo2.desc.ConstructorDesc;
 import io.quarkus.gizmo2.desc.MethodDesc;
@@ -30,10 +29,6 @@ public final class TypeVariableCreatorImpl extends AnnotatableCreatorImpl implem
     public TypeVariableCreatorImpl(final List<Annotation> visible, final List<Annotation> invisible, final String name) {
         super(visible, invisible);
         this.name = name;
-    }
-
-    public ModifierLocation modifierLocation() {
-        return ModifierLocation.NONE;
     }
 
     public String name() {

--- a/src/test/java/io/quarkus/gizmo2/AccessFlagsTest.java
+++ b/src/test/java/io/quarkus/gizmo2/AccessFlagsTest.java
@@ -29,7 +29,7 @@ public class AccessFlagsTest {
         assertFalse(clazz.isInterface());
         assertTrue(clazz.isSynthetic());
         assertTrue(Modifier.isPublic(clazz.getModifiers()));
-        assertTrue(Arrays.stream(clazz.getInterfaces()).anyMatch(c -> c.equals(Function.class)));
+        assertTrue(Arrays.asList(clazz.getInterfaces()).contains(Function.class));
         assertEquals(Super.class, clazz.getSuperclass());
     }
 
@@ -48,7 +48,7 @@ public class AccessFlagsTest {
         assertFalse(Modifier.isPublic(clazz.getModifiers()));
         assertFalse(Modifier.isPrivate(clazz.getModifiers()));
         assertFalse(Modifier.isProtected(clazz.getModifiers()));
-        assertTrue(Arrays.stream(clazz.getInterfaces()).anyMatch(c -> c.equals(Function.class)));
+        assertTrue(Arrays.asList(clazz.getInterfaces()).contains(Function.class));
         assertEquals(Super.class, clazz.getSuperclass());
     }
 
@@ -64,7 +64,7 @@ public class AccessFlagsTest {
         assertTrue(clazz.isSynthetic());
         assertTrue(Modifier.isPublic(clazz.getModifiers()));
         assertTrue(Modifier.isAbstract(clazz.getModifiers()));
-        assertTrue(Arrays.stream(clazz.getInterfaces()).anyMatch(c -> c.equals(Consumer.class)));
+        assertTrue(Arrays.asList(clazz.getInterfaces()).contains(Consumer.class));
         assertNull(clazz.getSuperclass());
     }
 
@@ -83,7 +83,7 @@ public class AccessFlagsTest {
         assertFalse(Modifier.isPrivate(clazz.getModifiers()));
         assertFalse(Modifier.isProtected(clazz.getModifiers()));
         assertTrue(Modifier.isAbstract(clazz.getModifiers()));
-        assertTrue(Arrays.stream(clazz.getInterfaces()).anyMatch(c -> c.equals(Consumer.class)));
+        assertTrue(Arrays.asList(clazz.getInterfaces()).contains(Consumer.class));
         assertNull(clazz.getSuperclass());
     }
 


### PR DESCRIPTION
Fixes #335.

Version 1 of this change used type-safe constants for all of the modifiers and access levels; it was pretty nifty but added about 30-40 new types, so it seemed a bit to heavy to justify.

This version makes a fair effort to put convenience methods in the right place, but otherwise does all checking at run time.

At present, if you try to introduce a flag to a creator which always forces that flag to be set, then you will get an exception. I'm undecided whether this is a preferable behavior.

I did not do anything about default access levels or modifiers yet, other than more or less mirroring what was already in the code.