### PR TITLE
fix `try`/`finally` in case the `try` body has nested blocks

### DIFF
--- a/src/main/java/io/quarkus/gizmo2/impl/Break.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/Break.java
@@ -18,7 +18,7 @@ final class Break extends Goto {
     }
 
     Label target(final BlockCreatorImpl from) {
-        TryFinally tryFinally = from.tryFinally;
+        TryFinally tryFinally = from.tryFinally();
         if (tryFinally != null) {
             return tryFinally.cleanup(new BreakKey(outer));
         } else {

--- a/src/main/java/io/quarkus/gizmo2/impl/GotoCase.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/GotoCase.java
@@ -17,7 +17,7 @@ class GotoCase extends Goto {
     }
 
     Label target(final BlockCreatorImpl from) {
-        TryFinally tryFinally = from.tryFinally;
+        TryFinally tryFinally = from.tryFinally();
         SwitchCreatorImpl<?> sci = (SwitchCreatorImpl<?>) switch_;
         if (tryFinally != null) {
             return tryFinally.cleanup(new GotoCaseKey(sci, case_));

--- a/src/main/java/io/quarkus/gizmo2/impl/GotoDefault.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/GotoDefault.java
@@ -14,7 +14,7 @@ class GotoDefault extends Goto {
     }
 
     Label target(final BlockCreatorImpl from) {
-        TryFinally tryFinally = from.tryFinally;
+        TryFinally tryFinally = from.tryFinally();
         SwitchCreatorImpl<?> sci = (SwitchCreatorImpl<?>) switch_;
         if (tryFinally != null) {
             return tryFinally.cleanup(new GotoDefaultKey(sci));

--- a/src/main/java/io/quarkus/gizmo2/impl/GotoStart.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/GotoStart.java
@@ -18,7 +18,7 @@ final class GotoStart extends Goto {
     }
 
     Label target(final BlockCreatorImpl from) {
-        TryFinally tryFinally = from.tryFinally;
+        TryFinally tryFinally = from.tryFinally();
         if (tryFinally != null) {
             return tryFinally.cleanup(new GotoStartKey(outer));
         } else {

--- a/src/main/java/io/quarkus/gizmo2/impl/Return.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/Return.java
@@ -27,7 +27,7 @@ final class Return extends Item {
     }
 
     public void writeCode(final CodeBuilder cb, final BlockCreatorImpl from) {
-        TryFinally tryFinally = from.tryFinally;
+        TryFinally tryFinally = from.tryFinally();
         ClassDesc returnType = from.returnType();
         if (tryFinally != null) {
             cb.goto_(tryFinally.cleanup(new ReturnKey(returnType)));


### PR DESCRIPTION
The nested blocks in the `try` body block did _not_ have the `tryFinally` field set, because that field is only set when the `finally` block is added. When the `try` body block is being generated, the field is `null` and hence copying that in the block constructor is _not_ enough to correctly propagate the enclosing `TryFinally`.

With this commit, we no longer attempt to propagate the enclosing `TryFinally` in the block constructor; we only let it be set on the outermost try body block. Instead, inside `writeCode()`, which is the only place we need it, we look it up in the block hierarchy.