### PR TITLE
Remove unused default method

### DIFF
--- a/src/main/java/io/quarkus/gizmo2/FieldVar.java
+++ b/src/main/java/io/quarkus/gizmo2/FieldVar.java
@@ -27,11 +27,4 @@ public sealed interface FieldVar extends Var permits InstanceFieldVar, StaticFie
      * {@return the descriptor of the field}
      */
     FieldDesc desc();
-
-    /**
-     * {@return {@code false} always (field variables may be reused)}
-     */
-    default boolean bound() {
-        return false;
-    }
 }


### PR DESCRIPTION
It's overridden in both subclasses. Also, the doc is not strictly accurate because a field deref might get bound.