### PR TITLE
Object methods improvements

### DIFF
--- a/src/main/java/io/quarkus/gizmo2/creator/BlockCreator.java
+++ b/src/main/java/io/quarkus/gizmo2/creator/BlockCreator.java
@@ -991,12 +991,12 @@ public sealed interface BlockCreator extends SimpleTyped permits BlockCreatorImp
      * The arguments must be of the same {@linkplain TypeKind type kind}.
      * This works equivalently to the {@code ==} operator in Java
      * for primitive and reference values.
-     * For object equality using {@link Object#equals}, see {@link #exprEquals(Expr, Expr)}.
+     * For object equality using {@link Object#equals}, see {@link #objEquals(Expr, Expr)}.
      *
      * @param a the left-hand argument (must not be {@code null})
      * @param b the right-hand argument (must not be {@code null})
      * @return the boolean result expression
-     * @see #exprEquals(Expr, Expr)
+     * @see #objEquals(Expr, Expr)
      */
     Expr eq(Expr a, Expr b);
 
@@ -1061,12 +1061,12 @@ public sealed interface BlockCreator extends SimpleTyped permits BlockCreatorImp
      * The arguments must be of the same {@linkplain TypeKind type kind}.
      * This works equivalently to the {@code !=} operator in Java
      * for primitive and reference values.
-     * For object equality using {@link Object#equals}, see {@link #exprEquals(Expr, Expr)}.
+     * For object equality using {@link Object#equals}, see {@link #objEquals(Expr, Expr)}.
      *
      * @param a the left-hand argument (must not be {@code null})
      * @param b the right-hand argument (must not be {@code null})
      * @return the boolean result expression
-     * @see #exprEquals(Expr, Expr)
+     * @see #objEquals(Expr, Expr)
      */
     Expr ne(Expr a, Expr b);
 
@@ -3203,7 +3203,7 @@ public sealed interface BlockCreator extends SimpleTyped permits BlockCreatorImp
      * @param expr the expression, which can be of any type (must not be {@code null})
      * @return an {@code int} expression representing the hash code of given expression (not {@code null})
      */
-    Expr exprHashCode(Expr expr);
+    Expr objHashCode(Expr expr);
 
     /**
      * Generates call to the {@code Objects#equals(a, b)} method if at least one
@@ -3214,7 +3214,7 @@ public sealed interface BlockCreator extends SimpleTyped permits BlockCreatorImp
      * @param b the second expression (must not be {@code null})
      * @return a {@code boolean} expression representing the equality between the two values (not {@code null})
      */
-    Expr exprEquals(Expr a, Expr b);
+    Expr objEquals(Expr a, Expr b);
 
     /**
      * Generates call to one of the {@code String#valueOf(expr)} overloads, based on the type of the argument.
@@ -3222,7 +3222,7 @@ public sealed interface BlockCreator extends SimpleTyped permits BlockCreatorImp
      * @param expr the expression, which can be of any type
      * @return a {@code String} expression representing the string value of given expression (not {@code null})
      */
-    Expr exprToString(Expr expr);
+    Expr objToString(Expr expr);
 
     /**
      * Generates call to one of the {@code Arrays#hashCode(expr)} overloads, based on the type of the argument,

--- a/src/main/java/io/quarkus/gizmo2/creator/ops/ObjectOps.java
+++ b/src/main/java/io/quarkus/gizmo2/creator/ops/ObjectOps.java
@@ -152,7 +152,7 @@ public class ObjectOps {
      *
      * @return the expression of the result (not {@code null})
      */
-    public Expr objGetClass() {
+    public Expr getClass_() {
         return invokeInstance(Class.class, "getClass");
     }
 
@@ -162,7 +162,7 @@ public class ObjectOps {
      *
      * @return the expression of the result (not {@code null})
      */
-    public Expr objToString() {
+    public Expr toString_() {
         return invokeInstance(String.class, "toString");
     }
 
@@ -173,7 +173,7 @@ public class ObjectOps {
      * @param otherObj the object to compare (must not be {@code null})
      * @return the expression of the result (not {@code null})
      */
-    public Expr objEquals(Expr otherObj) {
+    public Expr equals_(Expr otherObj) {
         return invokeInstance(boolean.class, "equals", Object.class, otherObj);
     }
 
@@ -183,7 +183,7 @@ public class ObjectOps {
      *
      * @return the expression of the result (not {@code null})
      */
-    public Expr objHashCode() {
+    public Expr hashCode_() {
         return invokeInstance(int.class, "hashCode");
     }
 }

--- a/src/main/java/io/quarkus/gizmo2/creator/ops/ObjectOps.java
+++ b/src/main/java/io/quarkus/gizmo2/creator/ops/ObjectOps.java
@@ -158,7 +158,7 @@ public class ObjectOps {
 
     /**
      * Generate a call to {@link Object#toString()}.
-     * For a {@code null}-safe variation, use {@link BlockCreator#exprToString(Expr)}.
+     * For a {@code null}-safe variation, use {@link BlockCreator#objToString(Expr)}.
      *
      * @return the expression of the result (not {@code null})
      */
@@ -168,7 +168,7 @@ public class ObjectOps {
 
     /**
      * Generate a call to {@link Object#equals(Object)}.
-     * For a {@code null}-safe variation, use {@link BlockCreator#exprEquals(Expr, Expr)}.
+     * For a {@code null}-safe variation, use {@link BlockCreator#objEquals(Expr, Expr)}.
      *
      * @param otherObj the object to compare (must not be {@code null})
      * @return the expression of the result (not {@code null})
@@ -179,7 +179,7 @@ public class ObjectOps {
 
     /**
      * Generate a call to {@link Object#hashCode()}.
-     * For a {@code null}-safe variation, use {@link BlockCreator#exprHashCode(Expr)}.
+     * For a {@code null}-safe variation, use {@link BlockCreator#objHashCode(Expr)}.
      *
      * @return the expression of the result (not {@code null})
      */

--- a/src/main/java/io/quarkus/gizmo2/creator/ops/StringBuilderOps.java
+++ b/src/main/java/io/quarkus/gizmo2/creator/ops/StringBuilderOps.java
@@ -9,7 +9,7 @@ import io.quarkus.gizmo2.creator.BlockCreator;
  * <ol>
  * <li>Create an instance using {@link BlockCreator#withNewStringBuilder()}</li>
  * <li>Append to it using {@link #append(Expr)}</li>
- * <li>Create the final string using {@link #objToString()}</li>
+ * <li>Create the final string using {@link #toString_()}</li>
  * </ol>
  * If you need to perform other operations on the {@code StringBuilder}
  * that this class doesn't provide, you should create an instance

--- a/src/main/java/io/quarkus/gizmo2/impl/BlockCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/BlockCreatorImpl.java
@@ -1064,7 +1064,7 @@ public final class BlockCreatorImpl extends Item implements BlockCreator {
         replaceLastItem(val.equals(Const.ofVoid()) ? Yield.YIELD_VOID : new Yield(val));
     }
 
-    public Expr exprHashCode(final Expr expr) {
+    public Expr objHashCode(final Expr expr) {
         return switch (expr.typeKind()) {
             case BOOLEAN -> invokeStatic(MethodDesc.of(Boolean.class, "hashCode", int.class, boolean.class), expr);
             case BYTE -> invokeStatic(MethodDesc.of(Byte.class, "hashCode", int.class, byte.class), expr);
@@ -1079,21 +1079,21 @@ public final class BlockCreatorImpl extends Item implements BlockCreator {
         };
     }
 
-    public Expr exprEquals(final Expr a, final Expr b) {
+    public Expr objEquals(final Expr a, final Expr b) {
         return switch (a.typeKind()) {
             case REFERENCE -> switch (b.typeKind()) {
                 case REFERENCE ->
                     invokeStatic(MethodDesc.of(Objects.class, "equals", boolean.class, Object.class, Object.class), a, b);
-                default -> exprEquals(a, box(b));
+                default -> objEquals(a, box(b));
             };
             default -> switch (b.typeKind()) {
-                case REFERENCE -> exprEquals(box(a), b);
+                case REFERENCE -> objEquals(box(a), b);
                 default -> eq(a, b);
             };
         };
     }
 
-    public Expr exprToString(final Expr expr) {
+    public Expr objToString(final Expr expr) {
         return invokeStatic(MethodDesc.of(String.class, "valueOf", String.class, switch (expr.typeKind()) {
             case BOOLEAN -> boolean.class;
             case BYTE, SHORT, INT -> int.class;

--- a/src/main/java/io/quarkus/gizmo2/impl/EqualsHashCodeToStringGenerator.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/EqualsHashCodeToStringGenerator.java
@@ -66,7 +66,7 @@ public class EqualsHashCodeToStringGenerator {
                             b0.if_(b0.ne(thisBits, thatBits), BlockCreator::returnFalse);
                         }
                         // Object
-                        case 'L' -> b0.ifNot(b0.exprEquals(thisValue, thatValue), BlockCreator::returnFalse);
+                        case 'L' -> b0.ifNot(b0.objEquals(thisValue, thatValue), BlockCreator::returnFalse);
                         // array
                         case '[' -> b0.ifNot(b0.arrayEquals(thisValue, thatValue), BlockCreator::returnFalse);
                         default -> throw impossibleSwitchCase(field);
@@ -99,7 +99,7 @@ public class EqualsHashCodeToStringGenerator {
 
                     LocalVar value = b0.localVar("value", b0.get(cc.this_().field(field)));
                     LocalVar hash = b0.localVar("hash",
-                            field.type().isArray() ? b0.arrayHashCode(value) : b0.exprHashCode(value));
+                            field.type().isArray() ? b0.arrayHashCode(value) : b0.objHashCode(value));
                     b0.set(result, b0.add(b0.mul(Const.of(31), result), hash));
                 }
 

--- a/src/main/java/io/quarkus/gizmo2/impl/EqualsHashCodeToStringGenerator.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/EqualsHashCodeToStringGenerator.java
@@ -138,7 +138,7 @@ public class EqualsHashCodeToStringGenerator {
                 }
 
                 result.append(')');
-                b0.return_(result.objToString());
+                b0.return_(result.toString_());
             });
         });
     }

--- a/src/main/java/io/quarkus/gizmo2/impl/TypeCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/TypeCreatorImpl.java
@@ -516,7 +516,7 @@ public abstract sealed class TypeCreatorImpl extends ModifiableCreatorImpl imple
                             // check for newline
                             b2.if_(b2.eq(a, '\n'), b3 -> {
                                 // end of string
-                                Expr toString = b3.withObject(sb).objToString();
+                                Expr toString = b3.withObject(sb).toString_();
                                 // this is safe because this statement does not use or leave anything on the stack
                                 b3.withStringBuilder(sb).setLength(0);
                                 b3.return_(toString);

--- a/src/test/java/io/quarkus/gizmo2/ArraysTest.java
+++ b/src/test/java/io/quarkus/gizmo2/ArraysTest.java
@@ -38,7 +38,7 @@ public class ArraysTest {
                     var arr = bc.localVar("arr", bc.newEmptyArray(String.class, Const.of(5)));
                     bc.set(arr.elem(0), Const.of("foo"));
                     bc.set(arr.elem(Const.of(1)), Const.of("bar"));
-                    bc.ifNot(bc.exprEquals(arr.elem(Integer.valueOf(1)), Const.of("bar")), fail -> fail.return_(-1));
+                    bc.ifNot(bc.objEquals(arr.elem(Integer.valueOf(1)), Const.of("bar")), fail -> fail.return_(-1));
                     bc.return_(arr.length());
                 });
             });

--- a/src/test/java/io/quarkus/gizmo2/AutoConversionTest.java
+++ b/src/test/java/io/quarkus/gizmo2/AutoConversionTest.java
@@ -50,7 +50,7 @@ public class AutoConversionTest {
                 mc.returning(String.class);
                 mc.body(bc -> {
                     bc.return_(bc.withNewStringBuilder().append(a).append("_").append(b).append("_").append(c)
-                            .append("_").append(d).objToString());
+                            .append("_").append(d).toString_());
                 });
             });
 
@@ -82,7 +82,7 @@ public class AutoConversionTest {
                 ParamVar b = mc.parameter("b", double.class);
                 mc.returning(String.class);
                 mc.body(bc -> {
-                    bc.return_(bc.withNewStringBuilder().append(a).append("_").append(b).objToString());
+                    bc.return_(bc.withNewStringBuilder().append(a).append("_").append(b).toString_());
                 });
             });
 
@@ -113,7 +113,7 @@ public class AutoConversionTest {
                 ParamVar b = mc.parameter("b", double.class);
                 mc.returning(String.class);
                 mc.body(bc -> {
-                    bc.return_(bc.withNewStringBuilder().append(a).append("_").append(b).objToString());
+                    bc.return_(bc.withNewStringBuilder().append(a).append("_").append(b).toString_());
                 });
             });
 
@@ -145,7 +145,7 @@ public class AutoConversionTest {
                 ParamVar b = mc.parameter("b", Double.class);
                 mc.returning(String.class);
                 mc.body(bc -> {
-                    bc.return_(bc.withNewStringBuilder().append(a).append("_").append(b).objToString());
+                    bc.return_(bc.withNewStringBuilder().append(a).append("_").append(b).toString_());
                 });
             });
 

--- a/src/test/java/io/quarkus/gizmo2/ConstantsTest.java
+++ b/src/test/java/io/quarkus/gizmo2/ConstantsTest.java
@@ -58,7 +58,7 @@ public class ConstantsTest {
                 mc.body(bc -> {
                     Const c = bytecode.get();
                     bc.return_(bc.withNewStringBuilder().append(c).append('|')
-                            .append(c.type().descriptorString()).objToString());
+                            .append(c.type().descriptorString()).toString_());
                 });
             });
         });

--- a/src/test/java/io/quarkus/gizmo2/FieldAccessTest.java
+++ b/src/test/java/io/quarkus/gizmo2/FieldAccessTest.java
@@ -139,7 +139,7 @@ public class FieldAccessTest {
                 smc.public_();
                 smc.body(b0 -> {
                     Expr instance = b0.new_(ClassDesc.of(className));
-                    b0.return_(b0.exprEquals(instance.field(field1), Const.of("Hello world")));
+                    b0.return_(b0.objEquals(instance.field(field1), Const.of("Hello world")));
                 });
             });
         });
@@ -174,7 +174,7 @@ public class FieldAccessTest {
                 smc.public_();
                 smc.body(b0 -> {
                     Expr instance = b0.new_(ClassDesc.of(className));
-                    b0.return_(b0.exprEquals(instance.field(field1), Const.of("Hello world")));
+                    b0.return_(b0.objEquals(instance.field(field1), Const.of("Hello world")));
                 });
             });
         });
@@ -199,7 +199,7 @@ public class FieldAccessTest {
                 mc.returning(boolean.class);
                 mc.public_();
                 mc.body(bc -> {
-                    bc.return_(bc.exprEquals(fieldVar, Const.of("Hello world")));
+                    bc.return_(bc.objEquals(fieldVar, Const.of("Hello world")));
                 });
             });
         });

--- a/src/test/java/io/quarkus/gizmo2/InvocationTest.java
+++ b/src/test/java/io/quarkus/gizmo2/InvocationTest.java
@@ -36,7 +36,7 @@ public class InvocationTest {
                 ParamVar input = mc.parameter("input", String.class);
                 mc.returning(String.class);
                 mc.body(bc -> {
-                    bc.return_(bc.withNewStringBuilder().append(input).append("_foobar").objToString());
+                    bc.return_(bc.withNewStringBuilder().append(input).append("_foobar").toString_());
                 });
             });
 
@@ -71,7 +71,7 @@ public class InvocationTest {
                 ParamVar input = mc.parameter("input", String.class);
                 mc.returning(String.class);
                 mc.body(bc -> {
-                    bc.return_(bc.withNewStringBuilder().append(input).append("_foobar").objToString());
+                    bc.return_(bc.withNewStringBuilder().append(input).append("_foobar").toString_());
                 });
             });
 
@@ -114,7 +114,7 @@ public class InvocationTest {
                 ParamVar input = mc.parameter("input", String.class);
                 mc.returning(String.class);
                 mc.body(bc -> {
-                    bc.return_(bc.withNewStringBuilder().append(input).append("_foobar").objToString());
+                    bc.return_(bc.withNewStringBuilder().append(input).append("_foobar").toString_());
                 });
             });
         });
@@ -181,7 +181,7 @@ public class InvocationTest {
                 ParamVar input = mc.parameter("input", String.class);
                 mc.returning(String.class);
                 mc.body(bc -> {
-                    bc.return_(bc.withNewStringBuilder().append(input).append("_foobar").objToString());
+                    bc.return_(bc.withNewStringBuilder().append(input).append("_foobar").toString_());
                 });
             });
 
@@ -220,7 +220,7 @@ public class InvocationTest {
                 ParamVar input = mc.parameter("input", String.class);
                 mc.returning(String.class);
                 mc.body(bc -> {
-                    bc.return_(bc.withNewStringBuilder().append(input).append("_foobar").objToString());
+                    bc.return_(bc.withNewStringBuilder().append(input).append("_foobar").toString_());
                 });
             });
         });
@@ -264,7 +264,7 @@ public class InvocationTest {
                 ParamVar input = mc.parameter("input", String.class);
                 mc.returning(String.class);
                 mc.body(bc -> {
-                    bc.return_(bc.withNewStringBuilder().append(input).append("_foobar").objToString());
+                    bc.return_(bc.withNewStringBuilder().append(input).append("_foobar").toString_());
                 });
             });
         });
@@ -343,7 +343,7 @@ public class InvocationTest {
                 ParamVar input = mc.parameter("input", String.class);
                 mc.returning(String.class);
                 mc.body(bc -> {
-                    bc.return_(bc.withNewStringBuilder().append(input).append("_foobar").objToString());
+                    bc.return_(bc.withNewStringBuilder().append(input).append("_foobar").toString_());
                 });
             });
 
@@ -371,7 +371,7 @@ public class InvocationTest {
                 ParamVar input = mc.parameter("input", String.class);
                 mc.returning(String.class);
                 mc.body(bc -> {
-                    bc.return_(bc.withNewStringBuilder().append(input).append("_foobar").objToString());
+                    bc.return_(bc.withNewStringBuilder().append(input).append("_foobar").toString_());
                 });
             });
 

--- a/src/test/java/io/quarkus/gizmo2/LoopTest.java
+++ b/src/test/java/io/quarkus/gizmo2/LoopTest.java
@@ -56,7 +56,7 @@ public class LoopTest {
                         MethodDesc append = MethodDesc.of(StringBuilder.class, "append", StringBuilder.class, String.class);
                         loop.invokeVirtual(append, ret, loop.cast(item, String.class));
                         // if(item.equals("bar")) break;
-                        loop.if_(loop.exprEquals(item, Const.of("bar")), isEqual -> {
+                        loop.if_(loop.objEquals(item, Const.of("bar")), isEqual -> {
                             isEqual.break_(loop);
                         });
                     });
@@ -89,7 +89,7 @@ public class LoopTest {
                 mc.body(bc -> {
                     var ret = bc.localVar("ret", bc.new_(StringBuilder.class));
                     bc.forEach(p, (loop, item) -> {
-                        loop.if_(loop.exprEquals(item, Const.of("bar")), isEqual -> {
+                        loop.if_(loop.objEquals(item, Const.of("bar")), isEqual -> {
                             isEqual.continue_(loop);
                         });
                         MethodDesc append = MethodDesc.of(StringBuilder.class, "append", StringBuilder.class, String.class);

--- a/src/test/java/io/quarkus/gizmo2/LoopTest.java
+++ b/src/test/java/io/quarkus/gizmo2/LoopTest.java
@@ -60,7 +60,7 @@ public class LoopTest {
                             isEqual.break_(loop);
                         });
                     });
-                    bc.return_(bc.withObject(ret).objToString());
+                    bc.return_(bc.withObject(ret).toString_());
                 });
             });
         });
@@ -95,7 +95,7 @@ public class LoopTest {
                         MethodDesc append = MethodDesc.of(StringBuilder.class, "append", StringBuilder.class, String.class);
                         loop.invokeVirtual(append, ret, loop.cast(item, String.class));
                     });
-                    bc.return_(bc.withObject(ret).objToString());
+                    bc.return_(bc.withObject(ret).toString_());
                 });
             });
         });

--- a/src/test/java/io/quarkus/gizmo2/TryTest.java
+++ b/src/test/java/io/quarkus/gizmo2/TryTest.java
@@ -41,31 +41,31 @@ public final class TryTest {
                 smc.returning(String.class);
                 smc.body(b0 -> {
                     b0.try_(try0 -> {
-                        try0.body(b1 -> b1.withObject(foo).objEquals(bar));
+                        try0.body(b1 -> b1.withObject(foo).equals_(bar));
                         try0.finally_(b1 -> b1.try_(try1 -> {
-                            try1.body(b2 -> b2.withObject(foo).objEquals(bar));
+                            try1.body(b2 -> b2.withObject(foo).equals_(bar));
                             try1.finally_(b2 -> b2.try_(try2 -> {
-                                try2.body(b3 -> b3.withObject(foo).objEquals(bar));
+                                try2.body(b3 -> b3.withObject(foo).equals_(bar));
                                 try2.finally_(b3 -> b3.try_(try3 -> {
-                                    try3.body(b4 -> b4.withObject(foo).objEquals(bar));
+                                    try3.body(b4 -> b4.withObject(foo).equals_(bar));
                                     try3.finally_(b4 -> b4.try_(try4 -> {
-                                        try4.body(b5 -> b5.withObject(foo).objEquals(bar));
+                                        try4.body(b5 -> b5.withObject(foo).equals_(bar));
                                         try4.finally_(b5 -> b5.try_(try5 -> {
-                                            try5.body(b6 -> b6.withObject(foo).objEquals(bar));
+                                            try5.body(b6 -> b6.withObject(foo).equals_(bar));
                                             try5.finally_(b6 -> b6.try_(try6 -> {
-                                                try6.body(b7 -> b7.withObject(foo).objEquals(bar));
+                                                try6.body(b7 -> b7.withObject(foo).equals_(bar));
                                                 try6.finally_(b7 -> b7.try_(try7 -> {
-                                                    try7.body(b8 -> b8.withObject(foo).objEquals(bar));
+                                                    try7.body(b8 -> b8.withObject(foo).equals_(bar));
                                                     try7.finally_(b8 -> b8.try_(try8 -> {
-                                                        try8.body(b9 -> b9.withObject(foo).objEquals(bar));
+                                                        try8.body(b9 -> b9.withObject(foo).equals_(bar));
                                                         try8.finally_(b9 -> b9.try_(try9 -> {
-                                                            try9.body(b10 -> b10.withObject(foo).objEquals(bar));
+                                                            try9.body(b10 -> b10.withObject(foo).equals_(bar));
                                                             try9.finally_(b10 -> b10.try_(try10 -> {
-                                                                try10.body(b11 -> b11.withObject(foo).objEquals(bar));
+                                                                try10.body(b11 -> b11.withObject(foo).equals_(bar));
                                                                 try10.finally_(b11 -> b11.try_(try11 -> {
-                                                                    try11.body(b12 -> b12.withObject(foo).objEquals(bar));
+                                                                    try11.body(b12 -> b12.withObject(foo).equals_(bar));
                                                                     try11.finally_(b12 -> b12.try_(try12 -> {
-                                                                        try12.body(b13 -> b13.withObject(foo).objEquals(bar));
+                                                                        try12.body(b13 -> b13.withObject(foo).equals_(bar));
                                                                         try12.finally_(b13 -> b13.return_(
                                                                                 b13.withString(foo).concat(bar)));
                                                                     }));

--- a/src/test/java/io/quarkus/gizmo2/ops/MapOpsTest.java
+++ b/src/test/java/io/quarkus/gizmo2/ops/MapOpsTest.java
@@ -59,9 +59,9 @@ public class MapOpsTest {
                     bc.if_(bc.ne(size, 2), fail -> fail.return_(1));
                     bc.if_(mapOps.isEmpty(), fail -> fail.return_(2));
                     bc.ifNot(mapOps.containsKey(Const.of("foo")), fail -> fail.return_(3));
-                    bc.ifNot(bc.exprEquals(mapOps.get(Const.of("foo")), Const.of("bar")),
+                    bc.ifNot(bc.objEquals(mapOps.get(Const.of("foo")), Const.of("bar")),
                             fail -> fail.return_(4));
-                    bc.ifNot(bc.exprEquals(mapOps.remove(Const.of("alpha")), Const.of("bravo")),
+                    bc.ifNot(bc.objEquals(mapOps.remove(Const.of("alpha")), Const.of("bravo")),
                             fail -> fail.return_(5));
                     bc.if_(bc.ne(mapOps.size(), 1), fail -> fail.return_(6));
                     mapOps.clear();
@@ -91,7 +91,7 @@ public class MapOpsTest {
                     assertThrows(IllegalArgumentException.class, () -> bc.mapOf(Const.of("foo")));
                     var map = bc.localVar("map", bc.mapOf(Const.of("foo"), Const.of("bar")));
                     MapOps mapOps = bc.withMap(map);
-                    bc.ifNot(bc.exprEquals(mapOps.get(Const.of("foo")), Const.of("bar")),
+                    bc.ifNot(bc.objEquals(mapOps.get(Const.of("foo")), Const.of("bar")),
                             fail -> fail.return_(-1));
                     bc.return_(mapOps.size());
                 });

--- a/src/test/java/io/quarkus/gizmo2/ops/OptionalOpsTest.java
+++ b/src/test/java/io/quarkus/gizmo2/ops/OptionalOpsTest.java
@@ -49,11 +49,11 @@ public class OptionalOpsTest {
                     var baz = bc.localVar("baz", bc.optionalOfNullable(Const.ofNull(String.class)));
                     bc.if_(bc.withOptional(foo).isEmpty(), fail -> fail.return_(1));
                     bc.ifNot(bc.withOptional(foo).isPresent(), fail -> fail.return_(2));
-                    bc.ifNot(bc.exprEquals(Const.of("foo"), bc.withOptional(foo).get()), fail -> fail.return_(3));
+                    bc.ifNot(bc.objEquals(Const.of("foo"), bc.withOptional(foo).get()), fail -> fail.return_(3));
                     bc.if_(bc.withOptional(bar).isEmpty(), fail -> fail.return_(4));
                     bc.if_(bc.withOptional(baz).isPresent(), fail -> fail.return_(5));
                     var qux = Const.of("qux");
-                    bc.ifNot(bc.exprEquals(qux, bc.withOptional(baz).orElse(qux)), fail -> fail.return_(6));
+                    bc.ifNot(bc.objEquals(qux, bc.withOptional(baz).orElse(qux)), fail -> fail.return_(6));
                     bc.return_(0);
                 });
             });

--- a/src/test/java/io/quarkus/gizmo2/ops/StringBuilderOpsTest.java
+++ b/src/test/java/io/quarkus/gizmo2/ops/StringBuilderOpsTest.java
@@ -49,7 +49,7 @@ public class StringBuilderOpsTest {
                     strBuilder.append(Const.ofNull(Object.class));
                     strBuilder.append("...");
                     strBuilder.append('!');
-                    bc.return_(strBuilder.objToString());
+                    bc.return_(strBuilder.toString_());
                 });
             });
         });


### PR DESCRIPTION
### rename ObjectOps methods that generate calls of the corresponding Object method

This is:

- `objGetClass()` -> `getClass_()`
- `objToString()` -> `toString_()`
- `objEquals()` -> `equals_()`
- `objHashCode()` -> `hashCode_()`

This makes the names closer to what the actual method names are.

### rename BlockCreator methods that generate null-safe calls of the common Object methods

This is:

- `exprToString()` -> `objToString()`
- `exprEquals()` -> `objEquals()`
- `exprHashCode()` -> `objHashCode()`

This makes the names closer to their array correspondents, making it clearer what each of them does.