### PR TITLE
Avoid instantiating a MethodType when we can easily avoid it

### DIFF
--- a/src/main/java/io/quarkus/gizmo2/desc/ConstructorDesc.java
+++ b/src/main/java/io/quarkus/gizmo2/desc/ConstructorDesc.java
@@ -5,6 +5,7 @@ import java.lang.constant.ConstantDescs;
 import java.lang.constant.MethodTypeDesc;
 import java.lang.invoke.MethodType;
 import java.lang.reflect.Constructor;
+import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Stream;
 
@@ -101,7 +102,7 @@ public sealed interface ConstructorDesc extends MemberDesc, MethodTyped permits 
      * @return the constructor descriptor (not {@code null})
      */
     static ConstructorDesc of(Class<?> owner, Class<?>... paramTypes) {
-        return of(owner, MethodType.methodType(void.class, paramTypes));
+        return of(owner, Arrays.asList(paramTypes));
     }
 
     /**
@@ -112,7 +113,12 @@ public sealed interface ConstructorDesc extends MemberDesc, MethodTyped permits 
      * @return the constructor descriptor (not {@code null})
      */
     static ConstructorDesc of(Class<?> owner, List<Class<?>> paramTypes) {
-        return of(owner, MethodType.methodType(void.class, paramTypes));
+        ClassDesc[] paramDescriptors = new ClassDesc[paramTypes.size()];
+        for (int i = 0; i < paramTypes.size(); i++) {
+            paramDescriptors[i] = Util.classDesc(paramTypes.get(i));
+        }
+
+        return of(Util.classDesc(owner), MethodTypeDesc.of(ConstantDescs.CD_void, paramDescriptors));
     }
 
     /**

--- a/src/main/java/io/quarkus/gizmo2/desc/MethodDesc.java
+++ b/src/main/java/io/quarkus/gizmo2/desc/MethodDesc.java
@@ -1,8 +1,10 @@
 package io.quarkus.gizmo2.desc;
 
+import java.lang.constant.ClassDesc;
 import java.lang.constant.MethodTypeDesc;
 import java.lang.invoke.MethodType;
 import java.lang.reflect.Method;
+import java.util.Arrays;
 import java.util.List;
 
 import io.quarkus.gizmo2.MethodTyped;
@@ -50,7 +52,7 @@ public sealed interface MethodDesc extends MemberDesc, MethodTyped
      * @return the method descriptor (must not be {@code null})
      */
     static MethodDesc of(Class<?> owner, String name, Class<?> returnType, Class<?>... paramTypes) {
-        return of(owner, name, MethodType.methodType(returnType, paramTypes));
+        return of(owner, name, returnType, Arrays.asList(paramTypes));
     }
 
     /**
@@ -63,7 +65,12 @@ public sealed interface MethodDesc extends MemberDesc, MethodTyped
      * @return the method descriptor (must not be {@code null})
      */
     static MethodDesc of(Class<?> owner, String name, Class<?> returnType, List<Class<?>> paramTypes) {
-        return of(owner, name, MethodType.methodType(returnType, paramTypes));
+        ClassDesc[] paramDescriptors = new ClassDesc[paramTypes.size()];
+        for (int i = 0; i < paramTypes.size(); i++) {
+            paramDescriptors[i] = Util.classDesc(paramTypes.get(i));
+        }
+
+        return of(owner, name, MethodTypeDesc.of(Util.classDesc(returnType), paramDescriptors));
     }
 
     /**


### PR DESCRIPTION
This way, we can also use our ClassDesc cache.

Originally coming from this PR: https://github.com/quarkusio/gizmo/pull/488/commits .

It doesn't bring much but it seems to be positive and it was already there so...

Before:

```
Result "io.quarkus.arc.crazybeans.test.ArcBuildTimeMeasurementJmhBenchmark.benchmarkArCInitialization":
  0.296 ±(99.9%) 0.003 s/op [Average]
  (min, avg, max) = (0.293, 0.296, 0.299), stdev = 0.002
  CI (99.9%): [0.293, 0.299] (assumes normal distribution)
```

After:

```
Result "io.quarkus.arc.crazybeans.test.ArcBuildTimeMeasurementJmhBenchmark.benchmarkArCInitialization":
  0.292 ±(99.9%) 0.002 s/op [Average]
  (min, avg, max) = (0.289, 0.292, 0.293), stdev = 0.001
  CI (99.9%): [0.290, 0.294] (assumes normal distribution)
```