### PR TITLE
Minor fixes for signatures

### DIFF
--- a/src/main/java/io/quarkus/gizmo2/GenericType.java
+++ b/src/main/java/io/quarkus/gizmo2/GenericType.java
@@ -343,6 +343,13 @@ public abstract class GenericType {
     public abstract boolean isRaw();
 
     /**
+     * {@return {@code true} if a signature attribute would be needed for this generic type, or {@code false} otherwise}
+     */
+    public boolean signatureNeeded() {
+        return !isRaw();
+    }
+
+    /**
      * {@return {@code true} if this type has type annotations with given retention policy,
      * or {@code false} if it does not}
      *
@@ -979,6 +986,10 @@ public abstract class GenericType {
         public <A extends java.lang.annotation.Annotation> OfInnerClass withAnnotation(final Class<A> annotationType,
                 final Consumer<AnnotationCreator<A>> builder) {
             return (OfInnerClass) super.withAnnotation(annotationType, builder);
+        }
+
+        public boolean isRaw() {
+            return super.isRaw() && outerType.isRaw();
         }
 
         public boolean hasVisibleAnnotations() {

--- a/src/main/java/io/quarkus/gizmo2/impl/ExecutableCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/ExecutableCreatorImpl.java
@@ -2,7 +2,6 @@ package io.quarkus.gizmo2.impl;
 
 import static io.github.dmlloyd.classfile.ClassFile.*;
 import static io.smallrye.common.constraint.Assert.*;
-import static java.lang.constant.ConstantDescs.*;
 
 import java.lang.annotation.RetentionPolicy;
 import java.lang.constant.ClassDesc;
@@ -260,9 +259,9 @@ public sealed abstract class ExecutableCreatorImpl extends ModifiableCreatorImpl
     }
 
     boolean signatureNeeded() {
-        return !typeParameters.isEmpty() || throws_.stream().anyMatch(t -> !t.isRaw() || t.hasAnnotations())
-                || !genericReturnType().isRaw() || genericReturnType().hasAnnotations()
-                || params.stream().anyMatch(p -> !p.genericType().isRaw() || p.genericType().hasAnnotations());
+        return !typeParameters.isEmpty() || throws_.stream().anyMatch(GenericType::signatureNeeded)
+                || genericReturnType().signatureNeeded()
+                || params.stream().map(ParamVarImpl::genericType).anyMatch(GenericType::signatureNeeded);
     }
 
     MethodSignature computeSignature() {

--- a/src/main/java/io/quarkus/gizmo2/impl/TypeCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/TypeCreatorImpl.java
@@ -194,8 +194,8 @@ public abstract sealed class TypeCreatorImpl extends ModifiableCreatorImpl imple
     }
 
     boolean signatureNeeded() {
-        return !typeParameters.isEmpty() || !superSig.isRaw() || superSig.hasAnnotations()
-                || interfaceSigs.stream().anyMatch(i -> !i.isRaw() || i.hasAnnotations());
+        return !typeParameters.isEmpty() || superSig.signatureNeeded()
+                || interfaceSigs.stream().anyMatch(GenericType::signatureNeeded);
     }
 
     ClassSignature computeSignature() {


### PR DESCRIPTION
- Do not compute signatures if there are type annotations but nothing else
- Centralize signature determination in `GenericType`
- We were not generating a signature when a generic type was a type variable; we always need a signature in that case