### PR TITLE
Avoid using Objects.hash(...) as it instantiates an array

### DIFF
--- a/src/main/java/io/quarkus/gizmo2/impl/MethodDescImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/MethodDescImpl.java
@@ -16,7 +16,7 @@ public sealed abstract class MethodDescImpl implements MethodDesc permits ClassM
         this.owner = owner;
         this.name = name;
         this.type = type;
-        hashCode = Objects.hash(owner, name, type);
+        this.hashCode = buildHashCode();
     }
 
     public ClassDesc owner() {
@@ -46,5 +46,12 @@ public sealed abstract class MethodDescImpl implements MethodDesc permits ClassM
 
     public String toString() {
         return toString(new StringBuilder()).toString();
+    }
+
+    public int buildHashCode() {
+        int result = Objects.hashCode(owner);
+        result = 31 * result + Objects.hashCode(name);
+        result = 31 * result + Objects.hashCode(type);
+        return result;
     }
 }


### PR DESCRIPTION
main

Result "io.quarkus.arc.crazybeans.test.ArcBuildTimeMeasurementJmhBenchmark.benchmarkArCInitialization":
  0.220 ±(99.9%) 0.003 s/op [Average]
  (min, avg, max) = (0.217, 0.220, 0.224), stdev = 0.002
  CI (99.9%): [0.217, 0.224] (assumes normal distribution)

this branch:

Result "io.quarkus.arc.crazybeans.test.ArcBuildTimeMeasurementJmhBenchmark.benchmarkArCInitialization":
  0.210 ±(99.9%) 0.003 s/op [Average]
  (min, avg, max) = (0.207, 0.210, 0.213), stdev = 0.002
  CI (99.9%): [0.208, 0.213] (assumes normal distribution)