### PR TITLE
Avoid instantiating an IllegalStateException in normal case

### DIFF
--- a/src/main/java/io/quarkus/gizmo2/impl/TryFinally.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/TryFinally.java
@@ -56,13 +56,13 @@ final class TryFinally extends Item {
         return body.mayFallThrough() && cleanupTemplate.mayFallThrough();
     }
 
-    IllegalStateException written = null;
+    boolean written = false;
 
     public void writeCode(final CodeBuilder cb, final BlockCreatorImpl block) {
-        if (written != null) {
-            throw written;
+        if (written) {
+            throw new IllegalStateException("Code has already been written");
         }
-        written = new IllegalStateException();
+        written = true;
         boolean bodyFallsThrough = body.mayFallThrough();
         final Label cleanupAndThrow = cb.newLabel();
         body.writeCode(cb, block);


### PR DESCRIPTION
Except if you're doing something wrong, it is useless and I could actually see it in some profiling.
Using a boolean and only instantiating the IllegalStateException if necessary.

<img width="2211" height="1262" alt="Screenshot From 2025-08-20 16-35-13" src="https://github.com/user-attachments/assets/394d6f26-777d-4766-8463-3952ac555959" />
