### PR TITLE
fix `BlockCreator.assert_()`

### DIFF
--- a/src/main/java/io/quarkus/gizmo2/impl/BlockCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/BlockCreatorImpl.java
@@ -1326,8 +1326,8 @@ public final class BlockCreatorImpl extends Item implements BlockCreator {
 
     public void assert_(final Consumer<BlockCreator> assertion, final String message) {
         if_(logicalAnd(Const.ofInvoke(Const.ofMethodHandle(InvokeKind.VIRTUAL,
-                MethodDesc.of(Class.class, "desiredAssertionStatus", boolean.class))), assertion),
-                __ -> throw_(AssertionError.class, message));
+                MethodDesc.of(Class.class, "desiredAssertionStatus", boolean.class)), Const.of(owner.type())), assertion),
+                bc -> bc.throw_(bc.new_(ConstructorDesc.of(AssertionError.class, Object.class), Const.of(message))));
     }
 
     protected Node forEachDependency(final Node node, final BiFunction<Item, Node, Node> op) {

--- a/src/main/java/io/quarkus/gizmo2/impl/constant/ConstImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/constant/ConstImpl.java
@@ -297,7 +297,7 @@ public abstract non-sealed class ConstImpl extends Item implements Const {
     }
 
     public static MethodHandleConst of(MethodHandleDesc desc) {
-        return new MethodHandleConst(desc);
+        return new MethodHandleConst(desc, null);
     }
 
     public static MethodHandleConst ofMethodHandle(InvokeKind kind, MethodDesc desc) {

--- a/src/main/java/io/quarkus/gizmo2/impl/constant/InvokeConst.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/constant/InvokeConst.java
@@ -1,5 +1,7 @@
 package io.quarkus.gizmo2.impl.constant;
 
+import static java.lang.constant.ConstantDescs.DEFAULT_NAME;
+
 import java.lang.constant.ConstantDesc;
 import java.lang.constant.ConstantDescs;
 import java.lang.constant.DynamicConstantDesc;
@@ -31,8 +33,10 @@ public final class InvokeConst extends ConstImpl {
     }
 
     public ConstantDesc desc() {
-        return DynamicConstantDesc.of(
+        return DynamicConstantDesc.ofNamed(
                 ConstantDescs.BSM_INVOKE,
+                DEFAULT_NAME,
+                type(),
                 Stream.concat(
                         Stream.of(handleConstant.desc()),
                         args.stream().map(ConstImpl::describeConstable).map(Optional::orElseThrow))
@@ -44,14 +48,14 @@ public final class InvokeConst extends ConstImpl {
     }
 
     public StringBuilder toShortString(final StringBuilder b) {
-        b.append("Invoke[");
-        handleConstant.toShortString(b).append("](");
+        b.append("Invoke:");
+        handleConstant.toShortString(b).append("(");
         Iterator<ConstImpl> iterator = args.iterator();
         if (iterator.hasNext()) {
-            handleConstant.toShortString(b);
+            iterator.next().toShortString(b);
             while (iterator.hasNext()) {
                 b.append(',');
-                handleConstant.toShortString(b);
+                iterator.next().toShortString(b);
             }
         }
         return b.append(')');

--- a/src/main/java/io/quarkus/gizmo2/impl/constant/MethodHandleConst.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/constant/MethodHandleConst.java
@@ -9,10 +9,12 @@ import io.quarkus.gizmo2.InvokeKind;
 import io.quarkus.gizmo2.desc.ConstructorDesc;
 import io.quarkus.gizmo2.desc.FieldDesc;
 import io.quarkus.gizmo2.desc.InterfaceMethodDesc;
+import io.quarkus.gizmo2.desc.MemberDesc;
 import io.quarkus.gizmo2.desc.MethodDesc;
 
 public final class MethodHandleConst extends ConstImpl {
     private final MethodHandleDesc desc;
+    private final MemberDesc member; // only for `toShortString()`
 
     MethodHandleConst(final InvokeKind kind, final MethodDesc desc) {
         this(MethodHandleDesc.ofMethod(switch (kind) {
@@ -26,11 +28,11 @@ public final class MethodHandleConst extends ConstImpl {
             case SPECIAL -> desc instanceof InterfaceMethodDesc
                     ? DirectMethodHandleDesc.Kind.INTERFACE_SPECIAL
                     : DirectMethodHandleDesc.Kind.SPECIAL;
-        }, desc.owner(), desc.name(), desc.type()));
+        }, desc.owner(), desc.name(), desc.type()), desc);
     }
 
     MethodHandleConst(final ConstructorDesc desc) {
-        this(MethodHandleDesc.ofConstructor(desc.owner(), desc.type().parameterArray()));
+        this(MethodHandleDesc.ofConstructor(desc.owner(), desc.type().parameterArray()), desc);
     }
 
     MethodHandleConst(final FieldDesc desc, final boolean static_, final boolean getter) {
@@ -39,12 +41,13 @@ public final class MethodHandleConst extends ConstImpl {
                         : getter ? DirectMethodHandleDesc.Kind.GETTER : DirectMethodHandleDesc.Kind.SETTER,
                 desc.owner(),
                 desc.name(),
-                desc.type()));
+                desc.type()), desc);
     }
 
-    MethodHandleConst(MethodHandleDesc desc) {
+    MethodHandleConst(MethodHandleDesc desc, MemberDesc member) {
         super(ConstantDescs.CD_MethodHandle);
         this.desc = desc;
+        this.member = member;
     }
 
     public boolean isNonZero() {
@@ -65,5 +68,10 @@ public final class MethodHandleConst extends ConstImpl {
 
     public Optional<MethodHandleDesc> describeConstable() {
         return Optional.of(desc);
+    }
+
+    @Override
+    public StringBuilder toShortString(StringBuilder b) {
+        return member != null ? member.toString(b) : b.append("<unknown>");
     }
 }

--- a/src/test/java/io/quarkus/gizmo2/AssertTest.java
+++ b/src/test/java/io/quarkus/gizmo2/AssertTest.java
@@ -1,0 +1,31 @@
+package io.quarkus.gizmo2;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.lang.constant.ClassDesc;
+
+import org.junit.jupiter.api.Test;
+
+public class AssertTest {
+    @Test
+    public void assert_() {
+        TestClassMaker tcm = new TestClassMaker();
+        Gizmo g = Gizmo.create(tcm);
+        g.class_(ClassDesc.of("io.quarkus.gizmo2.Assert"), cc -> {
+            cc.staticMethod("hello", mc -> {
+                mc.body(b0 -> {
+                    b0.assert_(b1 -> {
+                        b1.yield(Const.of(true));
+                    }, "assertion");
+                    b0.return_();
+                });
+            });
+        });
+
+        AssertionError e = assertThrows(AssertionError.class, () -> {
+            tcm.staticMethod("hello", Runnable.class).run();
+        });
+        assertEquals("assertion", e.getMessage());
+    }
+}

--- a/src/test/java/io/quarkus/gizmo2/TestClassMaker.java
+++ b/src/test/java/io/quarkus/gizmo2/TestClassMaker.java
@@ -220,6 +220,7 @@ public class TestClassMaker implements ClassOutput {
 
         private TestClassLoader() {
             super("[TEST]", TestClassMaker.class.getClassLoader());
+            setDefaultAssertionStatus(true);
             cf = ClassFile.of(ClassFile.ClassHierarchyResolverOption.of(this::getClassInfo));
         }
 


### PR DESCRIPTION
This commit actually includes 2 fixes:

1. The implementation of `assert_()`, albeit only 3 lines short, included multiple issues: there was no receiver set for virtual invocation of `desiredAssertionStatus()`, the `throw_()` method was called on a wrong `BlockCreator`, and a wrong `AssertionError` constructor was called (the `private` one accepts `String`, the `public` one accepts `Object`). This commit fixes them all.
2. The `InvokeConst` class didn't pass the return type of the given `MethodHandleConst` to the `DynamicConstantDesc` factory method, resulting in the actual return type being `Object`. However, the static type of `InvokeConst` is the return type of the method, which is a mismatch.

Further, `MethodHandleConst` now stores the referenced member for a better `toShortString()` implementation. Also, the `InvokeConst.toShortString()` implementation was fixed to no longer end up in an infinite regress.

Finally, a test for `assert_()` is added.