### PR TITLE
Assorted performance improvements

### DIFF
--- a/src/main/java/io/quarkus/gizmo2/GenericType.java
+++ b/src/main/java/io/quarkus/gizmo2/GenericType.java
@@ -713,10 +713,14 @@ public abstract class GenericType {
      */
     public static abstract class OfClass extends OfThrows {
         final List<TypeArgument> typeArguments;
+        private final boolean hasVisibleAnnotations;
+        private final boolean hasInvisibleAnnotations;
 
         OfClass(final List<Annotation> visible, final List<Annotation> invisible, final List<TypeArgument> typeArguments) {
             super(visible, invisible);
             this.typeArguments = typeArguments;
+            this.hasVisibleAnnotations = typeArguments.stream().anyMatch(TypeArgument::hasVisibleAnnotations);
+            this.hasInvisibleAnnotations = typeArguments.stream().anyMatch(TypeArgument::hasInvisibleAnnotations);
         }
 
         /**
@@ -744,11 +748,11 @@ public abstract class GenericType {
         }
 
         public boolean hasVisibleAnnotations() {
-            return super.hasVisibleAnnotations() || typeArguments.stream().anyMatch(TypeArgument::hasVisibleAnnotations);
+            return super.hasVisibleAnnotations() || hasVisibleAnnotations;
         }
 
         public boolean hasInvisibleAnnotations() {
-            return super.hasInvisibleAnnotations() || typeArguments.stream().anyMatch(TypeArgument::hasInvisibleAnnotations);
+            return super.hasInvisibleAnnotations() || hasInvisibleAnnotations;
         }
 
         /**

--- a/src/main/java/io/quarkus/gizmo2/desc/ConstructorDesc.java
+++ b/src/main/java/io/quarkus/gizmo2/desc/ConstructorDesc.java
@@ -5,6 +5,7 @@ import java.lang.constant.ConstantDescs;
 import java.lang.constant.MethodTypeDesc;
 import java.lang.invoke.MethodType;
 import java.lang.reflect.Constructor;
+import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Stream;
 
@@ -101,7 +102,7 @@ public sealed interface ConstructorDesc extends MemberDesc, MethodTyped permits 
      * @return the constructor descriptor (not {@code null})
      */
     static ConstructorDesc of(Class<?> owner, Class<?>... paramTypes) {
-        return of(owner, MethodType.methodType(void.class, paramTypes));
+        return of(owner, Arrays.asList(paramTypes));
     }
 
     /**
@@ -112,7 +113,12 @@ public sealed interface ConstructorDesc extends MemberDesc, MethodTyped permits 
      * @return the constructor descriptor (not {@code null})
      */
     static ConstructorDesc of(Class<?> owner, List<Class<?>> paramTypes) {
-        return of(owner, MethodType.methodType(void.class, paramTypes));
+        ClassDesc[] paramDescriptors = new ClassDesc[paramTypes.size()];
+        for (int i = 0; i < paramTypes.size(); i++) {
+            paramDescriptors[i] = Util.classDesc(paramTypes.get(i));
+        }
+
+        return of(Util.classDesc(owner), MethodTypeDesc.of(ConstantDescs.CD_void, paramDescriptors));
     }
 
     /**

--- a/src/main/java/io/quarkus/gizmo2/desc/MethodDesc.java
+++ b/src/main/java/io/quarkus/gizmo2/desc/MethodDesc.java
@@ -1,8 +1,10 @@
 package io.quarkus.gizmo2.desc;
 
+import java.lang.constant.ClassDesc;
 import java.lang.constant.MethodTypeDesc;
 import java.lang.invoke.MethodType;
 import java.lang.reflect.Method;
+import java.util.Arrays;
 import java.util.List;
 
 import io.quarkus.gizmo2.MethodTyped;
@@ -50,7 +52,7 @@ public sealed interface MethodDesc extends MemberDesc, MethodTyped
      * @return the method descriptor (must not be {@code null})
      */
     static MethodDesc of(Class<?> owner, String name, Class<?> returnType, Class<?>... paramTypes) {
-        return of(owner, name, MethodType.methodType(returnType, paramTypes));
+        return of(owner, name, returnType, Arrays.asList(paramTypes));
     }
 
     /**
@@ -63,7 +65,12 @@ public sealed interface MethodDesc extends MemberDesc, MethodTyped
      * @return the method descriptor (must not be {@code null})
      */
     static MethodDesc of(Class<?> owner, String name, Class<?> returnType, List<Class<?>> paramTypes) {
-        return of(owner, name, MethodType.methodType(returnType, paramTypes));
+        ClassDesc[] paramDescriptors = new ClassDesc[paramTypes.size()];
+        for (int i = 0; i < paramTypes.size(); i++) {
+            paramDescriptors[i] = Util.classDesc(paramTypes.get(i));
+        }
+
+        return of(owner, name, MethodTypeDesc.of(Util.classDesc(returnType), paramDescriptors));
     }
 
     /**

--- a/src/main/java/io/quarkus/gizmo2/impl/BlockCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/BlockCreatorImpl.java
@@ -111,6 +111,7 @@ public final class BlockCreatorImpl extends Item implements BlockCreator {
     private final Label endLabel;
     private final Item input;
     private final ClassDesc outputType;
+    private final TypeKind outputTypeKind;
     private final ClassDesc returnType;
     private Consumer<BlockCreator> loopAction;
 
@@ -161,6 +162,7 @@ public final class BlockCreatorImpl extends Item implements BlockCreator {
             head.insertNext(new BlockExpr(inputType));
         }
         this.outputType = outputType;
+        this.outputTypeKind = TypeKind.from(outputType);
         this.returnType = returnType;
     }
 
@@ -203,6 +205,11 @@ public final class BlockCreatorImpl extends Item implements BlockCreator {
 
     public ClassDesc type() {
         return outputType;
+    }
+
+    @Override
+    public TypeKind typeKind() {
+        return outputTypeKind;
     }
 
     public boolean active() {

--- a/src/main/java/io/quarkus/gizmo2/impl/Cast.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/Cast.java
@@ -5,16 +5,19 @@ import java.util.function.BiFunction;
 
 import io.quarkus.gizmo2.Expr;
 import io.quarkus.gizmo2.GenericType;
+import io.quarkus.gizmo2.TypeKind;
 
 abstract class Cast extends Item {
     final Item a;
     final GenericType toType;
+    final TypeKind toTypeKind;
 
     private boolean bound;
 
     public Cast(final Expr a, final GenericType toType) {
         this.a = (Item) a;
         this.toType = toType;
+        this.toTypeKind = TypeKind.from(toType.desc());
     }
 
     @Override
@@ -37,5 +40,10 @@ abstract class Cast extends Item {
 
     public ClassDesc type() {
         return toType.desc();
+    }
+
+    @Override
+    public TypeKind typeKind() {
+        return toTypeKind;
     }
 }

--- a/src/main/java/io/quarkus/gizmo2/impl/ConstructorDescImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/ConstructorDescImpl.java
@@ -18,7 +18,7 @@ public final class ConstructorDescImpl implements ConstructorDesc {
         }
         this.owner = owner;
         this.type = type;
-        hashCode = Objects.hash(owner, "<init>", type);
+        hashCode = buildHashCode();
     }
 
     public ClassDesc owner() {
@@ -56,5 +56,12 @@ public final class ConstructorDescImpl implements ConstructorDesc {
 
     public String toString() {
         return toString(new StringBuilder()).toString();
+    }
+
+    public int buildHashCode() {
+        int result = Objects.hashCode(owner);
+        result = 31 * result + "<init>".hashCode();
+        result = 31 * result + Objects.hashCode(type);
+        return result;
     }
 }

--- a/src/main/java/io/quarkus/gizmo2/impl/ExecutableCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/ExecutableCreatorImpl.java
@@ -30,6 +30,7 @@ import io.github.dmlloyd.classfile.attribute.RuntimeInvisibleTypeAnnotationsAttr
 import io.github.dmlloyd.classfile.attribute.RuntimeVisibleParameterAnnotationsAttribute;
 import io.github.dmlloyd.classfile.attribute.RuntimeVisibleTypeAnnotationsAttribute;
 import io.github.dmlloyd.classfile.attribute.SignatureAttribute;
+import io.github.dmlloyd.classfile.constantpool.ClassEntry;
 import io.quarkus.gizmo2.GenericType;
 import io.quarkus.gizmo2.ParamVar;
 import io.quarkus.gizmo2.This;
@@ -169,8 +170,11 @@ public sealed abstract class ExecutableCreatorImpl extends ModifiableCreatorImpl
         addInvisible(mb);
         List<GenericType.OfThrows> throws_ = this.throws_;
         if (!throws_.isEmpty()) {
-            mb.with(ExceptionsAttribute.of(
-                    throws_.stream().map(GenericType::desc).map(cd -> typeCreator.zb.constantPool().classEntry(cd)).toList()));
+            List<ClassEntry> exceptions = new ArrayList<>(throws_.size());
+            for (int i = 0; i < throws_.size(); i++) {
+                exceptions.add(typeCreator.zb.constantPool().classEntry(throws_.get(i).desc()));
+            }
+            mb.with(ExceptionsAttribute.of(exceptions));
             for (int i = 0; i < throws_.size(); i++) {
                 final GenericType.OfThrows genericType = throws_.get(i);
                 Util.computeAnnotations(genericType, RetentionPolicy.RUNTIME, TypeAnnotation.TargetInfo.ofThrows(i),
@@ -180,27 +184,41 @@ public sealed abstract class ExecutableCreatorImpl extends ModifiableCreatorImpl
             }
         }
         // lock parameters
-        List<MethodParameterInfo> mpi = params.stream()
-                .map(pv -> pv == null ? EMPTY_PI : MethodParameterInfo.ofParameter(Optional.of(pv.name()), pv.flags()))
-                .toList();
-        if (!mpi.isEmpty()) {
-            mb.with(MethodParametersAttribute.of(mpi));
-        }
-        // find parameter annotations, if any
-        if (params.stream().anyMatch(pvi -> !pvi.visible.isEmpty())) {
-            mb.with(RuntimeVisibleParameterAnnotationsAttribute.of(params.stream().map(
-                    pvi -> pvi != null ? pvi.visible : List.<Annotation> of()).toList()));
-        }
-        if (params.stream().anyMatch(pvi -> !pvi.invisible.isEmpty())) {
-            mb.with(RuntimeInvisibleParameterAnnotationsAttribute.of(params.stream().map(
-                    pvi -> pvi != null ? pvi.invisible : List.<Annotation> of()).toList()));
-        }
-        for (int i = 0; i < params.size(); i++) {
-            GenericType genericType = params.get(i).genericType();
-            Util.computeAnnotations(genericType, RetentionPolicy.RUNTIME, TypeAnnotation.TargetInfo.ofMethodFormalParameter(i),
-                    visible, new ArrayDeque<>());
-            Util.computeAnnotations(genericType, RetentionPolicy.CLASS, TypeAnnotation.TargetInfo.ofMethodFormalParameter(i),
-                    invisible, new ArrayDeque<>());
+        if (!params.isEmpty()) {
+            List<MethodParameterInfo> parameters = new ArrayList<>(params.size());
+            List<List<Annotation>> parametersVisibleAnnotations = new ArrayList<>(params.size());
+            List<List<Annotation>> parametersInvisibleAnnotations = new ArrayList<>(params.size());
+            boolean hasVisibleAnnotations = false;
+            boolean hasInvisibleAnnotations = false;
+            for (int i = 0; i < params.size(); i++) {
+                ParamVarImpl currentParam = params.get(i);
+                if (currentParam != null) {
+                    parameters.add(i, MethodParameterInfo.ofParameter(Optional.of(currentParam.name()), currentParam.flags()));
+                    parametersVisibleAnnotations.add(i, currentParam.visible);
+                    hasVisibleAnnotations = hasVisibleAnnotations || !currentParam.visible.isEmpty();
+                    parametersInvisibleAnnotations.add(i, currentParam.invisible);
+                    hasInvisibleAnnotations = hasInvisibleAnnotations || !currentParam.invisible.isEmpty();
+
+                    GenericType genericType = currentParam.genericType();
+                    Util.computeAnnotations(genericType, RetentionPolicy.RUNTIME,
+                            TypeAnnotation.TargetInfo.ofMethodFormalParameter(i),
+                            visible, new ArrayDeque<>());
+                    Util.computeAnnotations(genericType, RetentionPolicy.CLASS,
+                            TypeAnnotation.TargetInfo.ofMethodFormalParameter(i),
+                            invisible, new ArrayDeque<>());
+                } else {
+                    parameters.add(i, EMPTY_PI);
+                    parametersVisibleAnnotations.add(i, List.of());
+                    parametersInvisibleAnnotations.add(i, List.of());
+                }
+            }
+            mb.with(MethodParametersAttribute.of(parameters));
+            if (hasVisibleAnnotations) {
+                mb.with(RuntimeVisibleParameterAnnotationsAttribute.of(parametersVisibleAnnotations));
+            }
+            if (hasInvisibleAnnotations) {
+                mb.with(RuntimeInvisibleParameterAnnotationsAttribute.of(parametersInvisibleAnnotations));
+            }
         }
         Util.computeAnnotations(genericReturnType(), RetentionPolicy.RUNTIME, TypeAnnotation.TargetInfo.ofMethodReturn(),
                 visible, new ArrayDeque<>());

--- a/src/main/java/io/quarkus/gizmo2/impl/FieldDescImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/FieldDescImpl.java
@@ -3,18 +3,21 @@ package io.quarkus.gizmo2.impl;
 import java.lang.constant.ClassDesc;
 import java.util.Objects;
 
+import io.quarkus.gizmo2.TypeKind;
 import io.quarkus.gizmo2.desc.FieldDesc;
 
 public final class FieldDescImpl implements FieldDesc {
     private final ClassDesc owner;
     private final String name;
     private final ClassDesc type;
+    private final TypeKind typeKind;
     private final int hashCode;
 
     public FieldDescImpl(final ClassDesc owner, final String name, final ClassDesc type) {
         this.owner = owner;
         this.name = name;
         this.type = type;
+        this.typeKind = TypeKind.from(type);
         hashCode = Objects.hash(owner, name, type);
     }
 
@@ -28,6 +31,11 @@ public final class FieldDescImpl implements FieldDesc {
 
     public ClassDesc type() {
         return type;
+    }
+
+    @Override
+    public TypeKind typeKind() {
+        return typeKind;
     }
 
     public boolean equals(final Object obj) {

--- a/src/main/java/io/quarkus/gizmo2/impl/FieldSet.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/FieldSet.java
@@ -20,4 +20,9 @@ final class FieldSet extends Item {
     public void writeCode(final CodeBuilder cb, final BlockCreatorImpl block) {
         cb.putfield(fieldDeref.owner(), fieldDeref.name(), fieldDeref.desc().type());
     }
+
+    @Override
+    public boolean isVoid() {
+        return true;
+    }
 }

--- a/src/main/java/io/quarkus/gizmo2/impl/If.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/If.java
@@ -9,15 +9,18 @@ import java.util.List;
 
 import io.github.dmlloyd.classfile.CodeBuilder;
 import io.github.dmlloyd.classfile.Label;
+import io.quarkus.gizmo2.TypeKind;
 
 abstract class If extends Item {
     private final ClassDesc type;
+    private final TypeKind typeKind;
     final Kind kind;
     final BlockCreatorImpl whenTrue;
     final BlockCreatorImpl whenFalse;
 
     If(final ClassDesc type, final Kind kind, final BlockCreatorImpl whenTrue, final BlockCreatorImpl whenFalse) {
         this.type = type;
+        this.typeKind = TypeKind.from(type);
         this.kind = kind;
         this.whenTrue = whenTrue;
         this.whenFalse = whenFalse;
@@ -25,6 +28,11 @@ abstract class If extends Item {
 
     public ClassDesc type() {
         return type;
+    }
+
+    @Override
+    public TypeKind typeKind() {
+        return typeKind;
     }
 
     private static void comparable_acmp(CodeBuilder cb, Label label) {

--- a/src/main/java/io/quarkus/gizmo2/impl/Invoke.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/Invoke.java
@@ -12,6 +12,7 @@ import io.github.dmlloyd.classfile.CodeBuilder;
 import io.github.dmlloyd.classfile.Opcode;
 import io.quarkus.gizmo2.Expr;
 import io.quarkus.gizmo2.GenericType;
+import io.quarkus.gizmo2.TypeKind;
 import io.quarkus.gizmo2.desc.ConstructorDesc;
 import io.quarkus.gizmo2.desc.InterfaceMethodDesc;
 import io.quarkus.gizmo2.desc.MethodDesc;
@@ -20,6 +21,7 @@ final class Invoke extends Item {
     private final ClassDesc owner;
     private final String name;
     private final MethodTypeDesc type;
+    private final TypeKind typeKind;
     private final GenericType genericType;
     private final Item instance;
     private final List<Item> args;
@@ -63,6 +65,7 @@ final class Invoke extends Item {
         this.owner = owner;
         this.name = name;
         this.type = type;
+        this.typeKind = TypeKind.from(type.returnType());
         this.opcode = opcode;
         this.isInterface = isInterface;
         this.instance = instance;
@@ -76,6 +79,11 @@ final class Invoke extends Item {
 
     public ClassDesc type() {
         return type.returnType();
+    }
+
+    @Override
+    public TypeKind typeKind() {
+        return typeKind;
     }
 
     public GenericType genericType() {

--- a/src/main/java/io/quarkus/gizmo2/impl/LocalVarAllocator.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/LocalVarAllocator.java
@@ -40,4 +40,9 @@ final class LocalVarAllocator extends Item {
                     annotations, new ArrayDeque<>());
         }
     }
+
+    @Override
+    public boolean isVoid() {
+        return true;
+    }
 }

--- a/src/main/java/io/quarkus/gizmo2/impl/LocalVarImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/LocalVarImpl.java
@@ -13,12 +13,14 @@ import io.quarkus.gizmo2.creator.BlockCreator;
 public final class LocalVarImpl extends AssignableImpl implements LocalVar {
     private final String name;
     private final GenericType type;
+    private final TypeKind typeKind;
     private final BlockCreatorImpl owner;
     int slot = -1;
 
     LocalVarImpl(final BlockCreatorImpl owner, final String name, final GenericType type) {
         this.name = name;
         this.type = type;
+        this.typeKind = TypeKind.from(type.desc());
         this.owner = owner;
     }
 
@@ -36,6 +38,11 @@ public final class LocalVarImpl extends AssignableImpl implements LocalVar {
 
     public ClassDesc type() {
         return type.desc();
+    }
+
+    @Override
+    public TypeKind typeKind() {
+        return typeKind;
     }
 
     public GenericType genericType() {

--- a/src/main/java/io/quarkus/gizmo2/impl/LocalVarSet.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/LocalVarSet.java
@@ -21,4 +21,9 @@ final class LocalVarSet extends Item {
         localVar.checkSlot();
         cb.storeLocal(Util.actualKindOf(localVar.typeKind()), localVar.slot);
     }
+
+    @Override
+    public boolean isVoid() {
+        return true;
+    }
 }

--- a/src/main/java/io/quarkus/gizmo2/impl/MethodDescImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/MethodDescImpl.java
@@ -16,7 +16,7 @@ public sealed abstract class MethodDescImpl implements MethodDesc permits ClassM
         this.owner = owner;
         this.name = name;
         this.type = type;
-        hashCode = Objects.hash(owner, name, type);
+        this.hashCode = buildHashCode();
     }
 
     public ClassDesc owner() {
@@ -46,5 +46,12 @@ public sealed abstract class MethodDescImpl implements MethodDesc permits ClassM
 
     public String toString() {
         return toString(new StringBuilder()).toString();
+    }
+
+    public int buildHashCode() {
+        int result = Objects.hashCode(owner);
+        result = 31 * result + Objects.hashCode(name);
+        result = 31 * result + Objects.hashCode(type);
+        return result;
     }
 }

--- a/src/main/java/io/quarkus/gizmo2/impl/StringSwitchCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/StringSwitchCreatorImpl.java
@@ -14,6 +14,10 @@ import io.quarkus.gizmo2.impl.constant.StringConst;
  * A switch over {@code String} objects.
  */
 public final class StringSwitchCreatorImpl extends HashSwitchCreatorImpl<StringConst> {
+
+    private static final MethodTypeDesc STRING_EQUALS_METHOD_TYPE_DESC = MethodTypeDesc.of(CD_boolean, CD_Object);
+    private static final MethodTypeDesc STRING_HASH_CODE_METHOD_TYPE_DESC = MethodTypeDesc.of(CD_int);
+
     StringSwitchCreatorImpl(final BlockCreatorImpl enclosing, final Expr switchVal, final ClassDesc type) {
         super(enclosing, switchVal, type, StringConst.class);
     }
@@ -24,7 +28,7 @@ public final class StringSwitchCreatorImpl extends HashSwitchCreatorImpl<StringC
 
     void equaller(final CodeBuilder cb, final StringConst value, final Label ifEq) {
         value.writeCode(cb, enclosing);
-        cb.invokevirtual(CD_String, "equals", MethodTypeDesc.of(CD_boolean, CD_Object));
+        cb.invokevirtual(CD_String, "equals", STRING_EQUALS_METHOD_TYPE_DESC);
         // returns 1 if equal
         cb.ifne(ifEq);
     }
@@ -34,6 +38,6 @@ public final class StringSwitchCreatorImpl extends HashSwitchCreatorImpl<StringC
     }
 
     void hash(final CodeBuilder cb) {
-        cb.invokevirtual(CD_String, "hashCode", MethodTypeDesc.of(CD_int));
+        cb.invokevirtual(CD_String, "hashCode", STRING_HASH_CODE_METHOD_TYPE_DESC);
     }
 }

--- a/src/main/java/io/quarkus/gizmo2/impl/TryFinally.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/TryFinally.java
@@ -56,13 +56,13 @@ final class TryFinally extends Item {
         return body.mayFallThrough() && cleanupTemplate.mayFallThrough();
     }
 
-    IllegalStateException written = null;
+    boolean written = false;
 
     public void writeCode(final CodeBuilder cb, final BlockCreatorImpl block) {
-        if (written != null) {
-            throw written;
+        if (written) {
+            throw new IllegalStateException("Code has already been written");
         }
-        written = new IllegalStateException();
+        written = true;
         boolean bodyFallsThrough = body.mayFallThrough();
         final Label cleanupAndThrow = cb.newLabel();
         body.writeCode(cb, block);

--- a/src/main/java/io/quarkus/gizmo2/impl/TypeCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/TypeCreatorImpl.java
@@ -194,10 +194,24 @@ public abstract sealed class TypeCreatorImpl extends ModifiableCreatorImpl imple
     }
 
     ClassSignature computeSignature() {
+        List<Signature.TypeParam> signatureTypeParams;
+        if (!typeParameters.isEmpty()) {
+            signatureTypeParams = new ArrayList<>(typeParameters.size());
+            for (int i = 0; i < typeParameters.size(); i++) {
+                signatureTypeParams.add(Util.typeParamOf(typeParameters.get(i)));
+            }
+        } else {
+            signatureTypeParams = List.of();
+        }
+        Signature.ClassTypeSig[] signatureInterfaces = new Signature.ClassTypeSig[interfaceSigs.size()];
+        for (int i = 0; i < interfaceSigs.size(); i++) {
+            signatureInterfaces[i] = Util.signatureOf(interfaceSigs.get(i));
+        }
+
         return ClassSignature.of(
-                typeParameters.stream().map(Util::typeParamOf).toList(),
+                signatureTypeParams,
                 Util.signatureOf(superSig),
-                interfaceSigs.stream().map(Util::signatureOf).toArray(Signature.ClassTypeSig[]::new));
+                signatureInterfaces);
     }
 
     void implements_(final GenericType.OfClass genericType) {

--- a/src/main/java/io/quarkus/gizmo2/impl/Util.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/Util.java
@@ -424,7 +424,12 @@ public final class Util {
     // Generic type argument mapping
 
     public static Signature.TypeArg[] typeArgsOf(final List<TypeArgument> typeArguments) {
-        return typeArguments.stream().map(Util::typeArgOf).toArray(Signature.TypeArg[]::new);
+        Signature.TypeArg[] typeArgs = new Signature.TypeArg[typeArguments.size()];
+        for (int i = 0; i < typeArguments.size(); i++) {
+            typeArgs[i] = typeArgOf(typeArguments.get(i));
+        }
+
+        return typeArgs;
     }
 
     public static Signature.TypeArg typeArgOf(TypeArgument arg) {

--- a/src/main/java/io/quarkus/gizmo2/impl/constant/ConstImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/constant/ConstImpl.java
@@ -25,9 +25,11 @@ import io.quarkus.gizmo2.impl.Util;
 
 public abstract non-sealed class ConstImpl extends Item implements Const {
     private final ClassDesc type;
+    private final TypeKind typeKind;
 
     ConstImpl(final ClassDesc type) {
         this.type = type;
+        this.typeKind = TypeKind.from(type);
     }
 
     public static StringConst of(final String value) {
@@ -330,6 +332,11 @@ public abstract non-sealed class ConstImpl extends Item implements Const {
 
     public ClassDesc type() {
         return type;
+    }
+
+    @Override
+    public TypeKind typeKind() {
+        return typeKind;
     }
 
     public boolean bound() {


### PR DESCRIPTION
These results are based on the benchmark assembled by @Ladicek. I extract this to some sort of JMH benchmarks.

Baseline with Gizmo 2 (`0dff4ee`) :

```
Result "io.quarkus.arc.crazybeans.test.ArcBuildTimeMeasurementJmhBenchmark.benchmarkArCInitialization":
  0.218 ±(99.9%) 0.003 s/op [Average]
  (min, avg, max) = (0.216, 0.218, 0.223), stdev = 0.002
  CI (99.9%): [0.215, 0.221] (assumes normal distribution)
```

After all these patches:

```
Result "io.quarkus.arc.crazybeans.test.ArcBuildTimeMeasurementJmhBenchmark.benchmarkArCInitialization":
  0.200 ±(99.9%) 0.005 s/op [Average]
  (min, avg, max) = (0.196, 0.200, 0.207), stdev = 0.003
  CI (99.9%): [0.195, 0.205] (assumes normal distribution)
```

Note that we are still far from the results with Gizmo 1 but I need some of my Quarkus patches in to be able to compare things properly between Gizmo 1 and 2.

This should be reviewed commit per commit (and maybe discussed commit per commit).

In some cases, the result is to reduce allocations, in some cases CPU cycles but it all goes in the right direction.

The last one is the most controversial IMHO and I added the commit more to show the issue than to solve the problem this way: we are creating a gazillions of `TypeKind`, in large part because of the calls to `isVoid()`, that then calls `typeKind()` which in most cases instantiates a new `TypeKind`. I think we should cache the value once and for all. In this commit, I fixed the most prominent culprits for ArC but really, I think we should probably change the pattern and enforce the caching for all ``Item``s by having a proper constructor that takes the type as a parameter and caches the type kind value in `Item`.

Happy to discuss these changes in a call if it helps.