### PR TITLE
remove the Expr.bound() method from public API

### DIFF
--- a/src/main/java/io/quarkus/gizmo2/Expr.java
+++ b/src/main/java/io/quarkus/gizmo2/Expr.java
@@ -23,12 +23,6 @@ public sealed interface Expr extends SimpleTyped permits Const, Assignable, This
     }
 
     /**
-     * {@return {@code true} if the expression is bound to a single point in the instruction list, or {@code false} otherwise}
-     * Bound expressions may not be used again.
-     */
-    boolean bound();
-
-    /**
      * {@return an assignable for an element of this array}
      *
      * @param index the array index (must not be {@code null})

--- a/src/main/java/io/quarkus/gizmo2/impl/BlockCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/BlockCreatorImpl.java
@@ -845,7 +845,7 @@ public final class BlockCreatorImpl extends Item implements BlockCreator {
 
     private If doIfInsn(final ClassDesc type, final Expr cond, final BlockCreatorImpl wt, final BlockCreatorImpl wf) {
         // try to combine the condition into the `if`
-        if (cond.bound()) {
+        if (((Item) cond).bound()) {
             Item prevItem = tail.prev().item();
             if (prevItem == cond) {
                 if (cond instanceof Rel rel) {

--- a/src/main/java/io/quarkus/gizmo2/impl/Item.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/Item.java
@@ -29,6 +29,10 @@ public abstract non-sealed class Item implements Expr {
         return ConstantDescs.CD_void;
     }
 
+    /**
+     * {@return {@code true} if the expression is bound to a single point in the instruction list, or {@code false} otherwise}
+     * Bound expressions may not be used again.
+     */
     public boolean bound() {
         return true;
     }


### PR DESCRIPTION
This method is only meaningful internally.