### PR TITLE
improvements

### DIFF
--- a/src/main/java/io/quarkus/gizmo2/creator/BlockCreator.java
+++ b/src/main/java/io/quarkus/gizmo2/creator/BlockCreator.java
@@ -971,6 +971,18 @@ public sealed interface BlockCreator extends SimpleTyped permits BlockCreatorImp
      * Create a new array with the given type, initialized with the given values.
      *
      * @param componentType the component type (must not be {@code null})
+     * @param values the values to assign into the array after mapping (must not be {@code null})
+     * @param mapper function that turns values into expressions (must not be {@code null})
+     * @return the expression for the new array (not {@code null})
+     */
+    default <T> Expr newArray(Class<?> componentType, List<T> values, Function<T, ? extends Expr> mapper) {
+        return newArray(Util.classDesc(componentType), values, mapper);
+    }
+
+    /**
+     * Create a new array with the given type, initialized with the given values.
+     *
+     * @param componentType the component type (must not be {@code null})
      * @param values the values to assign into the array (must not be {@code null})
      * @return the expression for the new array (not {@code null})
      */
@@ -2794,6 +2806,17 @@ public sealed interface BlockCreator extends SimpleTyped permits BlockCreatorImp
      * @return the returned value (not {@code null})
      */
     Expr blockExpr(ClassDesc type, Consumer<BlockCreator> nested);
+
+    /**
+     * Create a block expression of given {@code type}. The block must {@link #yield(Expr)} its result.
+     *
+     * @param type the output type (must not be {@code null})
+     * @param nested the builder for the block body (must not be {@code null})
+     * @return the returned value (not {@code null})
+     */
+    default Expr blockExpr(Class<?> type, Consumer<BlockCreator> nested) {
+        return blockExpr(Util.classDesc(type), nested);
+    }
 
     /**
      * If the given object is an instance of the given type, then execute the block with the narrowed object.

--- a/src/main/java/io/quarkus/gizmo2/impl/BlockCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/BlockCreatorImpl.java
@@ -572,6 +572,14 @@ public final class BlockCreatorImpl extends Item implements BlockCreator {
     }
 
     public Expr lambda(final MethodDesc sam, final ClassDesc samOwner, final Consumer<LambdaCreator> builder) {
+        // certain versions of GraalVM native image cannot handle our custom translation strategy of lambdas
+        // see: https://github.com/quarkusio/quarkus/issues/49346
+        // we'll need to handle it better, but for now, let's just use the "classic" translation strategy always
+        // this code block shall be removed in the future
+        if (true) {
+            return lambdaDebug(sam, samOwner, builder);
+        }
+
         if (Util.debug) {
             return lambdaDebug(sam, samOwner, builder);
         }

--- a/src/main/java/io/quarkus/gizmo2/impl/BlockCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/BlockCreatorImpl.java
@@ -432,7 +432,7 @@ public final class BlockCreatorImpl extends Item implements BlockCreator {
                 // wrap with cmpg
                 return relZero(cmpg(a, Const.of(0, a.typeKind())), kind);
             }
-            default -> throw new IllegalStateException();
+            default -> throw impossibleSwitchCase(a.typeKind().asLoadable());
         }
     }
 

--- a/src/main/java/io/quarkus/gizmo2/impl/Cmp.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/Cmp.java
@@ -2,6 +2,7 @@ package io.quarkus.gizmo2.impl;
 
 import static io.quarkus.gizmo2.impl.Conversions.convert;
 import static io.quarkus.gizmo2.impl.Conversions.numericPromotion;
+import static io.smallrye.common.constraint.Assert.impossibleSwitchCase;
 import static java.lang.constant.ConstantDescs.CD_Double;
 import static java.lang.constant.ConstantDescs.CD_Float;
 import static java.lang.constant.ConstantDescs.CD_Integer;
@@ -56,7 +57,7 @@ final class Cmp extends Item {
             case FLOAT -> kind.floatOp.apply(cb);
             case DOUBLE -> kind.doubleOp.apply(cb);
             case REFERENCE -> kind.refOp.apply(cb);
-            default -> throw new IllegalStateException();
+            default -> throw impossibleSwitchCase(a.typeKind().asLoadable());
         }
     }
 

--- a/src/main/java/io/quarkus/gizmo2/impl/Dup.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/Dup.java
@@ -1,5 +1,7 @@
 package io.quarkus.gizmo2.impl;
 
+import static io.smallrye.common.constraint.Assert.impossibleSwitchCase;
+
 import java.lang.constant.ClassDesc;
 import java.util.function.BiFunction;
 
@@ -46,7 +48,7 @@ final class Dup extends Item {
             case 1 -> cb.dup();
             case 0 -> {
             }
-            default -> throw new IllegalStateException();
+            default -> throw impossibleSwitchCase(typeKind().asLoadable());
         }
     }
 }

--- a/src/main/java/io/quarkus/gizmo2/impl/HashSwitchCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/HashSwitchCreatorImpl.java
@@ -108,8 +108,8 @@ abstract sealed class HashSwitchCreatorImpl<C extends ConstImpl> extends SwitchC
 
         // finally, the default block
         if (default_ == null) {
+            // `fallOut` and `nonMatching` refer to the same object, so we need to bind it just once
             cb.labelBinding(fallOut);
-            cb.labelBinding(nonMatching);
         } else {
             default_.writeCode(cb, block);
         }

--- a/src/main/java/io/quarkus/gizmo2/impl/IfRel.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/IfRel.java
@@ -1,5 +1,7 @@
 package io.quarkus.gizmo2.impl;
 
+import static io.smallrye.common.constraint.Assert.impossibleSwitchCase;
+
 import java.lang.constant.ClassDesc;
 import java.util.function.BiFunction;
 
@@ -21,7 +23,7 @@ final class IfRel extends If {
         return switch (a.typeKind().asLoadable()) {
             case INT -> kind.if_icmp;
             case REFERENCE -> kind.if_acmp;
-            default -> throw new IllegalStateException();
+            default -> throw impossibleSwitchCase(a.typeKind().asLoadable());
         };
     }
 }

--- a/src/main/java/io/quarkus/gizmo2/impl/IfZero.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/IfZero.java
@@ -1,6 +1,7 @@
 package io.quarkus.gizmo2.impl;
 
 import static io.quarkus.gizmo2.impl.Conversions.convert;
+import static io.smallrye.common.constraint.Assert.impossibleSwitchCase;
 import static java.lang.constant.ConstantDescs.CD_boolean;
 
 import java.lang.constant.ClassDesc;
@@ -23,7 +24,7 @@ final class IfZero extends If {
         return switch (a.typeKind().asLoadable()) {
             case INT -> kind.if_;
             case REFERENCE -> kind.if_acmpnull;
-            default -> throw new IllegalStateException();
+            default -> throw impossibleSwitchCase(a.typeKind().asLoadable());
         };
     }
 }

--- a/src/main/java/io/quarkus/gizmo2/impl/PerfectHashSwitchCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/PerfectHashSwitchCreatorImpl.java
@@ -49,8 +49,8 @@ sealed abstract class PerfectHashSwitchCreatorImpl<C extends ConstImpl> extends 
         }
         // finally, the default block
         if (default_ == null) {
+            // `fallOut` and `nonMatching` refer to the same object, so we need to bind it just once
             cb.labelBinding(fallOut);
-            cb.labelBinding(nonMatching);
         } else {
             default_.writeCode(cb, block);
         }

--- a/src/main/java/io/quarkus/gizmo2/impl/RelZero.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/RelZero.java
@@ -1,5 +1,6 @@
 package io.quarkus.gizmo2.impl;
 
+import static io.smallrye.common.constraint.Assert.impossibleSwitchCase;
 import static java.lang.constant.ConstantDescs.CD_boolean;
 
 import java.lang.constant.ClassDesc;
@@ -67,7 +68,7 @@ final class RelZero extends Item {
                 cb.iand();
                 return;
             }
-            default -> throw new IllegalStateException();
+            default -> throw impossibleSwitchCase(a.typeKind().asLoadable());
         }
         cb.iconst_0();
         cb.goto_(end);

--- a/src/main/java/io/quarkus/gizmo2/impl/TryCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/TryCreatorImpl.java
@@ -29,7 +29,8 @@ public final class TryCreatorImpl implements TryCreator {
 
     private void advanceToState(int newState) {
         if (state > newState) {
-            throw new IllegalStateException();
+            throw new IllegalStateException("Wrong method call order: body() must come first, then arbitrarily "
+                    + "many catch_(), then at most one finally_()");
         }
         this.state = newState;
     }

--- a/src/test/java/io/quarkus/gizmo2/SwitchTest.java
+++ b/src/test/java/io/quarkus/gizmo2/SwitchTest.java
@@ -60,7 +60,7 @@ public final class SwitchTest {
     public void testIntSwitch() {
         TestClassMaker tcm = new TestClassMaker();
         Gizmo g = Gizmo.create(tcm);
-        g.class_(ClassDesc.of("io.quarkus.gizmo2.TestIntSwitchExpr"), zc -> {
+        g.class_(ClassDesc.of("io.quarkus.gizmo2.TestIntSwitch"), zc -> {
             zc.staticMethod("frobnicate", mc -> {
                 mc.returning(int.class);
                 ParamVar cp = mc.parameter("cp", int.class);
@@ -88,6 +88,32 @@ public final class SwitchTest {
                         });
                         sc.default_(b1 -> b1.yield(cp));
                     }));
+                });
+            });
+        });
+        IntUnaryOperator frobnicate = tcm.staticMethod("frobnicate", IntUnaryOperator.class);
+        assertEquals('i', frobnicate.applyAsInt('a'));
+        assertEquals('q', frobnicate.applyAsInt('q'));
+        assertEquals('o', frobnicate.applyAsInt('e'));
+    }
+
+    @Test
+    public void testIntSwitchWithoutDefaultCase() {
+        TestClassMaker tcm = new TestClassMaker();
+        Gizmo g = Gizmo.create(tcm);
+        g.class_(ClassDesc.of("io.quarkus.gizmo2.TestIntSwitch"), zc -> {
+            zc.staticMethod("frobnicate", mc -> {
+                mc.returning(int.class);
+                ParamVar cp = mc.parameter("cp", int.class);
+                mc.body(b0 -> {
+                    b0.switch_(cp, sc -> {
+                        sc.caseOf('a', b1 -> b1.return_(Const.of((int) 'i')));
+                        sc.caseOf('e', b1 -> b1.return_(Const.of((int) 'o')));
+                        sc.caseOf('i', b1 -> b1.return_(Const.of((int) 'u')));
+                        sc.caseOf('o', b1 -> b1.return_(Const.of((int) 'a')));
+                        sc.caseOf('u', b1 -> b1.return_(Const.of((int) 'e')));
+                    });
+                    b0.return_(cp);
                 });
             });
         });
@@ -154,6 +180,33 @@ public final class SwitchTest {
                         sc.caseOf("three", b1 -> b1.yield(Const.of(3)));
                         sc.default_(b1 -> b1.yield(Const.of(-1)));
                     }));
+                });
+            });
+        });
+        NumberParser nameToNumber = tcm.staticMethod("nameToNumber", NumberParser.class);
+        assertEquals(0, nameToNumber.get("zero"));
+        assertEquals(1, nameToNumber.get("one"));
+        assertEquals(2, nameToNumber.get("two"));
+        assertEquals(3, nameToNumber.get("three"));
+        assertEquals(-1, nameToNumber.get("four"));
+    }
+
+    @Test
+    public void testStringSwitchWithoutDefaultCase() {
+        TestClassMaker tcm = new TestClassMaker();
+        Gizmo g = Gizmo.create(tcm);
+        g.class_(ClassDesc.of("io.quarkus.gizmo2.TestStringSwitch"), zc -> {
+            zc.staticMethod("nameToNumber", mc -> {
+                mc.returning(int.class);
+                ParamVar name = mc.parameter("name", String.class);
+                mc.body(b0 -> {
+                    b0.switch_(name, sc -> {
+                        sc.caseOf("zero", b1 -> b1.return_(Const.of(0)));
+                        sc.caseOf("one", b1 -> b1.return_(Const.of(1)));
+                        sc.caseOf("two", b1 -> b1.return_(Const.of(2)));
+                        sc.caseOf("three", b1 -> b1.return_(Const.of(3)));
+                    });
+                    b0.return_(Const.of(-1));
                 });
             });
         });


### PR DESCRIPTION
- improve message-less `IllegalStateException` in default switch cases
- improve exception message in `TryCreatorImpl`
- add `newArray()` and `blockExpr()` overloads that accept `Class`
- always use the classic javac translation strategy of lambdas
- fix label binding in default-less switch statements