### PR TITLE
fix how lambdas are generated

### DIFF
--- a/src/main/java/io/quarkus/gizmo2/impl/BlockCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/BlockCreatorImpl.java
@@ -579,7 +579,7 @@ public final class BlockCreatorImpl extends Item implements BlockCreator {
             });
         });
         owner.buildLambdaBootstrap();
-        String encoded = Base64.getEncoder().encodeToString(bytes);
+        String encoded = Base64.getUrlEncoder().encodeToString(bytes);
         MethodTypeDesc ctorType = MethodTypeDesc.of(
                 samOwner,
                 captureExprs.stream().map(Expr::type).toArray(ClassDesc[]::new));

--- a/src/main/java/io/quarkus/gizmo2/impl/LocalVarImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/LocalVarImpl.java
@@ -56,10 +56,12 @@ public final class LocalVarImpl extends AssignableImpl implements LocalVar {
         if (slot == -1) {
             if (creationSite == null) {
                 throw new IllegalStateException("Local variable '" + name + "' was not allocated (check if it was"
-                        + " declared on the correct BlockCreator)" + Util.trackingMessage);
+                        + " declared on the correct BlockCreator or if it was captured if you're generating a lambda)"
+                        + Util.trackingMessage);
             } else {
                 throw new IllegalStateException("Local variable '" + name + "' created at " + creationSite
-                        + " was not allocated (check if it was declared on the correct BlockCreator)");
+                        + " was not allocated (check if it was declared on the correct BlockCreator or if it was"
+                        + " captured if you're generating a lambda)");
             }
         }
     }

--- a/src/main/java/io/quarkus/gizmo2/impl/TypeCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/TypeCreatorImpl.java
@@ -368,7 +368,7 @@ public abstract sealed class TypeCreatorImpl extends ModifiableCreatorImpl imple
                         smc.body(b0 -> {
                             var decoder = b0.localVar("decoder", b0.invokeStatic(MethodDesc.of(
                                     Base64.class,
-                                    "getDecoder",
+                                    "getUrlDecoder",
                                     Base64.Decoder.class)));
                             var bytes = b0.localVar("bytes", b0.invokeVirtual(MethodDesc.of(
                                     Base64.Decoder.class,


### PR DESCRIPTION
To generate a lambda, we create an anonymous class, serialize it and use Base64 to encode the serialized class. (The invokedynamic bootstrap method then decodes the serialized form and spins up a new class.) We used the default Base64 alphabet, which includes a disallowed character: `/`.

With this commit, we use the URL-safe Base64 alphabet, which does not include any disallowed characters.

This commit also adjusts the error message for not allocated local variables: this may also happen if a lambda uses a non-captured variable from outer lexical scope. Took me a while to figure out, so I figured the error message should contain a hint.