### PR TITLE
fix numeric promotion for eq/ne comparisons

### DIFF
--- a/src/main/java/io/quarkus/gizmo2/impl/BlockCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/BlockCreatorImpl.java
@@ -3,6 +3,7 @@ package io.quarkus.gizmo2.impl;
 import static io.quarkus.gizmo2.impl.Conversions.boxingConversion;
 import static io.quarkus.gizmo2.impl.Conversions.convert;
 import static io.quarkus.gizmo2.impl.Conversions.numericPromotion;
+import static io.quarkus.gizmo2.impl.Conversions.numericPromotionRequired;
 import static io.quarkus.gizmo2.impl.Conversions.unboxingConversion;
 import static io.quarkus.gizmo2.impl.Preconditions.requireArray;
 import static io.quarkus.gizmo2.impl.Preconditions.requireSameTypeKind;
@@ -421,7 +422,9 @@ public final class BlockCreatorImpl extends Item implements BlockCreator {
 
     private Expr rel(Expr a, Expr b, final If.Kind kind) {
         ClassDesc operandType = a.type();
-        Optional<ClassDesc> promotedType = numericPromotion(a.type(), b.type());
+        Optional<ClassDesc> promotedType = numericPromotionRequired(kind, a.type(), b.type())
+                ? numericPromotion(a.type(), b.type())
+                : Optional.empty();
         if (promotedType.isPresent()) {
             operandType = promotedType.get();
             a = convert(a, operandType);

--- a/src/main/java/io/quarkus/gizmo2/impl/Conversions.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/Conversions.java
@@ -179,11 +179,6 @@ final class Conversions {
         if (b.isClassOrInterface()) {
             b = unboxTypes.getOrDefault(b, b);
         }
-        if (a.equals(b)) {
-            // also covers the case when both `a` and `b` are `boolean`,
-            // which may occur in case of `Rel` with `If.Kind.EQ` and `NE`
-            return Optional.of(a);
-        }
         if (a.isPrimitive() && b.isPrimitive()) {
             TypeKind aKind = TypeKind.from(a);
             TypeKind bKind = TypeKind.from(b);
@@ -198,5 +193,24 @@ final class Conversions {
             }
         }
         return Optional.empty();
+    }
+
+    /**
+     * {@return whether a logical operation of given {@code kind} with given argument types {@code a} and {@code b}
+     * requires numeric promotion}
+     *
+     * @param kind the kind of the logical operation (must not be {@code null})
+     * @param a the type of the first argument (must not be {@code null})
+     * @param b the type of the second argument (must not be {@code null})
+     */
+    static boolean numericPromotionRequired(If.Kind kind, ClassDesc a, ClassDesc b) {
+        if (kind != If.Kind.EQ && kind != If.Kind.NE) {
+            // non-equality operations (<, <=, >, >=) all require numeric promotion
+            return true;
+        }
+
+        // equality operations only require promotion if performed on numeric types
+        // that is, all primitive types except `boolean` (and `void`, but that never occurs here)
+        return a.isPrimitive() && !CD_boolean.equals(a) || b.isPrimitive() && !CD_boolean.equals(b);
     }
 }

--- a/src/test/java/io/quarkus/gizmo2/AutoConversionTest.java
+++ b/src/test/java/io/quarkus/gizmo2/AutoConversionTest.java
@@ -1616,4 +1616,84 @@ public class AutoConversionTest {
         assertFalse(tcm.staticMethod("test1", BooleanSupplier.class).getAsBoolean());
         assertTrue(tcm.staticMethod("test2", BooleanSupplier.class).getAsBoolean());
     }
+
+    @Test
+    public void eq_noConversion() {
+        TestClassMaker tcm = new TestClassMaker();
+        Gizmo g = Gizmo.create(tcm);
+        g.class_("io.quarkus.gizmo2.EQ", cc -> {
+            cc.staticMethod("test1", mc -> {
+                // static boolean test1() {
+                //     return new Integer(5) == null;
+                // }
+                mc.returning(boolean.class);
+                mc.body(bc -> {
+                    bc.return_(bc.eq(bc.new_(Integer.class, Const.of(5)), Const.ofNull(Integer.class)));
+                });
+            });
+            cc.staticMethod("test2", mc -> {
+                // static boolean test2() {
+                //     return new Integer(5) == new Integer(7);
+                // }
+                mc.returning(boolean.class);
+                mc.body(bc -> {
+                    bc.return_(bc.eq(bc.new_(Integer.class, Const.of(5)), bc.new_(Integer.class, Const.of(7))));
+                });
+            });
+            cc.staticMethod("test3", mc -> {
+                // static boolean test3() {
+                //     Integer i = new Integer(5);
+                //     return i == i;
+                // }
+                mc.returning(boolean.class);
+                mc.body(bc -> {
+                    LocalVar i = bc.localVar("i", bc.new_(Integer.class, Const.of(5)));
+                    bc.return_(bc.eq(i, i));
+                });
+            });
+        });
+        assertFalse(tcm.staticMethod("test1", BooleanSupplier.class).getAsBoolean());
+        assertFalse(tcm.staticMethod("test2", BooleanSupplier.class).getAsBoolean());
+        assertTrue(tcm.staticMethod("test3", BooleanSupplier.class).getAsBoolean());
+    }
+
+    @Test
+    public void ne_noConversion() {
+        TestClassMaker tcm = new TestClassMaker();
+        Gizmo g = Gizmo.create(tcm);
+        g.class_("io.quarkus.gizmo2.NE", cc -> {
+            cc.staticMethod("test1", mc -> {
+                // static boolean test1() {
+                //     return new Integer(5) != null;
+                // }
+                mc.returning(boolean.class);
+                mc.body(bc -> {
+                    bc.return_(bc.ne(bc.new_(Integer.class, Const.of(5)), Const.ofNull(Integer.class)));
+                });
+            });
+            cc.staticMethod("test2", mc -> {
+                // static boolean test2() {
+                //     return new Integer(5) != new Integer(7);
+                // }
+                mc.returning(boolean.class);
+                mc.body(bc -> {
+                    bc.return_(bc.ne(bc.new_(Integer.class, Const.of(5)), bc.new_(Integer.class, Const.of(7))));
+                });
+            });
+            cc.staticMethod("test3", mc -> {
+                // static boolean test3() {
+                //     Integer i = new Integer(5);
+                //     return i != i;
+                // }
+                mc.returning(boolean.class);
+                mc.body(bc -> {
+                    LocalVar i = bc.localVar("i", bc.new_(Integer.class, Const.of(5)));
+                    bc.return_(bc.ne(i, i));
+                });
+            });
+        });
+        assertTrue(tcm.staticMethod("test1", BooleanSupplier.class).getAsBoolean());
+        assertTrue(tcm.staticMethod("test2", BooleanSupplier.class).getAsBoolean());
+        assertFalse(tcm.staticMethod("test3", BooleanSupplier.class).getAsBoolean());
+    }
 }


### PR DESCRIPTION
The non-equality comparisons (`<`, `<=`, `>`, `>=`) require numeric promotion always, but equality comparisons (`==`, `!=`) only require it if at least one argument is numeric type (that is, primitive but not `boolean`). If both arguments are not numeric types, no numeric promotion should happen.

We previously guarded against that in a naive way: the `numericPromotion()` method returned early when both operands were of the same type after unboxing. This leads to incorrect conversion in case of equality comparisons on primitive wrapper types (and may lead to NPE at runtime). This commit adds proper guard to the appropriate place.

Note that there are other occurences of `numericPromotion()` which are not guarded by `numericPromotionRequired()`. These are in `BinOp` and in `Cmp`, where on both places the operation is always numeric and so always requires numeric promotion.