### PR TITLE
improve local vars

### DIFF
--- a/src/main/java/io/quarkus/gizmo2/creator/BlockCreator.java
+++ b/src/main/java/io/quarkus/gizmo2/creator/BlockCreator.java
@@ -122,8 +122,8 @@ public sealed interface BlockCreator extends SimpleTyped permits BlockCreatorImp
     // lexical variables
 
     /**
-     * Declare a local variable, but doesn't assign it a value.
-     * Such variables may not be read before they are written.
+     * Declare a local variable with given {@code name} and {@code type}, which is initialized
+     * to the {@linkplain Const#ofDefault(ClassDesc) default value} of given type.
      * <p>
      * Variable names are not strictly required to be unique, but it is a good practice.
      *
@@ -134,8 +134,8 @@ public sealed interface BlockCreator extends SimpleTyped permits BlockCreatorImp
     LocalVar declare(String name, GenericType type);
 
     /**
-     * Declare a local variable, but doesn't assign it a value.
-     * Such variables may not be read before they are written.
+     * Declare a local variable with given {@code name} and {@code type}, which is initialized
+     * to the {@linkplain Const#ofDefault(ClassDesc) default value} of given type.
      * <p>
      * Variable names are not strictly required to be unique, but it is a good practice.
      *
@@ -148,8 +148,8 @@ public sealed interface BlockCreator extends SimpleTyped permits BlockCreatorImp
     }
 
     /**
-     * Declare a local variable, but doesn't assign it a value.
-     * Such variables may not be read before they are written.
+     * Declare a local variable with given {@code name} and {@code type}, which is initialized
+     * to the {@linkplain Const#ofDefault(Class) default value} of given type.
      * <p>
      * Variable names are not strictly required to be unique, but it is a good practice.
      *
@@ -162,7 +162,8 @@ public sealed interface BlockCreator extends SimpleTyped permits BlockCreatorImp
     }
 
     /**
-     * Declare a local variable and define its initial value.
+     * Declare a local variable with given {@code name}, which is initialized to the given {@code value}.
+     * The type of the new variable is the type of the {@code value}.
      * <p>
      * Variable names are not strictly required to be unique, but it is a good practice.
      *
@@ -170,23 +171,22 @@ public sealed interface BlockCreator extends SimpleTyped permits BlockCreatorImp
      * @param value the variable initial value (must not be {@code null})
      * @return the local variable (not {@code null})
      */
-    default LocalVar define(String name, Expr value) {
+    default LocalVar declare(String name, Expr value) {
         LocalVar var = declare(name, value.genericType());
         set(var, value);
         return var;
     }
 
     /**
-     * Declare a local variable which is initialized to the given variable's current value.
+     * Declare a local variable, which is initialized to the given variable's current value.
+     * The name and type of the new variable are the same as the name and type of the {@code original}.
      * The given variable may be a parameter, local variable, or field variable.
-     * <p>
-     * The name of the new variable is the same as the name of the {@code original}.
      *
      * @param original the original variable (must not be {@code null})
-     * @return the new local variable (must not be {@code null})
+     * @return the new local variable (not {@code null})
      */
-    default LocalVar define(Var original) {
-        return define(original.name(), original);
+    default LocalVar declare(Var original) {
+        return declare(original.name(), original);
     }
 
     // reading memory

--- a/src/main/java/io/quarkus/gizmo2/creator/ops/StringBuilderOps.java
+++ b/src/main/java/io/quarkus/gizmo2/creator/ops/StringBuilderOps.java
@@ -35,7 +35,7 @@ public final class StringBuilderOps extends ObjectOps implements ComparableOps {
      * @param bc the block creator (must not be {@code null})
      */
     public StringBuilderOps(final BlockCreator bc) {
-        super(StringBuilder.class, bc, bc.define("stringBuilder", bc.new_(StringBuilder.class)));
+        super(StringBuilder.class, bc, bc.declare("stringBuilder", bc.new_(StringBuilder.class)));
     }
 
     /**

--- a/src/main/java/io/quarkus/gizmo2/impl/BlockCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/BlockCreatorImpl.java
@@ -218,6 +218,7 @@ public final class BlockCreatorImpl extends Item implements BlockCreator {
     public LocalVar declare(final String name, final GenericType type) {
         LocalVarImpl lv = new LocalVarImpl(this, name, type);
         addItem(lv.allocator());
+        set(lv, Const.ofDefault(type.desc()));
         return lv;
     }
 
@@ -724,15 +725,15 @@ public final class BlockCreatorImpl extends Item implements BlockCreator {
 
     public void forEach(final Expr fn, final BiConsumer<BlockCreator, ? super LocalVar> builder) {
         block(fn, (b0, fn0) -> {
-            Var items = b0.define("$$items" + depth, fn0);
+            Var items = b0.declare("$$items" + depth, fn0);
             if (items.type().isArray()) {
                 // iterate array
                 Expr lv = items.length();
-                Expr length = lv instanceof Const ? lv : b0.define("$$length" + depth, lv);
-                LocalVar idx = b0.define("$$idx" + depth, Const.of(0));
+                Expr length = lv instanceof Const ? lv : b0.declare("$$length" + depth, lv);
+                LocalVar idx = b0.declare("$$idx" + depth, Const.of(0));
                 b0.block(b1 -> {
                     b1.if_(b1.lt(idx, length), b2 -> {
-                        LocalVar val = b2.define("$$val" + depth, items.elem(idx));
+                        LocalVar val = b2.declare("$$val" + depth, items.elem(idx));
                         builder.accept(b2, val);
                         if (b2.active()) {
                             b2.inc(idx);
@@ -742,10 +743,10 @@ public final class BlockCreatorImpl extends Item implements BlockCreator {
                 });
             } else {
                 // use iterable
-                LocalVar itr = b0.define("$$itr" + depth, b0.iterate(items));
+                LocalVar itr = b0.declare("$$itr" + depth, b0.iterate(items));
                 b0.block(b1 -> {
                     b1.if_(b1.withIterator(itr).hasNext(), b2 -> {
-                        LocalVar val = b2.define("$$val" + depth, b2.withIterator(itr).next());
+                        LocalVar val = b2.declare("$$val" + depth, b2.withIterator(itr).next());
                         ((BlockCreatorImpl) b2).loopAction = bb -> bb.goto_(b1);
                         builder.accept(b2, val);
                         if (b2.active()) {
@@ -831,7 +832,7 @@ public final class BlockCreatorImpl extends Item implements BlockCreator {
     }
 
     public void ifInstanceOf(final Expr obj, final ClassDesc type, final BiConsumer<BlockCreator, ? super LocalVar> ifTrue) {
-        doIf(instanceOf(obj, type), bc -> ifTrue.accept(bc, bc.define("$$instance" + depth, bc.cast(obj, type))), null);
+        doIf(instanceOf(obj, type), bc -> ifTrue.accept(bc, bc.declare("$$instance" + depth, bc.cast(obj, type))), null);
     }
 
     public void ifNotInstanceOf(Expr obj, ClassDesc type, Consumer<BlockCreator> ifFalse) {
@@ -840,7 +841,7 @@ public final class BlockCreatorImpl extends Item implements BlockCreator {
 
     public void ifInstanceOfElse(final Expr obj, final ClassDesc type, final BiConsumer<BlockCreator, ? super LocalVar> ifTrue,
             final Consumer<BlockCreator> ifFalse) {
-        doIf(instanceOf(obj, type), bc -> ifTrue.accept(bc, bc.define("$$instance" + depth, bc.cast(obj, type))), ifFalse);
+        doIf(instanceOf(obj, type), bc -> ifTrue.accept(bc, bc.declare("$$instance" + depth, bc.cast(obj, type))), ifFalse);
     }
 
     private If doIfInsn(final ClassDesc type, final Expr cond, final BlockCreatorImpl wt, final BlockCreatorImpl wf) {
@@ -983,7 +984,7 @@ public final class BlockCreatorImpl extends Item implements BlockCreator {
             });
         } else {
             block(resource, (b0, opened) -> {
-                LocalVar rsrc = b0.define("$$resource" + depth, opened);
+                LocalVar rsrc = b0.declare("$$resource" + depth, opened);
                 autoClose(rsrc, b1 -> {
                     body.accept(b1, rsrc);
                 });
@@ -1021,7 +1022,7 @@ public final class BlockCreatorImpl extends Item implements BlockCreator {
 
     public void synchronized_(final Expr monitor, final Consumer<BlockCreator> body) {
         block(monitor, (b0, mon) -> {
-            LocalVar mv = b0.define("$$monitor" + depth, mon);
+            LocalVar mv = b0.declare("$$monitor" + depth, mon);
             ((BlockCreatorImpl) b0).monitorEnter((Item) mv);
             b0.try_(t1 -> {
                 t1.body(body);
@@ -1032,7 +1033,7 @@ public final class BlockCreatorImpl extends Item implements BlockCreator {
 
     public void locked(final Expr jucLock, final Consumer<BlockCreator> body) {
         block(jucLock, (b0, lock) -> {
-            LocalVar lv = b0.define("$$lock" + depth, lock);
+            LocalVar lv = b0.declare("$$lock" + depth, lock);
             b0.invokeInterface(MethodDesc.of(Lock.class, "lock", void.class), lv);
             b0.try_(t1 -> {
                 t1.body(body);

--- a/src/main/java/io/quarkus/gizmo2/impl/EqualsHashCodeToStringGenerator.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/EqualsHashCodeToStringGenerator.java
@@ -38,15 +38,15 @@ public class EqualsHashCodeToStringGenerator {
                 b0.if_(b0.eq(cc.this_(), other), BlockCreator::returnTrue);
                 b0.ifNotInstanceOf(other, thisClass, BlockCreator::returnFalse);
 
-                Expr otherCast = b0.define("other", b0.cast(other, thisClass));
+                Expr otherCast = b0.declare("other", b0.cast(other, thisClass));
                 for (FieldDesc field : fields) {
                     if (!field.owner().equals(thisClass)) {
                         throw new IllegalArgumentException(
                                 "Field does not belong to " + thisClass.displayName() + ": " + field);
                     }
 
-                    LocalVar thisValue = b0.define("thisValue", b0.get(cc.this_().field(field)));
-                    LocalVar thatValue = b0.define("thatValue", b0.get(otherCast.field(field)));
+                    LocalVar thisValue = b0.declare("thisValue", b0.get(cc.this_().field(field)));
+                    LocalVar thatValue = b0.declare("thatValue", b0.get(otherCast.field(field)));
                     String fieldDesc = field.type().descriptorString();
                     switch (fieldDesc.charAt(0)) {
                         // boolean, byte, short, int, long, char
@@ -90,15 +90,15 @@ public class EqualsHashCodeToStringGenerator {
                     return;
                 }
 
-                LocalVar result = b0.define("result", Const.of(1));
+                LocalVar result = b0.declare("result", Const.of(1));
                 for (FieldDesc field : fields) {
                     if (!field.owner().equals(thisClass)) {
                         throw new IllegalArgumentException(
                                 "Field does not belong to " + thisClass.displayName() + ": " + field);
                     }
 
-                    LocalVar value = b0.define("value", b0.get(cc.this_().field(field)));
-                    LocalVar hash = b0.define("hash",
+                    LocalVar value = b0.declare("value", b0.get(cc.this_().field(field)));
+                    LocalVar hash = b0.declare("hash",
                             field.type().isArray() ? b0.arrayHashCode(value) : b0.exprHashCode(value));
                     b0.set(result, b0.add(b0.mul(Const.of(31), result), hash));
                 }

--- a/src/main/java/io/quarkus/gizmo2/impl/TryCatch.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/TryCatch.java
@@ -83,7 +83,7 @@ final class TryCatch extends Item {
 
         void accept(final BiConsumer<BlockCreator, ? super LocalVar> builder) {
             body().accept((b, e) -> {
-                builder.accept(b, b.define(caughtName, e));
+                builder.accept(b, b.declare(caughtName, e));
             });
         }
     }

--- a/src/main/java/io/quarkus/gizmo2/impl/TryCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/TryCreatorImpl.java
@@ -88,7 +88,7 @@ public final class TryCreatorImpl implements TryCreator {
             tryCatch = new TryCatch(body);
         }
         tryCatch.addCatch(superType, types, caughtName).accept((b0, e) -> {
-            builder.accept(b0, b0.define(caughtName, e));
+            builder.accept(b0, b0.declare(caughtName, e));
         });
     }
 

--- a/src/main/java/io/quarkus/gizmo2/impl/TypeCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/TypeCreatorImpl.java
@@ -387,16 +387,16 @@ public abstract sealed class TypeCreatorImpl extends AnnotatableCreatorImpl impl
                         ParamVar base64 = smc.parameter("base64", 1);
                         ParamVar methodType = smc.parameter("methodType", 2);
                         smc.body(b0 -> {
-                            var decoder = b0.define("decoder", b0.invokeStatic(MethodDesc.of(
+                            var decoder = b0.declare("decoder", b0.invokeStatic(MethodDesc.of(
                                     Base64.class,
                                     "getDecoder",
                                     Base64.Decoder.class)));
-                            var bytes = b0.define("bytes", b0.invokeVirtual(MethodDesc.of(
+                            var bytes = b0.declare("bytes", b0.invokeVirtual(MethodDesc.of(
                                     Base64.Decoder.class,
                                     "decode",
                                     byte[].class,
                                     String.class), decoder, base64));
-                            var definedLookup = b0.define("definedLookup", b0.invokeVirtual(MethodDesc.of(
+                            var definedLookup = b0.declare("definedLookup", b0.invokeVirtual(MethodDesc.of(
                                     MethodHandles.Lookup.class,
                                     "defineHiddenClass",
                                     MethodHandles.Lookup.class,
@@ -408,13 +408,13 @@ public abstract sealed class TypeCreatorImpl extends AnnotatableCreatorImpl impl
                                     Const.of(false),
                                     b0.newArray(MethodHandles.Lookup.ClassOption.class,
                                             Const.of(MethodHandles.Lookup.ClassOption.NESTMATE))));
-                            var definedClass = b0.define("definedClass", b0.invokeVirtual(
+                            var definedClass = b0.declare("definedClass", b0.invokeVirtual(
                                     MethodDesc.of(
                                             MethodHandles.Lookup.class,
                                             "lookupClass",
                                             Class.class),
                                     definedLookup));
-                            var ctorType = b0.define("ctorType", b0.invokeVirtual(
+                            var ctorType = b0.declare("ctorType", b0.invokeVirtual(
                                     MethodDesc.of(
                                             MethodType.class,
                                             "changeReturnType",
@@ -422,7 +422,7 @@ public abstract sealed class TypeCreatorImpl extends AnnotatableCreatorImpl impl
                                             Class.class),
                                     methodType,
                                     Const.of(void.class)));
-                            var ctorHandle = b0.define("ctorHandle", b0.invokeVirtual(
+                            var ctorHandle = b0.declare("ctorHandle", b0.invokeVirtual(
                                     MethodDesc.of(
                                             MethodHandles.Lookup.class,
                                             "findConstructor",
@@ -441,10 +441,10 @@ public abstract sealed class TypeCreatorImpl extends AnnotatableCreatorImpl impl
                                             methodType),
                                     0), t1 -> {
                                         // no parameters, so it should be a singleton
-                                        LocalVar instance = t1.define("instance", t1.invokeVirtual(
+                                        LocalVar instance = t1.declare("instance", t1.invokeVirtual(
                                                 MethodDesc.of(MethodHandle.class, "invoke", Object.class),
                                                 ctorHandle));
-                                        LocalVar constHandle = t1.define("constHandle", t1.invokeStatic(
+                                        LocalVar constHandle = t1.declare("constHandle", t1.invokeStatic(
                                                 MethodDesc.of(
                                                         MethodHandles.class,
                                                         "constant",
@@ -528,7 +528,7 @@ public abstract sealed class TypeCreatorImpl extends AnnotatableCreatorImpl impl
                 ParamVar is = mc.parameter("is", CD_InputStream);
                 mc.body(b0 -> {
                     // first byte of the line
-                    LocalVar a = b0.define("a", b0.invokeVirtual(MD_InputStream_read, is));
+                    LocalVar a = b0.declare("a", b0.invokeVirtual(MD_InputStream_read, is));
                     // EOF (expected)
                     b0.if_(b0.eq(a, -1), BlockCreator::returnNull);
                     b0.loop(b1 -> {
@@ -554,7 +554,7 @@ public abstract sealed class TypeCreatorImpl extends AnnotatableCreatorImpl impl
                                 b3.throw_(CharConversionException.class);
                             });
                             // at least two bytes
-                            LocalVar b = b2.define("b", b2.invokeVirtual(MD_InputStream_read, is));
+                            LocalVar b = b2.declare("b", b2.invokeVirtual(MD_InputStream_read, is));
                             // check for eof (unexpected)
                             b2.if_(b2.eq(b, -1), b3 -> {
                                 // eof (unexpected)
@@ -575,7 +575,7 @@ public abstract sealed class TypeCreatorImpl extends AnnotatableCreatorImpl impl
                                 b3.break_(b2);
                             });
                             // at least three bytes
-                            LocalVar c = b2.define("c", b2.invokeVirtual(MD_InputStream_read, is));
+                            LocalVar c = b2.declare("c", b2.invokeVirtual(MD_InputStream_read, is));
                             // check for eof (unexpected)
                             b2.if_(b2.eq(c, -1), b3 -> {
                                 // eof (unexpected)
@@ -598,7 +598,7 @@ public abstract sealed class TypeCreatorImpl extends AnnotatableCreatorImpl impl
                                 b3.break_(b2);
                             });
                             // four bytes (or invalid)
-                            LocalVar d = b2.define("d", b2.invokeVirtual(MD_InputStream_read, is));
+                            LocalVar d = b2.declare("d", b2.invokeVirtual(MD_InputStream_read, is));
                             // check for eof (unexpected)
                             b2.if_(b2.eq(d, -1), b3 -> {
                                 // eof (unexpected)
@@ -649,7 +649,7 @@ public abstract sealed class TypeCreatorImpl extends AnnotatableCreatorImpl impl
                         b1.throw_(ClassCastException.class);
                     });
                     // load resource
-                    LocalVar is = b0.define("is", b0.invokeVirtual(
+                    LocalVar is = b0.declare("is", b0.invokeVirtual(
                             ClassMethodDesc.of(
                                     CD_Class,
                                     "getResourceAsStream",
@@ -664,9 +664,9 @@ public abstract sealed class TypeCreatorImpl extends AnnotatableCreatorImpl impl
                     });
                     b0.autoClose(is, b1 -> {
                         // decode the bytes
-                        LocalVar sb = b1.define("sb", b1.new_(CD_StringBuilder, Const.of(100)));
-                        LocalVar list = b1.define("list", b1.new_(CD_ArrayList, Const.of(60)));
-                        LocalVar line = b1.define("line", b1.invokeStatic(ClassMethodDesc.of(
+                        LocalVar sb = b1.declare("sb", b1.new_(CD_StringBuilder, Const.of(100)));
+                        LocalVar list = b1.declare("list", b1.new_(CD_ArrayList, Const.of(60)));
+                        LocalVar line = b1.declare("line", b1.invokeStatic(ClassMethodDesc.of(
                                 type,
                                 "$readUtfLine",
                                 MethodTypeDesc.of(
@@ -720,7 +720,7 @@ public abstract sealed class TypeCreatorImpl extends AnnotatableCreatorImpl impl
                         b1.throw_(ClassCastException.class);
                     });
                     // load resource
-                    LocalVar is = b0.define("is", b0.invokeVirtual(
+                    LocalVar is = b0.declare("is", b0.invokeVirtual(
                             ClassMethodDesc.of(
                                     CD_Class,
                                     "getResourceAsStream",
@@ -735,9 +735,9 @@ public abstract sealed class TypeCreatorImpl extends AnnotatableCreatorImpl impl
                     });
                     b0.autoClose(is, b1 -> {
                         // decode the bytes
-                        LocalVar sb = b1.define("sb", b1.new_(CD_StringBuilder, Const.of(100)));
-                        LocalVar list = b1.define("list", b1.new_(CD_ArrayList, Const.of(60)));
-                        LocalVar line = b1.define("line", b1.invokeStatic(ClassMethodDesc.of(
+                        LocalVar sb = b1.declare("sb", b1.new_(CD_StringBuilder, Const.of(100)));
+                        LocalVar list = b1.declare("list", b1.new_(CD_ArrayList, Const.of(60)));
+                        LocalVar line = b1.declare("line", b1.invokeStatic(ClassMethodDesc.of(
                                 type,
                                 "$readUtfLine",
                                 MethodTypeDesc.of(
@@ -791,7 +791,7 @@ public abstract sealed class TypeCreatorImpl extends AnnotatableCreatorImpl impl
                         b1.throw_(ClassCastException.class);
                     });
                     // load resource
-                    LocalVar is = b0.define("is", b0.invokeVirtual(
+                    LocalVar is = b0.declare("is", b0.invokeVirtual(
                             ClassMethodDesc.of(
                                     CD_Class,
                                     "getResourceAsStream",
@@ -806,9 +806,9 @@ public abstract sealed class TypeCreatorImpl extends AnnotatableCreatorImpl impl
                     });
                     b0.autoClose(is, b1 -> {
                         // decode the bytes
-                        LocalVar sb = b1.define("sb", b1.new_(CD_StringBuilder, Const.of(100)));
-                        LocalVar list = b1.define("list", b1.new_(CD_ArrayList, Const.of(60)));
-                        LocalVar key = b1.define("key", b1.invokeStatic(ClassMethodDesc.of(
+                        LocalVar sb = b1.declare("sb", b1.new_(CD_StringBuilder, Const.of(100)));
+                        LocalVar list = b1.declare("list", b1.new_(CD_ArrayList, Const.of(60)));
+                        LocalVar key = b1.declare("key", b1.invokeStatic(ClassMethodDesc.of(
                                 type,
                                 "$readUtfLine",
                                 MethodTypeDesc.of(
@@ -816,7 +816,7 @@ public abstract sealed class TypeCreatorImpl extends AnnotatableCreatorImpl impl
                                         CD_StringBuilder,
                                         CD_InputStream)),
                                 sb, is));
-                        LocalVar value = b1.define("value", b1.invokeStatic(ClassMethodDesc.of(
+                        LocalVar value = b1.declare("value", b1.invokeStatic(ClassMethodDesc.of(
                                 type,
                                 "$readUtfLine",
                                 MethodTypeDesc.of(

--- a/src/test/java/io/quarkus/gizmo2/AnonClassTest.java
+++ b/src/test/java/io/quarkus/gizmo2/AnonClassTest.java
@@ -39,7 +39,7 @@ public final class AnonClassTest {
                 // }
                 smc.returning(int.class);
                 smc.body(b0 -> {
-                    var ret = b0.define("ret", b0.new_(AtomicInteger.class));
+                    var ret = b0.declare("ret", b0.new_(AtomicInteger.class));
                     Expr runnable = b0.newAnonymousClass(Runnable.class, acc -> {
                         var capturedRet = acc.capture(ret);
                         acc.method("run", imc -> {
@@ -87,7 +87,7 @@ public final class AnonClassTest {
                 // }
                 smc.returning(int.class);
                 smc.body(b0 -> {
-                    var ret = b0.define("ret", b0.new_(AtomicInteger.class));
+                    var ret = b0.declare("ret", b0.new_(AtomicInteger.class));
                     Expr base = b0.newAnonymousClass(ConstructorDesc.of(baseDesc), List.of(), acc -> {
                         var capturedRet = acc.capture(ret);
                         acc.method("go", imc -> {

--- a/src/test/java/io/quarkus/gizmo2/ArraysTest.java
+++ b/src/test/java/io/quarkus/gizmo2/ArraysTest.java
@@ -35,7 +35,7 @@ public class ArraysTest {
                 // }
                 mc.returning(int.class);
                 mc.body(bc -> {
-                    var arr = bc.define("arr", bc.newEmptyArray(String.class, Const.of(5)));
+                    var arr = bc.declare("arr", bc.newEmptyArray(String.class, Const.of(5)));
                     bc.set(arr.elem(0), Const.of("foo"));
                     bc.set(arr.elem(Const.of(1)), Const.of("bar"));
                     bc.ifNot(bc.exprEquals(arr.elem(Integer.valueOf(1)), Const.of("bar")), fail -> fail.return_(-1));
@@ -141,15 +141,15 @@ public class ArraysTest {
             return bc.newArray(String[].class, a1, a2);
         }, "[[ab, cd], [ef, gh]]");
         testCreateArray(bc -> {
-            Expr cs1 = bc.define("cs1", bc.new_(StringBuilder.class, Const.of("ij")));
-            Expr cs2 = bc.define("cs2", bc.new_(StringBuilder.class, Const.of("mn")));
+            Expr cs1 = bc.declare("cs1", bc.new_(StringBuilder.class, Const.of("ij")));
+            Expr cs2 = bc.declare("cs2", bc.new_(StringBuilder.class, Const.of("mn")));
             Expr a1 = bc.newArray(CharSequence.class, cs1, Const.of("kl"), cs2);
             Expr a2 = bc.newArray(CharSequence.class);
             return bc.newArray(CharSequence[].class, a1, a2);
         }, "[[ij, kl, mn], []]");
         testCreateArray(bc -> {
-            Expr num1 = bc.define("num1", bc.new_(Integer.class, Const.of(123)));
-            Expr num2 = bc.define("num2", bc.new_(Integer.class, Const.of(456)));
+            Expr num1 = bc.declare("num1", bc.new_(Integer.class, Const.of(123)));
+            Expr num2 = bc.declare("num2", bc.new_(Integer.class, Const.of(456)));
             Expr a1 = bc.newArray(String.class, Const.of("op"), Const.of("qr"));
             Expr a2 = bc.newArray(CharSequence.class);
             Expr a3 = bc.newArray(Integer.class, num1, num2);
@@ -186,35 +186,35 @@ public class ArraysTest {
     @Test
     public void readPrimitiveArray() {
         testReadArray(bc -> {
-            Expr arr = bc.define("arr", bc.newArray(boolean.class, Const.of(true), Const.of(false)));
+            Expr arr = bc.declare("arr", bc.newArray(boolean.class, Const.of(true), Const.of(false)));
             return bc.add(arr.elem(0), arr.elem(1));
         }, 1);
         testReadArray(bc -> {
-            Expr arr = bc.define("arr", bc.newArray(byte.class, Const.of((byte) 1), Const.of((byte) 2)));
+            Expr arr = bc.declare("arr", bc.newArray(byte.class, Const.of((byte) 1), Const.of((byte) 2)));
             return bc.add(arr.elem(0), arr.elem(1));
         }, 3);
         testReadArray(bc -> {
-            Expr arr = bc.define("arr", bc.newArray(short.class, Const.of((short) 3), Const.of((short) 4)));
+            Expr arr = bc.declare("arr", bc.newArray(short.class, Const.of((short) 3), Const.of((short) 4)));
             return bc.add(arr.elem(0), arr.elem(1));
         }, 7);
         testReadArray(bc -> {
-            Expr arr = bc.define("arr", bc.newArray(char.class, Const.of('a'), Const.of('b')));
+            Expr arr = bc.declare("arr", bc.newArray(char.class, Const.of('a'), Const.of('b')));
             return bc.add(arr.elem(0), arr.elem(1));
         }, 195); // a = 97, b = 98
         testReadArray(bc -> {
-            Expr arr = bc.define("arr", bc.newArray(int.class, Const.of(7), Const.of(8)));
+            Expr arr = bc.declare("arr", bc.newArray(int.class, Const.of(7), Const.of(8)));
             return bc.add(arr.elem(0), arr.elem(1));
         }, 15);
         testReadArray(bc -> {
-            Expr arr = bc.define("arr", bc.newArray(long.class, Const.of(9L), Const.of(10L)));
+            Expr arr = bc.declare("arr", bc.newArray(long.class, Const.of(9L), Const.of(10L)));
             return bc.add(bc.cast(arr.elem(0), int.class), bc.cast(arr.elem(1), int.class));
         }, 19);
         testReadArray(bc -> {
-            Expr arr = bc.define("arr", bc.newArray(float.class, Const.of(11.0F), Const.of(12.0F)));
+            Expr arr = bc.declare("arr", bc.newArray(float.class, Const.of(11.0F), Const.of(12.0F)));
             return bc.add(bc.cast(arr.elem(0), int.class), bc.cast(arr.elem(1), int.class));
         }, 23);
         testReadArray(bc -> {
-            Expr arr = bc.define("arr", bc.newArray(double.class, Const.of(13.0), Const.of(14.0)));
+            Expr arr = bc.declare("arr", bc.newArray(double.class, Const.of(13.0), Const.of(14.0)));
             return bc.add(bc.cast(arr.elem(0), int.class), bc.cast(arr.elem(1), int.class));
         }, 27);
     }
@@ -222,7 +222,7 @@ public class ArraysTest {
     @Test
     public void readReferenceArray() {
         testReadArray(bc -> {
-            Expr arr = bc.define("arr", bc.newArray(String.class, Const.of("ab"), Const.of("cde")));
+            Expr arr = bc.declare("arr", bc.newArray(String.class, Const.of("ab"), Const.of("cde")));
             Expr l1 = bc.withString(arr.elem(0)).length();
             Expr l2 = bc.withString(arr.elem(1)).length();
             return bc.add(l1, l2);
@@ -273,7 +273,7 @@ public class ArraysTest {
                 // }
                 mc.returning(Object.class); // always `String`
                 mc.body(bc -> {
-                    LocalVar arr = bc.define("arr", bc.newArray(String.class, Const.of("foo"),
+                    LocalVar arr = bc.declare("arr", bc.newArray(String.class, Const.of("foo"),
                             Const.of("bar"), Const.of("baz"), Const.of("quux")));
                     bc.return_(arr.elem(bc.add(bc.invokeStatic(one), bc.invokeStatic(two))));
                 });
@@ -312,7 +312,7 @@ public class ArraysTest {
                 // }
                 mc.returning(int.class);
                 mc.body(bc -> {
-                    LocalVar arr = bc.define("arr", bc.newArray(int.class, Const.of(1),
+                    LocalVar arr = bc.declare("arr", bc.newArray(int.class, Const.of(1),
                             Const.of(2), Const.of(3), Const.of(4), Const.of(5)));
                     bc.return_(bc.add(arr.elem(bc.invokeStatic(two)), arr.elem(bc.invokeStatic(three))));
                 });
@@ -378,7 +378,7 @@ public class ArraysTest {
                 mc.returning(int.class);
                 ParamVar param = mc.parameter("value", int.class);
                 mc.body(bc -> {
-                    LocalVar array = bc.define("array",
+                    LocalVar array = bc.declare("array",
                             bc.newArray(int.class, Const.of(1), Const.of(2), Const.of(3)));
 
                     bc.set(array.elem(1), param);
@@ -401,7 +401,7 @@ public class ArraysTest {
                 mc.returning(int.class);
                 ParamVar param = mc.parameter("value", int.class);
                 mc.body(bc -> {
-                    LocalVar array = bc.define("array",
+                    LocalVar array = bc.declare("array",
                             bc.newArray(int.class, Const.of(1), Const.of(2), Const.of(3)));
 
                     bc.set(array.elem(1), param, MemoryOrder.Volatile);

--- a/src/test/java/io/quarkus/gizmo2/AtomicsTest.java
+++ b/src/test/java/io/quarkus/gizmo2/AtomicsTest.java
@@ -37,7 +37,7 @@ public final class AtomicsTest {
             zc.staticMethod("test0", mc -> {
                 mc.body(b0 -> {
                     b0.line(nextLine());
-                    LocalVar instance = b0.define("instance", b0.new_(desc));
+                    LocalVar instance = b0.declare("instance", b0.new_(desc));
                     b0.invokeStatic(assertEqualsI, instance.field(intVal), Const.of(123));
                     // instance int: volatile
                     b0.line(nextLine());
@@ -88,7 +88,7 @@ public final class AtomicsTest {
             zc.staticMethod("test2", mc -> {
                 mc.body(b0 -> {
                     b0.line(nextLine());
-                    LocalVar array = b0.define("array", b0.newArray(int.class, Const.of(404)));
+                    LocalVar array = b0.declare("array", b0.newArray(int.class, Const.of(404)));
                     b0.invokeStatic(assertEqualsI, Const.of(404), array.elem(0));
                     // array int: volatile
                     b0.line(nextLine());
@@ -114,7 +114,7 @@ public final class AtomicsTest {
             zc.staticMethod("test3", mc -> {
                 mc.body(b0 -> {
                     b0.line(nextLine());
-                    LocalVar instance = b0.define("instance", b0.new_(desc));
+                    LocalVar instance = b0.declare("instance", b0.new_(desc));
                     b0.invokeStatic(assertEqualsL, Const.of("Hello"), instance.field(strVal));
                     // instance obj: volatile
                     b0.line(nextLine());
@@ -165,7 +165,7 @@ public final class AtomicsTest {
             zc.staticMethod("test5", mc -> {
                 mc.body(b0 -> {
                     b0.line(nextLine());
-                    LocalVar array = b0.define("array", b0.newArray(String.class, Const.of("Goodbye")));
+                    LocalVar array = b0.declare("array", b0.newArray(String.class, Const.of("Goodbye")));
                     b0.invokeStatic(assertEqualsL, Const.of("Goodbye"), array.elem(0));
                     // array obj: volatile
                     b0.line(nextLine());
@@ -213,7 +213,7 @@ public final class AtomicsTest {
             zc.staticMethod("test0", mc -> {
                 mc.body(b0 -> {
                     b0.line(nextLine());
-                    LocalVar instance = b0.define("instance", b0.new_(desc));
+                    LocalVar instance = b0.declare("instance", b0.new_(desc));
                     b0.invokeStatic(assertEqualsI, Const.of(123), instance.field(intVal));
                     // instance int: volatile
                     b0.line(nextLine());
@@ -264,7 +264,7 @@ public final class AtomicsTest {
             zc.staticMethod("test2", mc -> {
                 mc.body(b0 -> {
                     b0.line(nextLine());
-                    LocalVar array = b0.define("array", b0.newArray(int.class, Const.of(404)));
+                    LocalVar array = b0.declare("array", b0.newArray(int.class, Const.of(404)));
                     b0.invokeStatic(assertEqualsI, Const.of(404), array.elem(0));
                     // array int: volatile
                     b0.line(nextLine());
@@ -309,7 +309,7 @@ public final class AtomicsTest {
             zc.staticMethod("test0", mc -> {
                 mc.body(b0 -> {
                     b0.line(nextLine());
-                    LocalVar instance = b0.define("instance", b0.new_(desc));
+                    LocalVar instance = b0.declare("instance", b0.new_(desc));
                     b0.invokeStatic(assertEqualsI, Const.of(123), instance.field(intVal));
                     // instance int: volatile
                     b0.line(nextLine());
@@ -360,7 +360,7 @@ public final class AtomicsTest {
             zc.staticMethod("test2", mc -> {
                 mc.body(b0 -> {
                     b0.line(nextLine());
-                    LocalVar array = b0.define("array", b0.newArray(int.class, Const.of(404)));
+                    LocalVar array = b0.declare("array", b0.newArray(int.class, Const.of(404)));
                     b0.invokeStatic(assertEqualsI, Const.of(404), array.elem(0));
                     // array int: volatile
                     b0.line(nextLine());
@@ -405,7 +405,7 @@ public final class AtomicsTest {
             zc.staticMethod("test0", mc -> {
                 mc.body(b0 -> {
                     b0.line(nextLine());
-                    LocalVar instance = b0.define("instance", b0.new_(desc));
+                    LocalVar instance = b0.declare("instance", b0.new_(desc));
                     b0.invokeStatic(assertEqualsI, Const.of(4095), instance.field(intVal));
                     // instance int: volatile
                     b0.line(nextLine());
@@ -456,7 +456,7 @@ public final class AtomicsTest {
             zc.staticMethod("test2", mc -> {
                 mc.body(b0 -> {
                     b0.line(nextLine());
-                    LocalVar array = b0.define("array", b0.newArray(int.class, Const.of(4095)));
+                    LocalVar array = b0.declare("array", b0.newArray(int.class, Const.of(4095)));
                     b0.invokeStatic(assertEqualsI, Const.of(4095), array.elem(0));
                     // array int: volatile
                     b0.line(nextLine());
@@ -501,7 +501,7 @@ public final class AtomicsTest {
             zc.staticMethod("test0", mc -> {
                 mc.body(b0 -> {
                     b0.line(nextLine());
-                    LocalVar instance = b0.define("instance", b0.new_(desc));
+                    LocalVar instance = b0.declare("instance", b0.new_(desc));
                     b0.invokeStatic(assertEqualsI, Const.of(4095), instance.field(intVal));
                     // instance int: volatile
                     b0.line(nextLine());
@@ -552,7 +552,7 @@ public final class AtomicsTest {
             zc.staticMethod("test2", mc -> {
                 mc.body(b0 -> {
                     b0.line(nextLine());
-                    LocalVar array = b0.define("array", b0.newArray(int.class, Const.of(4095)));
+                    LocalVar array = b0.declare("array", b0.newArray(int.class, Const.of(4095)));
                     b0.invokeStatic(assertEqualsI, Const.of(4095), array.elem(0));
                     // array int: volatile
                     b0.line(nextLine());
@@ -601,7 +601,7 @@ public final class AtomicsTest {
             zc.staticMethod("test0", mc -> {
                 mc.body(b0 -> {
                     b0.line(nextLine());
-                    LocalVar instance = b0.define("instance", b0.new_(desc));
+                    LocalVar instance = b0.declare("instance", b0.new_(desc));
                     b0.invokeStatic(assertEqualsI, instance.field(intVal), Const.of(123));
                     // instance int
                     b0.line(nextLine());
@@ -630,7 +630,7 @@ public final class AtomicsTest {
             zc.staticMethod("test2", mc -> {
                 mc.body(b0 -> {
                     b0.line(nextLine());
-                    LocalVar array = b0.define("array", b0.newArray(int.class, Const.of(404)));
+                    LocalVar array = b0.declare("array", b0.newArray(int.class, Const.of(404)));
                     b0.invokeStatic(assertEqualsI, Const.of(404), array.elem(0));
                     // array int
                     b0.line(nextLine());
@@ -645,7 +645,7 @@ public final class AtomicsTest {
             zc.staticMethod("test3", mc -> {
                 mc.body(b0 -> {
                     b0.line(nextLine());
-                    LocalVar instance = b0.define("instance", b0.new_(desc));
+                    LocalVar instance = b0.declare("instance", b0.new_(desc));
                     b0.invokeStatic(assertEqualsL, Const.of("Hello"), instance.field(strVal));
                     // instance obj
                     b0.line(nextLine());
@@ -675,7 +675,7 @@ public final class AtomicsTest {
             zc.staticMethod("test5", mc -> {
                 mc.body(b0 -> {
                     b0.line(nextLine());
-                    LocalVar array = b0.define("array", b0.newArray(String.class, Const.of("Goodbye")));
+                    LocalVar array = b0.declare("array", b0.newArray(String.class, Const.of("Goodbye")));
                     b0.invokeStatic(assertEqualsL, Const.of("Goodbye"), array.elem(0));
                     // array obj
                     b0.line(nextLine());
@@ -716,7 +716,7 @@ public final class AtomicsTest {
             zc.staticMethod("test0", mc -> {
                 mc.body(b0 -> {
                     b0.line(nextLine());
-                    LocalVar instance = b0.define("instance", b0.new_(desc));
+                    LocalVar instance = b0.declare("instance", b0.new_(desc));
                     b0.invokeStatic(assertEqualsI, instance.field(intVal), Const.of(123));
                     // instance int
                     b0.line(nextLine());
@@ -745,7 +745,7 @@ public final class AtomicsTest {
             zc.staticMethod("test2", mc -> {
                 mc.body(b0 -> {
                     b0.line(nextLine());
-                    LocalVar array = b0.define("array", b0.newArray(int.class, Const.of(404)));
+                    LocalVar array = b0.declare("array", b0.newArray(int.class, Const.of(404)));
                     b0.invokeStatic(assertEqualsI, Const.of(404), array.elem(0));
                     // array int
                     b0.line(nextLine());
@@ -760,7 +760,7 @@ public final class AtomicsTest {
             zc.staticMethod("test3", mc -> {
                 mc.body(b0 -> {
                     b0.line(nextLine());
-                    LocalVar instance = b0.define("instance", b0.new_(desc));
+                    LocalVar instance = b0.declare("instance", b0.new_(desc));
                     b0.invokeStatic(assertEqualsL, Const.of("Hello"), instance.field(strVal));
                     // instance obj
                     b0.line(nextLine());
@@ -791,7 +791,7 @@ public final class AtomicsTest {
             zc.staticMethod("test5", mc -> {
                 mc.body(b0 -> {
                     b0.line(nextLine());
-                    LocalVar array = b0.define("array", b0.newArray(String.class, Const.of("Goodbye")));
+                    LocalVar array = b0.declare("array", b0.newArray(String.class, Const.of("Goodbye")));
                     b0.invokeStatic(assertEqualsL, Const.of("Goodbye"), array.elem(0));
                     // array obj
                     b0.line(nextLine());
@@ -832,7 +832,7 @@ public final class AtomicsTest {
             zc.staticMethod("test0", mc -> {
                 mc.body(b0 -> {
                     b0.line(nextLine());
-                    LocalVar instance = b0.define("instance", b0.new_(desc));
+                    LocalVar instance = b0.declare("instance", b0.new_(desc));
                     b0.invokeStatic(assertEqualsI, instance.field(intVal), Const.of(123));
                     // instance int: volatile
                     b0.line(nextLine());
@@ -883,7 +883,7 @@ public final class AtomicsTest {
             zc.staticMethod("test2", mc -> {
                 mc.body(b0 -> {
                     b0.line(nextLine());
-                    LocalVar array = b0.define("array", b0.newArray(int.class, Const.of(404)));
+                    LocalVar array = b0.declare("array", b0.newArray(int.class, Const.of(404)));
                     b0.invokeStatic(assertEqualsI, Const.of(404), array.elem(0));
                     // array int: volatile
                     b0.line(nextLine());
@@ -909,7 +909,7 @@ public final class AtomicsTest {
             zc.staticMethod("test3", mc -> {
                 mc.body(b0 -> {
                     b0.line(nextLine());
-                    LocalVar instance = b0.define("instance", b0.new_(desc));
+                    LocalVar instance = b0.declare("instance", b0.new_(desc));
                     b0.invokeStatic(assertEqualsL, Const.of("Hello"), instance.field(strVal));
                     // instance obj: volatile
                     b0.line(nextLine());
@@ -960,7 +960,7 @@ public final class AtomicsTest {
             zc.staticMethod("test5", mc -> {
                 mc.body(b0 -> {
                     b0.line(nextLine());
-                    LocalVar array = b0.define("array", b0.newArray(String.class, Const.of("Goodbye")));
+                    LocalVar array = b0.declare("array", b0.newArray(String.class, Const.of("Goodbye")));
                     b0.invokeStatic(assertEqualsL, Const.of("Goodbye"), array.elem(0));
                     // array obj: volatile
                     b0.line(nextLine());

--- a/src/test/java/io/quarkus/gizmo2/AutoConversionTest.java
+++ b/src/test/java/io/quarkus/gizmo2/AutoConversionTest.java
@@ -513,7 +513,7 @@ public class AutoConversionTest {
                 // }
                 mc.returning(int.class);
                 mc.body(bc -> {
-                    LocalVar instance = bc.define("instance", bc.new_(cc.type()));
+                    LocalVar instance = bc.declare("instance", bc.new_(cc.type()));
 
                     bc.set(instance.field(field1), Const.of(13));
                     bc.set(instance.field(field2), bc.new_(Integer.class, Const.of(42)));
@@ -548,7 +548,7 @@ public class AutoConversionTest {
                 // }
                 mc.returning(double.class);
                 mc.body(bc -> {
-                    LocalVar instance = bc.define("instance", bc.new_(cc.type()));
+                    LocalVar instance = bc.declare("instance", bc.new_(cc.type()));
 
                     bc.set(instance.field(field1), Const.of(13));
                     bc.set(instance.field(field2), Const.of(42.0F));
@@ -583,7 +583,7 @@ public class AutoConversionTest {
                 // }
                 mc.returning(int.class);
                 mc.body(bc -> {
-                    LocalVar instance = bc.define("instance", bc.new_(cc.type()));
+                    LocalVar instance = bc.declare("instance", bc.new_(cc.type()));
 
                     bc.set(instance.field(field1), Const.of(13), MemoryOrder.Volatile);
                     bc.set(instance.field(field2), bc.new_(Integer.class, Const.of(42)), MemoryOrder.Volatile);
@@ -618,7 +618,7 @@ public class AutoConversionTest {
                 // }
                 mc.returning(double.class);
                 mc.body(bc -> {
-                    LocalVar instance = bc.define("instance", bc.new_(cc.type()));
+                    LocalVar instance = bc.declare("instance", bc.new_(cc.type()));
 
                     bc.set(instance.field(field1), Const.of(13), MemoryOrder.Volatile);
                     bc.set(instance.field(field2), Const.of(42.0F), MemoryOrder.Volatile);
@@ -694,7 +694,7 @@ public class AutoConversionTest {
                 // }
                 mc.returning(int.class);
                 mc.body(bc -> {
-                    LocalVar array = bc.define("array", bc.newEmptyArray(int.class, 2));
+                    LocalVar array = bc.declare("array", bc.newEmptyArray(int.class, 2));
                     bc.set(array.elem(0), Const.of(13));
                     bc.set(array.elem(1), bc.new_(Integer.class, Const.of(42)));
 
@@ -719,7 +719,7 @@ public class AutoConversionTest {
                 // }
                 mc.returning(int.class);
                 mc.body(bc -> {
-                    LocalVar array = bc.define("array", bc.newEmptyArray(Integer.class, 2));
+                    LocalVar array = bc.declare("array", bc.newEmptyArray(Integer.class, 2));
                     bc.set(array.elem(0), Const.of(13));
                     bc.set(array.elem(1), bc.new_(Integer.class, Const.of(42)));
 
@@ -744,7 +744,7 @@ public class AutoConversionTest {
                 // }
                 mc.returning(double.class);
                 mc.body(bc -> {
-                    LocalVar array = bc.define("array", bc.newEmptyArray(double.class, 2));
+                    LocalVar array = bc.declare("array", bc.newEmptyArray(double.class, 2));
                     bc.set(array.elem(0), Const.of(13));
                     bc.set(array.elem(1), Const.of(42L));
 
@@ -769,7 +769,7 @@ public class AutoConversionTest {
                 // }
                 mc.returning(int.class);
                 mc.body(bc -> {
-                    LocalVar array = bc.define("array", bc.newEmptyArray(int.class, 2));
+                    LocalVar array = bc.declare("array", bc.newEmptyArray(int.class, 2));
                     bc.set(array.elem(0), Const.of(13), MemoryOrder.Volatile);
                     bc.set(array.elem(1), bc.new_(Integer.class, Const.of(42)), MemoryOrder.Volatile);
 
@@ -794,7 +794,7 @@ public class AutoConversionTest {
                 // }
                 mc.returning(int.class);
                 mc.body(bc -> {
-                    LocalVar array = bc.define("array", bc.newEmptyArray(Integer.class, 2));
+                    LocalVar array = bc.declare("array", bc.newEmptyArray(Integer.class, 2));
                     bc.set(array.elem(0), Const.of(13), MemoryOrder.Volatile);
                     bc.set(array.elem(1), bc.new_(Integer.class, Const.of(42)), MemoryOrder.Volatile);
 
@@ -819,7 +819,7 @@ public class AutoConversionTest {
                 // }
                 mc.returning(double.class);
                 mc.body(bc -> {
-                    LocalVar array = bc.define("array", bc.newEmptyArray(double.class, 2));
+                    LocalVar array = bc.declare("array", bc.newEmptyArray(double.class, 2));
                     bc.set(array.elem(0), Const.of(13), MemoryOrder.Volatile);
                     bc.set(array.elem(1), Const.of(42L), MemoryOrder.Volatile);
 
@@ -842,7 +842,7 @@ public class AutoConversionTest {
                 // }
                 mc.returning(int.class);
                 mc.body(bc -> {
-                    LocalVar array = bc.define("array",
+                    LocalVar array = bc.declare("array",
                             bc.newArray(int.class, Const.of(13), Const.of(42)));
 
                     bc.return_(bc.add(
@@ -866,7 +866,7 @@ public class AutoConversionTest {
                 // }
                 mc.returning(int.class);
                 mc.body(bc -> {
-                    LocalVar array = bc.define("array",
+                    LocalVar array = bc.declare("array",
                             bc.newArray(int.class, Const.of(13), Const.of(42)));
 
                     bc.return_(bc.add(

--- a/src/test/java/io/quarkus/gizmo2/BasicTest.java
+++ b/src/test/java/io/quarkus/gizmo2/BasicTest.java
@@ -73,7 +73,7 @@ public final class BasicTest {
                 mc.body(b0 -> {
                     Expr concat1 = b0.invokeVirtual(MethodDesc.of(String.class, "concat", String.class, String.class), first,
                             List.of(ConstImpl.of(" ")));
-                    LocalVar spaced = b0.define("spaced", concat1);
+                    LocalVar spaced = b0.declare("spaced", concat1);
                     Expr concat2 = b0.invokeVirtual(MethodDesc.of(String.class, "concat", String.class, String.class), spaced,
                             List.of(second));
 

--- a/src/test/java/io/quarkus/gizmo2/BoxUnboxTest.java
+++ b/src/test/java/io/quarkus/gizmo2/BoxUnboxTest.java
@@ -217,9 +217,9 @@ public class BoxUnboxTest {
                 mc.body(bc -> {
                     // WORKAROUND: we need to use local vars for types where unboxing involves cmp/cmpg
                     // TODO: file a new issue
-                    var lu = bc.define("lv", bc.unbox(l));
-                    var fu = bc.define("fv", bc.unbox(f));
-                    var du = bc.define("dv", bc.unbox(d));
+                    var lu = bc.declare("lv", bc.unbox(l));
+                    var fu = bc.declare("fv", bc.unbox(f));
+                    var du = bc.declare("dv", bc.unbox(d));
                     bc.ifNot(bc.unbox(bool), fail -> fail.return_(1));
                     bc.if_(bc.ne(bc.unbox(b), Const.of((byte) 123)), fail -> fail.return_(2));
                     bc.if_(bc.ne(bc.unbox(s), Const.of((short) 456)), fail -> fail.return_(3));
@@ -281,9 +281,9 @@ public class BoxUnboxTest {
                 mc.body(bc -> {
                     // WORKAROUND: we need to use local vars for types where unboxing involves cmp/cmpg
                     // TODO: file a new issue
-                    var lu = bc.define("lv", bc.unbox(bc.unbox(l)));
-                    var fu = bc.define("fv", bc.unbox(bc.unbox(f)));
-                    var du = bc.define("dv", bc.unbox(bc.unbox(d)));
+                    var lu = bc.declare("lv", bc.unbox(bc.unbox(l)));
+                    var fu = bc.declare("fv", bc.unbox(bc.unbox(f)));
+                    var du = bc.declare("dv", bc.unbox(bc.unbox(d)));
                     bc.ifNot(bc.unbox(bc.unbox(bool)), fail -> fail.return_(1));
                     bc.if_(bc.ne(bc.unbox(bc.unbox(b)), Const.of((byte) 123)), fail -> fail.return_(2));
                     bc.if_(bc.ne(bc.unbox(bc.unbox(s)), Const.of((short) 456)), fail -> fail.return_(3));
@@ -345,9 +345,9 @@ public class BoxUnboxTest {
                 mc.body(bc -> {
                     // WORKAROUND: we need to use local vars for types where unboxing involves cmp/cmpg
                     // TODO: file a new issue
-                    var lu = bc.define("lv", bc.cast(l, long.class));
-                    var fu = bc.define("fv", bc.cast(f, float.class));
-                    var du = bc.define("dv", bc.cast(d, double.class));
+                    var lu = bc.declare("lv", bc.cast(l, long.class));
+                    var fu = bc.declare("fv", bc.cast(f, float.class));
+                    var du = bc.declare("dv", bc.cast(d, double.class));
                     bc.ifNot(bc.cast(bool, boolean.class), fail -> fail.return_(1));
                     bc.if_(bc.ne(bc.cast(b, byte.class), Const.of((byte) 123)), fail -> fail.return_(2));
                     bc.if_(bc.ne(bc.cast(s, short.class), Const.of((short) 456)), fail -> fail.return_(3));

--- a/src/test/java/io/quarkus/gizmo2/CollectionConstantsTest.java
+++ b/src/test/java/io/quarkus/gizmo2/CollectionConstantsTest.java
@@ -13,7 +13,7 @@ import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
 
-public final class TestCollectionsConstants {
+public final class CollectionConstantsTest {
     @Test
     public void testConstantStringList() {
         TestClassMaker tcm = new TestClassMaker();

--- a/src/test/java/io/quarkus/gizmo2/ComparisonsTest.java
+++ b/src/test/java/io/quarkus/gizmo2/ComparisonsTest.java
@@ -88,7 +88,7 @@ public class ComparisonsTest {
                 // }
                 mc.returning(boolean.class);
                 mc.body(bc -> {
-                    LocalVar obj = bc.define("obj", bc.new_(Object.class));
+                    LocalVar obj = bc.declare("obj", bc.new_(Object.class));
                     bc.return_(bc.eq(obj, obj));
                 });
             });
@@ -146,7 +146,7 @@ public class ComparisonsTest {
                 // }
                 mc.returning(boolean.class);
                 mc.body(bc -> {
-                    LocalVar obj = bc.define("obj", bc.new_(Object.class));
+                    LocalVar obj = bc.declare("obj", bc.new_(Object.class));
                     bc.return_(bc.ne(obj, obj));
                 });
             });

--- a/src/test/java/io/quarkus/gizmo2/ConditionalsTest.java
+++ b/src/test/java/io/quarkus/gizmo2/ConditionalsTest.java
@@ -28,7 +28,7 @@ public class ConditionalsTest {
                 ParamVar val = mc.parameter("val", String.class);
                 mc.returning(boolean.class);
                 mc.body(bc -> {
-                    var len = bc.define("len",
+                    var len = bc.declare("len",
                             bc.invokeVirtual(MethodDesc.of(String.class, "length", int.class), val));
                     bc.if_(bc.ne(len, 5), BlockCreator::returnFalse);
                     bc.returnTrue();
@@ -55,7 +55,7 @@ public class ConditionalsTest {
                 ParamVar val = mc.parameter("val", String.class);
                 mc.returning(boolean.class);
                 mc.body(bc -> {
-                    var len = bc.define("len",
+                    var len = bc.declare("len",
                             bc.invokeVirtual(MethodDesc.of(String.class, "length", int.class), val));
                     bc.ifNot(bc.eq(len, 5), BlockCreator::returnFalse);
                     bc.returnTrue();
@@ -79,7 +79,7 @@ public class ConditionalsTest {
                 ParamVar val = mc.parameter("val", String.class);
                 mc.returning(boolean.class);
                 mc.body(b0 -> {
-                    var len = b0.define("len",
+                    var len = b0.declare("len",
                             b0.invokeVirtual(MethodDesc.of(String.class, "length", int.class), val));
                     Expr result = b0.cond(boolean.class, b0.ne(len, 5),
                             b1 -> b1.yield(Const.of(false)),

--- a/src/test/java/io/quarkus/gizmo2/FieldAccessTest.java
+++ b/src/test/java/io/quarkus/gizmo2/FieldAccessTest.java
@@ -353,7 +353,7 @@ public class FieldAccessTest {
             cc.staticMethod("test", mc -> {
                 mc.returning(int.class);
                 mc.body(bc -> {
-                    LocalVar instance = bc.define("instance", bc.new_(cc.type()));
+                    LocalVar instance = bc.declare("instance", bc.new_(cc.type()));
                     bc.return_(instance.field(field));
                 });
             });
@@ -376,7 +376,7 @@ public class FieldAccessTest {
             cc.staticMethod("test", mc -> {
                 mc.returning(int.class);
                 mc.body(bc -> {
-                    LocalVar instance = bc.define("instance", bc.new_(cc.type()));
+                    LocalVar instance = bc.declare("instance", bc.new_(cc.type()));
                     bc.return_(bc.get(instance.field(field)));
                 });
             });
@@ -399,7 +399,7 @@ public class FieldAccessTest {
             cc.staticMethod("test", mc -> {
                 mc.returning(int.class);
                 mc.body(bc -> {
-                    LocalVar instance = bc.define("instance", bc.new_(cc.type()));
+                    LocalVar instance = bc.declare("instance", bc.new_(cc.type()));
                     bc.return_(bc.get(instance.field(field), MemoryOrder.Volatile));
                 });
             });
@@ -422,7 +422,7 @@ public class FieldAccessTest {
                 mc.returning(int.class);
                 ParamVar param = mc.parameter("value", int.class);
                 mc.body(bc -> {
-                    LocalVar instance = bc.define("instance", bc.new_(cc.type()));
+                    LocalVar instance = bc.declare("instance", bc.new_(cc.type()));
 
                     bc.set(instance.field(field), param);
 
@@ -450,7 +450,7 @@ public class FieldAccessTest {
                 mc.returning(int.class);
                 ParamVar param = mc.parameter("value", int.class);
                 mc.body(bc -> {
-                    LocalVar instance = bc.define("instance", bc.new_(cc.type()));
+                    LocalVar instance = bc.declare("instance", bc.new_(cc.type()));
 
                     bc.set(instance.field(field), param, MemoryOrder.Volatile);
 

--- a/src/test/java/io/quarkus/gizmo2/LambdaTest.java
+++ b/src/test/java/io/quarkus/gizmo2/LambdaTest.java
@@ -26,7 +26,7 @@ public class LambdaTest {
                 // }
                 smc.returning(int.class);
                 smc.body(b0 -> {
-                    var ret = b0.define("ret", b0.new_(AtomicInteger.class));
+                    var ret = b0.declare("ret", b0.new_(AtomicInteger.class));
                     Expr runnable = b0.lambda(Runnable.class, lc -> {
                         var capturedRet = lc.capture(ret);
                         lc.body(b1 -> {
@@ -57,7 +57,7 @@ public class LambdaTest {
                 // }
                 smc.returning(int.class);
                 smc.body(b0 -> {
-                    var ret = b0.define("ret", b0.new_(AtomicInteger.class));
+                    var ret = b0.declare("ret", b0.new_(AtomicInteger.class));
                     Expr consumer = b0.lambda(Consumer.class, lc -> {
                         var capturedRet = lc.capture(ret);
                         var input = lc.parameter("t", 0);
@@ -94,14 +94,14 @@ public class LambdaTest {
                 // }
                 mc.returning(int.class);
                 mc.body(bc -> {
-                    var ret = bc.define("ret", bc.new_(AtomicInteger.class));
+                    var ret = bc.declare("ret", bc.new_(AtomicInteger.class));
                     var supplier = bc.declare("supplier", IntSupplier.class);
                     bc.set(supplier, bc.lambda(IntSupplier.class, lc -> {
                         lc.body(lbc -> {
                             lbc.return_(1);
                         });
                     }));
-                    var suppliedValue = bc.define("suppliedValue",
+                    var suppliedValue = bc.declare("suppliedValue",
                             bc.invokeInterface(MethodDesc.of(IntSupplier.class, "getAsInt", int.class), supplier));
                     var consumer = bc.declare("consumer", Consumer.class);
                     bc.set(consumer, bc.lambda(Consumer.class, lc -> {

--- a/src/test/java/io/quarkus/gizmo2/LocalVarTest.java
+++ b/src/test/java/io/quarkus/gizmo2/LocalVarTest.java
@@ -1,0 +1,42 @@
+package io.quarkus.gizmo2;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.util.function.Supplier;
+
+import org.junit.jupiter.api.Test;
+
+public class LocalVarTest {
+    @Test
+    public void initializedVar() {
+        TestClassMaker tcm = new TestClassMaker();
+        Gizmo g = Gizmo.create(tcm);
+        g.class_("io.quarkus.gizmo2.InitializedVar", cc -> {
+            cc.staticMethod("hello", mc -> {
+                mc.returning(Object.class); // always `String`
+                mc.body(bc -> {
+                    LocalVar hello = bc.declare("hello", Const.of("Hello World!"));
+                    bc.return_(hello);
+                });
+            });
+        });
+        assertEquals("Hello World!", tcm.staticMethod("hello", Supplier.class).get());
+    }
+
+    @Test
+    public void noninitializedVar() {
+        TestClassMaker tcm = new TestClassMaker();
+        Gizmo g = Gizmo.create(tcm);
+        g.class_("io.quarkus.gizmo2.NoninitializedVar", cc -> {
+            cc.staticMethod("hello", mc -> {
+                mc.returning(Object.class); // always `String`
+                mc.body(bc -> {
+                    LocalVar hello = bc.declare("hello", String.class);
+                    bc.return_(hello);
+                });
+            });
+        });
+        assertNull(tcm.staticMethod("hello", Supplier.class).get());
+    }
+}

--- a/src/test/java/io/quarkus/gizmo2/LoopTest.java
+++ b/src/test/java/io/quarkus/gizmo2/LoopTest.java
@@ -50,7 +50,7 @@ public class LoopTest {
                 mc.public_();
                 mc.body(bc -> {
                     // StringBuilder ret = new StringBuilder();
-                    var ret = bc.define("ret", bc.new_(StringBuilder.class));
+                    var ret = bc.declare("ret", bc.new_(StringBuilder.class));
                     bc.forEach(p, (loop, item) -> {
                         // ret.append(item);
                         MethodDesc append = MethodDesc.of(StringBuilder.class, "append", StringBuilder.class, String.class);
@@ -87,7 +87,7 @@ public class LoopTest {
                 mc.returning(String.class);
                 mc.public_();
                 mc.body(bc -> {
-                    var ret = bc.define("ret", bc.new_(StringBuilder.class));
+                    var ret = bc.declare("ret", bc.new_(StringBuilder.class));
                     bc.forEach(p, (loop, item) -> {
                         loop.if_(loop.exprEquals(item, Const.of("bar")), isEqual -> {
                             isEqual.continue_(loop);
@@ -116,8 +116,8 @@ public class LoopTest {
             cc.staticMethod("test", mc -> {
                 mc.returning(Object.class);
                 mc.body(bc -> {
-                    var i = bc.define("i", Const.of(0));
-                    var sum = bc.define("sum", Const.of(0));
+                    var i = bc.declare("i", Const.of(0));
+                    var sum = bc.declare("sum", Const.of(0));
                     bc.doWhile(loop -> {
                         loop.inc(i);
                         loop.set(sum, loop.add(sum, i));
@@ -146,8 +146,8 @@ public class LoopTest {
             cc.staticMethod("test", mc -> {
                 mc.returning(Object.class);
                 mc.body(bc -> {
-                    var i = bc.define("i", Const.of(0));
-                    var sum = bc.define("sum", Const.of(0));
+                    var i = bc.declare("i", Const.of(0));
+                    var sum = bc.declare("sum", Const.of(0));
                     bc.doWhile(loop -> {
                         loop.inc(i);
                         loop.if_(loop.eq(loop.rem(i, 2), Const.of(0)), isEven -> {
@@ -177,8 +177,8 @@ public class LoopTest {
             cc.staticMethod("test", mc -> {
                 mc.returning(Object.class);
                 mc.body(bc -> {
-                    var i = bc.define("i", Const.of(0));
-                    var sum = bc.define("sum", Const.of(0));
+                    var i = bc.declare("i", Const.of(0));
+                    var sum = bc.declare("sum", Const.of(0));
                     bc.while_(cond -> cond.yield(cond.lt(i, 10)), loop -> {
                         loop.inc(i);
                         loop.set(sum, loop.add(sum, i));
@@ -207,8 +207,8 @@ public class LoopTest {
             cc.staticMethod("test", mc -> {
                 mc.returning(Object.class);
                 mc.body(bc -> {
-                    var i = bc.define("i", Const.of(0));
-                    var sum = bc.define("sum", Const.of(0));
+                    var i = bc.declare("i", Const.of(0));
+                    var sum = bc.declare("sum", Const.of(0));
                     bc.while_(cond -> cond.yield(cond.lt(i, 10)), loop -> {
                         loop.inc(i);
                         loop.if_(loop.eq(loop.rem(i, 2), Const.of(0)), isEven -> {

--- a/src/test/java/io/quarkus/gizmo2/TryTest.java
+++ b/src/test/java/io/quarkus/gizmo2/TryTest.java
@@ -187,8 +187,8 @@ public final class TryTest {
             cc.staticMethod("test0", smc -> {
                 smc.returning(boolean.class);
                 smc.body(b0 -> {
-                    LocalVar i = b0.define("i", Const.of(1));
-                    LocalVar ran = b0.define("ran", Const.of(false));
+                    LocalVar i = b0.declare("i", Const.of(1));
+                    LocalVar ran = b0.declare("ran", Const.of(false));
                     b0.while_(cond1 -> cond1.yield(cond1.lt(i, 10)), b1 -> {
                         b1.try_(try2 -> {
                             try2.body(b3 -> {
@@ -209,8 +209,8 @@ public final class TryTest {
             cc.staticMethod("test1", smc -> {
                 smc.returning(boolean.class);
                 smc.body(b0 -> {
-                    LocalVar i = b0.define("i", Const.of(1));
-                    LocalVar ran = b0.define("ran", Const.of(false));
+                    LocalVar i = b0.declare("i", Const.of(1));
+                    LocalVar ran = b0.declare("ran", Const.of(false));
                     b0.while_(cond1 -> cond1.yield(cond1.lt(i, 10)), b1 -> {
                         b1.try_(try2 -> {
                             try2.body(b3 -> {
@@ -234,7 +234,7 @@ public final class TryTest {
             });
             MethodDesc test2 = cc.staticMethod("test2body", smc -> {
                 smc.body(b0 -> {
-                    LocalVar i = b0.define("i", Const.of(1));
+                    LocalVar i = b0.declare("i", Const.of(1));
                     b0.while_(cond1 -> cond1.yield(cond1.lt(i, 10)), b1 -> {
                         b1.try_(try2 -> {
                             try2.body(b3 -> {
@@ -270,8 +270,8 @@ public final class TryTest {
             cc.staticMethod("test0", smc -> {
                 smc.returning(boolean.class);
                 smc.body(b0 -> {
-                    LocalVar ranCatch = b0.define("ranCatch", Const.of(false));
-                    LocalVar ranFinally = b0.define("ranFinally", Const.of(false));
+                    LocalVar ranCatch = b0.declare("ranCatch", Const.of(false));
+                    LocalVar ranFinally = b0.declare("ranFinally", Const.of(false));
                     // use line numbers to make debugging stack traces more readable
                     b0.line(1);
                     b0.try_(try1 -> {
@@ -300,7 +300,7 @@ public final class TryTest {
             cc.staticMethod("test1", smc -> {
                 smc.returning(boolean.class);
                 smc.body(b0 -> {
-                    LocalVar ran = b0.define("ran", Const.of(false));
+                    LocalVar ran = b0.declare("ran", Const.of(false));
                     b0.try_(try1 -> {
                         try1.body(b2 -> {
                             b2.try_(try3 -> {

--- a/src/test/java/io/quarkus/gizmo2/ops/ListOpsTest.java
+++ b/src/test/java/io/quarkus/gizmo2/ops/ListOpsTest.java
@@ -32,9 +32,9 @@ public class ListOpsTest {
                 ParamVar t = mc.parameter("t", Object.class);
                 mc.returning(Object.class);
                 mc.body(bc -> {
-                    var list = bc.define("list", bc.cast(t, List.class));
+                    var list = bc.declare("list", bc.cast(t, List.class));
                     ListOps listOps = bc.withList(list);
-                    var size = bc.define("size", listOps.size());
+                    var size = bc.declare("size", listOps.size());
                     bc.if_(bc.gt(size, 1), gt1 -> {
                         gt1.return_(gt1.withList(list).get(gt1.sub(size, Const.of(1))));
                     });

--- a/src/test/java/io/quarkus/gizmo2/ops/MapOpsTest.java
+++ b/src/test/java/io/quarkus/gizmo2/ops/MapOpsTest.java
@@ -51,7 +51,7 @@ public class MapOpsTest {
                 // }
                 mc.returning(int.class);
                 mc.body(bc -> {
-                    var map = bc.define("map", bc.new_(HashMap.class));
+                    var map = bc.declare("map", bc.new_(HashMap.class));
                     MapOps mapOps = bc.withMap(map);
                     mapOps.put(Const.of("foo"), Const.of("bar"));
                     mapOps.put(Const.of("alpha"), Const.of("bravo"));
@@ -89,7 +89,7 @@ public class MapOpsTest {
                 mc.returning(int.class);
                 mc.body(bc -> {
                     assertThrows(IllegalArgumentException.class, () -> bc.mapOf(Const.of("foo")));
-                    var map = bc.define("map", bc.mapOf(Const.of("foo"), Const.of("bar")));
+                    var map = bc.declare("map", bc.mapOf(Const.of("foo"), Const.of("bar")));
                     MapOps mapOps = bc.withMap(map);
                     bc.ifNot(bc.exprEquals(mapOps.get(Const.of("foo")), Const.of("bar")),
                             fail -> fail.return_(-1));

--- a/src/test/java/io/quarkus/gizmo2/ops/OptionalOpsTest.java
+++ b/src/test/java/io/quarkus/gizmo2/ops/OptionalOpsTest.java
@@ -44,9 +44,9 @@ public class OptionalOpsTest {
                 // }
                 mc.returning(int.class);
                 mc.body(bc -> {
-                    var foo = bc.define("foo", bc.optionalOf(Const.of("foo")));
-                    var bar = bc.define("bar", bc.optionalOfNullable(Const.of("bar")));
-                    var baz = bc.define("baz", bc.optionalOfNullable(Const.ofNull(String.class)));
+                    var foo = bc.declare("foo", bc.optionalOf(Const.of("foo")));
+                    var bar = bc.declare("bar", bc.optionalOfNullable(Const.of("bar")));
+                    var baz = bc.declare("baz", bc.optionalOfNullable(Const.ofNull(String.class)));
                     bc.if_(bc.withOptional(foo).isEmpty(), fail -> fail.return_(1));
                     bc.ifNot(bc.withOptional(foo).isPresent(), fail -> fail.return_(2));
                     bc.ifNot(bc.exprEquals(Const.of("foo"), bc.withOptional(foo).get()), fail -> fail.return_(3));

--- a/src/test/java/io/quarkus/gizmo2/ops/StringBuilderOpsTest.java
+++ b/src/test/java/io/quarkus/gizmo2/ops/StringBuilderOpsTest.java
@@ -23,7 +23,7 @@ public class StringBuilderOpsTest {
             MethodDesc charSeq = cc.staticMethod("createCharSequence", mc -> {
                 mc.returning(CharSequence.class);
                 mc.body(bc -> {
-                    LocalVar strBuilder = bc.define("stringBuilder", bc.new_(StringBuilder.class));
+                    LocalVar strBuilder = bc.declare("stringBuilder", bc.new_(StringBuilder.class));
                     bc.withStringBuilder(strBuilder).append("ghi");
                     bc.return_(strBuilder);
                 });

--- a/src/test/java/io/quarkus/gizmo2/ops/ThrowableOpsTest.java
+++ b/src/test/java/io/quarkus/gizmo2/ops/ThrowableOpsTest.java
@@ -25,7 +25,7 @@ public class ThrowableOpsTest {
                 //    throw e;
                 // }
                 mc.body(bc -> {
-                    var e = bc.define("e", bc.new_(IllegalStateException.class, Const.of("foo")));
+                    var e = bc.declare("e", bc.new_(IllegalStateException.class, Const.of("foo")));
                     ThrowableOps throwableOps = bc.withThrowable(e);
                     throwableOps.addSuppressed(bc.new_(NullPointerException.class, Const.of("npe")));
                     throwableOps.addSuppressed(bc.new_(IllegalArgumentException.class, Const.of("iae")));


### PR DESCRIPTION
The `define()` method is now called `declare()`, because there's no distinction between declarations and definitions in Java (actually there are no definitions; it's just declarations).

Also, variables that were previously declared but not initialized are now initialized to the default value of their type.