### PR TITLE
move implements_() to ClassCreator and add extends_() to InterfaceCreator

### DIFF
--- a/src/main/java/io/quarkus/gizmo2/creator/ClassCreator.java
+++ b/src/main/java/io/quarkus/gizmo2/creator/ClassCreator.java
@@ -42,6 +42,32 @@ public sealed interface ClassCreator extends TypeCreator, SimpleTyped, TypeParam
     void extends_(ClassDesc desc);
 
     /**
+     * Implement a generic interface.
+     *
+     * @param genericType the generic interface type (must not be {@code null})
+     */
+    void implements_(GenericType.OfClass genericType);
+
+    /**
+     * Implement an interface.
+     *
+     * @param interface_ the descriptor of the interface (must not be {@code null})
+     */
+    void implements_(ClassDesc interface_);
+
+    /**
+     * Implement an interface.
+     *
+     * @param interface_ the interface (must not be {@code null})
+     */
+    default void implements_(Class<?> interface_) {
+        if (!interface_.isInterface()) {
+            throw new IllegalArgumentException("Only interfaces may be implemented");
+        }
+        implements_(Util.classDesc(interface_));
+    }
+
+    /**
      * Extend the given class.
      *
      * @param clazz the class (must not be {@code null})

--- a/src/main/java/io/quarkus/gizmo2/creator/InterfaceCreator.java
+++ b/src/main/java/io/quarkus/gizmo2/creator/InterfaceCreator.java
@@ -1,15 +1,43 @@
 package io.quarkus.gizmo2.creator;
 
+import java.lang.constant.ClassDesc;
 import java.lang.constant.MethodTypeDesc;
 import java.util.function.Consumer;
 
+import io.quarkus.gizmo2.GenericType;
 import io.quarkus.gizmo2.desc.MethodDesc;
 import io.quarkus.gizmo2.impl.InterfaceCreatorImpl;
+import io.quarkus.gizmo2.impl.Util;
 
 /**
  * A creator for an interface type.
  */
 public sealed interface InterfaceCreator extends TypeCreator, TypeParameterizedCreator permits InterfaceCreatorImpl {
+    /**
+     * Extend a generic interface.
+     *
+     * @param genericType the generic interface type (must not be {@code null})
+     */
+    void extends_(GenericType.OfClass genericType);
+
+    /**
+     * Extend an interface.
+     *
+     * @param interface_ the descriptor of the interface (must not be {@code null})
+     */
+    void extends_(ClassDesc interface_);
+
+    /**
+     * Extend an interface.
+     *
+     * @param interface_ the interface (must not be {@code null})
+     */
+    default void extends_(Class<?> interface_) {
+        if (!interface_.isInterface()) {
+            throw new IllegalArgumentException("Only interfaces may be implemented");
+        }
+        extends_(Util.classDesc(interface_));
+    }
 
     /**
      * Add a default method to the interface.

--- a/src/main/java/io/quarkus/gizmo2/creator/TypeCreator.java
+++ b/src/main/java/io/quarkus/gizmo2/creator/TypeCreator.java
@@ -17,7 +17,6 @@ import io.quarkus.gizmo2.desc.ConstructorDesc;
 import io.quarkus.gizmo2.desc.FieldDesc;
 import io.quarkus.gizmo2.desc.MethodDesc;
 import io.quarkus.gizmo2.impl.TypeCreatorImpl;
-import io.quarkus.gizmo2.impl.Util;
 
 /**
  * A creator for a type.
@@ -56,32 +55,6 @@ public sealed interface TypeCreator extends ModifiableCreator, GenericTyped
      * {@return the generic type of this class}
      */
     GenericType.OfClass genericType();
-
-    /**
-     * Implement a generic interface.
-     *
-     * @param genericType the generic interface type (must not be {@code null})
-     */
-    void implements_(GenericType.OfClass genericType);
-
-    /**
-     * Implement an interface.
-     *
-     * @param interface_ the descriptor of the interface (must not be {@code null})
-     */
-    void implements_(ClassDesc interface_);
-
-    /**
-     * Implement an interface.
-     *
-     * @param interface_ the interface (must not be {@code null})
-     */
-    default void implements_(Class<?> interface_) {
-        if (!interface_.isInterface()) {
-            throw new IllegalArgumentException("Only interfaces may be implemented");
-        }
-        implements_(Util.classDesc(interface_));
-    }
 
     /**
      * Add a general static initializer block to the type.

--- a/src/main/java/io/quarkus/gizmo2/impl/ClassCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/ClassCreatorImpl.java
@@ -39,6 +39,16 @@ public sealed class ClassCreatorImpl extends TypeCreatorImpl implements ClassCre
         super.extends_(desc);
     }
 
+    @Override
+    public void implements_(GenericType.OfClass genericType) {
+        super.implements_(genericType);
+    }
+
+    @Override
+    public void implements_(ClassDesc interface_) {
+        super.implements_(interface_);
+    }
+
     public ClassDesc superClass() {
         return super.superClass();
     }

--- a/src/main/java/io/quarkus/gizmo2/impl/InterfaceCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/InterfaceCreatorImpl.java
@@ -9,6 +9,7 @@ import java.util.function.Consumer;
 import io.github.dmlloyd.classfile.ClassBuilder;
 import io.github.dmlloyd.classfile.ClassFile;
 import io.quarkus.gizmo2.ClassOutput;
+import io.quarkus.gizmo2.GenericType;
 import io.quarkus.gizmo2.creator.AbstractMethodCreator;
 import io.quarkus.gizmo2.creator.InstanceMethodCreator;
 import io.quarkus.gizmo2.creator.InterfaceCreator;
@@ -26,6 +27,16 @@ public final class InterfaceCreatorImpl extends TypeCreatorImpl implements Inter
 
     public ModifierLocation modifierLocation() {
         return ModifierLocation.INTERFACE;
+    }
+
+    @Override
+    public void extends_(GenericType.OfClass genericType) {
+        super.implements_(genericType);
+    }
+
+    @Override
+    public void extends_(ClassDesc interface_) {
+        super.implements_(interface_);
     }
 
     MethodDesc methodDesc(final String name, final MethodTypeDesc type) {

--- a/src/main/java/io/quarkus/gizmo2/impl/TypeCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/TypeCreatorImpl.java
@@ -198,7 +198,7 @@ public abstract sealed class TypeCreatorImpl extends ModifiableCreatorImpl imple
                 interfaceSigs.stream().map(Util::signatureOf).toArray(Signature.ClassTypeSig[]::new));
     }
 
-    public void implements_(final GenericType.OfClass genericType) {
+    void implements_(final GenericType.OfClass genericType) {
         zb.withInterfaceSymbols(genericType.desc());
         if (interfaceSigs.isEmpty()) {
             interfaceSigs = new ArrayList<>(4);
@@ -206,7 +206,7 @@ public abstract sealed class TypeCreatorImpl extends ModifiableCreatorImpl imple
         interfaceSigs.add(genericType);
     }
 
-    public void implements_(final ClassDesc interface_) {
+    void implements_(final ClassDesc interface_) {
         implements_((GenericType.OfClass) GenericType.of(interface_));
     }
 

--- a/src/test/java/io/quarkus/gizmo2/AccessFlagsTest.java
+++ b/src/test/java/io/quarkus/gizmo2/AccessFlagsTest.java
@@ -61,7 +61,7 @@ public class AccessFlagsTest {
         TestClassMaker tcm = new TestClassMaker();
         Gizmo g = Gizmo.create(tcm);
         g.interface_("io.quarkus.gizmo2.FooInterface", cc -> {
-            cc.implements_(Consumer.class);
+            cc.extends_(Consumer.class);
         });
         Class<?> clazz = tcm.definedClass();
         assertTrue(clazz.isInterface());
@@ -78,7 +78,7 @@ public class AccessFlagsTest {
         Gizmo g = Gizmo.create(tcm);
         g.interface_(ClassDesc.of("io.quarkus.gizmo2.FooInterface"), cc -> {
             cc.packagePrivate();
-            cc.implements_(Consumer.class);
+            cc.extends_(Consumer.class);
             assertThrows(IllegalArgumentException.class, () -> cc.setAccess(AccessLevel.PROTECTED));
             assertThrows(IllegalArgumentException.class, () -> cc.addFlag(ModifierFlag.SYNCHRONIZED));
         });


### PR DESCRIPTION
This makes the `InterfaceCreator` usage closer to Java language syntax, where making an interface extend another interface uses the `extends` keyword.