### PR TITLE
avoid constant dynamic for primitive class constants

### DIFF
--- a/src/main/java/io/quarkus/gizmo2/impl/constant/ClassConst.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/constant/ClassConst.java
@@ -1,10 +1,23 @@
 package io.quarkus.gizmo2.impl.constant;
 
+import static io.smallrye.common.constraint.Assert.impossibleSwitchCase;
+import static java.lang.constant.ConstantDescs.CD_Boolean;
+import static java.lang.constant.ConstantDescs.CD_Byte;
+import static java.lang.constant.ConstantDescs.CD_Character;
+import static java.lang.constant.ConstantDescs.CD_Class;
+import static java.lang.constant.ConstantDescs.CD_Double;
+import static java.lang.constant.ConstantDescs.CD_Float;
+import static java.lang.constant.ConstantDescs.CD_Integer;
+import static java.lang.constant.ConstantDescs.CD_Long;
+import static java.lang.constant.ConstantDescs.CD_Short;
+import static java.lang.constant.ConstantDescs.CD_Void;
+
 import java.lang.constant.ClassDesc;
 import java.lang.constant.ConstantDesc;
-import java.lang.constant.ConstantDescs;
 import java.util.Optional;
 
+import io.github.dmlloyd.classfile.CodeBuilder;
+import io.quarkus.gizmo2.impl.BlockCreatorImpl;
 import io.quarkus.gizmo2.impl.Util;
 
 public final class ClassConst extends ConstImpl {
@@ -12,7 +25,7 @@ public final class ClassConst extends ConstImpl {
     private final ClassDesc value;
 
     public ClassConst(ClassDesc value) {
-        super(ConstantDescs.CD_Class);
+        super(CD_Class);
         this.value = value;
     }
 
@@ -46,5 +59,28 @@ public final class ClassConst extends ConstImpl {
 
     public StringBuilder toShortString(final StringBuilder b) {
         return Util.descName(b.append("Class["), value).append(']');
+    }
+
+    @Override
+    public void writeCode(CodeBuilder cb, BlockCreatorImpl block) {
+        if (value.isPrimitive()) {
+            // use the javac translation strategy: read the `TYPE` field from the wrapper class
+            // by default, condy would be used, which we don't want
+            ClassDesc wrapper = switch (value.descriptorString()) {
+                case "B" -> CD_Byte;
+                case "S" -> CD_Short;
+                case "C" -> CD_Character;
+                case "I" -> CD_Integer;
+                case "J" -> CD_Long;
+                case "F" -> CD_Float;
+                case "D" -> CD_Double;
+                case "Z" -> CD_Boolean;
+                case "V" -> CD_Void;
+                default -> throw impossibleSwitchCase(value);
+            };
+            cb.getstatic(wrapper, "TYPE", CD_Class);
+        } else {
+            super.writeCode(cb, block);
+        }
     }
 }

--- a/src/test/java/io/quarkus/gizmo2/ConstantsTest.java
+++ b/src/test/java/io/quarkus/gizmo2/ConstantsTest.java
@@ -64,4 +64,17 @@ public class ConstantsTest {
         });
         assertEquals(expectedResult, tcm.staticMethod("returnValueAndDescriptor", Supplier.class).get());
     }
+
+    @Test
+    public void primitiveClassConstants() {
+        test(() -> Const.of(byte.class), "byte|Ljava/lang/Class;");
+        test(() -> Const.of(short.class), "short|Ljava/lang/Class;");
+        test(() -> Const.of(char.class), "char|Ljava/lang/Class;");
+        test(() -> Const.of(int.class), "int|Ljava/lang/Class;");
+        test(() -> Const.of(long.class), "long|Ljava/lang/Class;");
+        test(() -> Const.of(float.class), "float|Ljava/lang/Class;");
+        test(() -> Const.of(double.class), "double|Ljava/lang/Class;");
+        test(() -> Const.of(boolean.class), "boolean|Ljava/lang/Class;");
+        test(() -> Const.of(void.class), "void|Ljava/lang/Class;");
+    }
 }


### PR DESCRIPTION
The `Class`-typed constants used to be emitted as LDC always. This leads to constant dynamic being used for primitive types, which we don't want. This commit moves to the classic javac translation strategy: for primitive class constants, we just load the `TYPE` field from the wrapper class.