### PR TITLE
Add a constant for GenericType of java.lang.Object

### DIFF
--- a/src/main/java/io/quarkus/gizmo2/GenericTypes.java
+++ b/src/main/java/io/quarkus/gizmo2/GenericTypes.java
@@ -45,4 +45,8 @@ public final class GenericTypes {
      * The generic type for {@code void}.
      */
     public static final GenericType GT_void = GenericType.of(CD_void);
+    /**
+     * The generic type for {@code java.lang.Object}.
+     */
+    public static final GenericType GT_Object = GenericType.of(CD_Object);
 }

--- a/src/main/java/io/quarkus/gizmo2/impl/Conversions.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/Conversions.java
@@ -13,6 +13,7 @@ import java.util.Set;
 
 import io.quarkus.gizmo2.Expr;
 import io.quarkus.gizmo2.GenericType;
+import io.quarkus.gizmo2.GenericTypes;
 import io.quarkus.gizmo2.TypeKind;
 
 final class Conversions {
@@ -178,7 +179,7 @@ final class Conversions {
             // primitive widening
             return new PrimitiveCast(item, GenericType.of(toType));
         } else if (!fromType.isPrimitive() && DS_Object.equals(toDesc)) {
-            return new UncheckedCast(item, GenericType.of(toType));
+            return new UncheckedCast(item, GenericTypes.GT_Object);
         } else if (DS_Object.equals(fromDesc)) {
             if (toType.isPrimitive()) {
                 return new Unbox(new CheckCast(item, GenericType.of(boxTypes.get(toDesc))));


### PR DESCRIPTION
This is more to start a discussion about if we should better cache these things.