### PR TITLE
add `InstanceExecutableCreator.this_()`

### DIFF
--- a/src/main/java/io/quarkus/gizmo2/creator/InstanceExecutableCreator.java
+++ b/src/main/java/io/quarkus/gizmo2/creator/InstanceExecutableCreator.java
@@ -1,8 +1,14 @@
 package io.quarkus.gizmo2.creator;
 
+import io.quarkus.gizmo2.This;
+
 /**
  * A creator for instance executables.
  */
 public sealed interface InstanceExecutableCreator extends ExecutableCreator, InstanceBodyCreator
         permits ConstructorCreator, InstanceMethodCreator {
+    /**
+     * {@return the {@code this} expression}
+     */
+    This this_();
 }

--- a/src/main/java/io/quarkus/gizmo2/impl/ExecutableCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/ExecutableCreatorImpl.java
@@ -32,6 +32,7 @@ import io.github.dmlloyd.classfile.attribute.RuntimeVisibleTypeAnnotationsAttrib
 import io.github.dmlloyd.classfile.attribute.SignatureAttribute;
 import io.quarkus.gizmo2.GenericType;
 import io.quarkus.gizmo2.ParamVar;
+import io.quarkus.gizmo2.This;
 import io.quarkus.gizmo2.TypeParameter;
 import io.quarkus.gizmo2.creator.BlockCreator;
 import io.quarkus.gizmo2.creator.ConstructorCreator;
@@ -405,5 +406,10 @@ public sealed abstract class ExecutableCreatorImpl extends ModifiableCreatorImpl
             typeParameters = Util.listWith(typeParameters, var);
         }
         return var;
+    }
+
+    // required by `InstanceExecutableCreator`
+    public This this_() {
+        return typeCreator.this_();
     }
 }

--- a/src/test/java/io/quarkus/gizmo2/InstanceExecutableCreatorTest.java
+++ b/src/test/java/io/quarkus/gizmo2/InstanceExecutableCreatorTest.java
@@ -25,7 +25,7 @@ public class InstanceExecutableCreatorTest {
             cc.constructor(con -> {
                 con.public_();
                 con.body(bc -> {
-                    bc.invokeSpecial(ConstructorDesc.of(Object.class), cc.this_());
+                    bc.invokeSpecial(ConstructorDesc.of(Object.class), con.this_());
                     bc.return_();
                 });
             });
@@ -45,7 +45,7 @@ public class InstanceExecutableCreatorTest {
                 mc.body(bc -> {
                     // return convert((String)t);
                     Expr strVal = bc.cast(p, String.class);
-                    bc.return_(bc.invokeVirtual(convert, cc.this_(), strVal));
+                    bc.return_(bc.invokeVirtual(convert, mc.this_(), strVal));
                 });
             });
         });


### PR DESCRIPTION
This is a shortcut for accessing `TypeCreator.this_()`, useful especially in situations when the original `TypeCreator` is not readily available.