### PR TITLE
improve switch

### DIFF
--- a/src/main/java/io/quarkus/gizmo2/creator/BlockCreator.java
+++ b/src/main/java/io/quarkus/gizmo2/creator/BlockCreator.java
@@ -2914,6 +2914,18 @@ public sealed interface BlockCreator extends SimpleTyped permits BlockCreatorImp
     Expr switchEnum(ClassDesc outputType, Expr val, Consumer<SwitchCreator> builder);
 
     /**
+     * Construct a {@code switch} expression for {@code enum} constants.
+     *
+     * @param outputType the output type of this {@code switch} (must not be {@code null})
+     * @param val the value to switch on (must not be {@code null})
+     * @param builder the builder for the {@code switch} statement (must not be {@code null})
+     * @return the switch expression result (not {@code null})
+     */
+    default Expr switchEnum(Class<?> outputType, Expr val, Consumer<SwitchCreator> builder) {
+        return switchEnum(Util.classDesc(outputType), val, builder);
+    }
+
+    /**
      * Construct a {@code switch} statement.
      * The type of the switch value must be of one of these supported types:
      * <ul>
@@ -2933,7 +2945,7 @@ public sealed interface BlockCreator extends SimpleTyped permits BlockCreatorImp
     }
 
     /**
-     * Construct a {@code switch} statement.
+     * Construct a {@code switch} expression.
      * The type of the switch value must be of one of these supported types:
      * <ul>
      * <li>{@code int} (which includes {@code byte}, {@code char}, {@code short}, and {@code boolean})</li>
@@ -2950,6 +2962,27 @@ public sealed interface BlockCreator extends SimpleTyped permits BlockCreatorImp
      * @return the switch expression result (not {@code null})
      */
     Expr switch_(ClassDesc outputType, Expr val, Consumer<SwitchCreator> builder);
+
+    /**
+     * Construct a {@code switch} expression.
+     * The type of the switch value must be of one of these supported types:
+     * <ul>
+     * <li>{@code int} (which includes {@code byte}, {@code char}, {@code short}, and {@code boolean})</li>
+     * <li>{@code long}</li>
+     * <li>{@code java.lang.String}</li>
+     * <li>{@code java.lang.Class}</li>
+     * </ul>
+     * The type of the {@code switch} creator depends on the type of the value.
+     * For {@code enum} switches, use {@link #switchEnum(Expr, Consumer)}.
+     *
+     * @param outputType the output type of this {@code switch} (must not be {@code null})
+     * @param val the value to switch on (must not be {@code null})
+     * @param builder the builder for the {@code switch} statement (must not be {@code null})
+     * @return the switch expression result (not {@code null})
+     */
+    default Expr switch_(Class<?> outputType, Expr val, Consumer<SwitchCreator> builder) {
+        return switch_(Util.classDesc(outputType), val, builder);
+    }
 
     /**
      * Exit the given enclosing block.

--- a/src/main/java/io/quarkus/gizmo2/impl/SwitchCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/SwitchCreatorImpl.java
@@ -65,6 +65,12 @@ public sealed abstract class SwitchCreatorImpl<C extends ConstImpl> extends Item
         this.switchVal = (Item) switchVal;
         this.type = type;
         this.constantType = constantType;
+
+        if (!type.equals(CD_void)) {
+            // switch expressions may always fall through, even if all branches actually may not
+            // this allows (and, in fact, requires) using them as actual expressions
+            fallThrough = true;
+        }
     }
 
     protected Node forEachDependency(final Node node, final BiFunction<Item, Node, Node> op) {
@@ -99,6 +105,9 @@ public sealed abstract class SwitchCreatorImpl<C extends ConstImpl> extends Item
                     fallThrough = true;
                 } else {
                     throw new IllegalStateException("Missing default branch on switch expression");
+                }
+                if (cases.isEmpty()) {
+                    throw new IllegalStateException("No case branch and no default branch on switch");
                 }
             }
         } finally {


### PR DESCRIPTION
1. Add `BlockCreator.switch_()` and `switchEnum()` overloads that accept `Class` as the `switch` expression type, in addition to `ClassDesc`. Often, the type is statically known and easier to express as `Class`.
2. Add validation that at least one `case` or `default` branch is added to a `switch`. If none is added, an exception is thrown early.
3. Allow hash-based `switch` implementations to have no `case` branches, only a `default` branch. This condition occurs in practice when `case` branches are generated based on an external list of objects. Such lists may easily be empty. This has always been allowed for value-based `switch` implementations (called "perfect hash" based here).
4. Let `switch` expressions (`switch` with a non-`void` type) always fall through. This allows (and, in fact, requires) using them as actual expressions.

   Note that `switch` statements (`switch` with a `void` type) behave as before: if no branch may fall through, the entire `switch` may not either.

Tests are added for items 3 and 4.