### PR TITLE
improvements

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-api</artifactId>
+            <artifactId>junit-jupiter</artifactId>
             <version>${version.junit}</version>
             <scope>test</scope>
         </dependency>

--- a/src/main/java/io/quarkus/gizmo2/Gizmo.java
+++ b/src/main/java/io/quarkus/gizmo2/Gizmo.java
@@ -30,6 +30,8 @@ public sealed interface Gizmo permits GizmoImpl {
 
     /**
      * {@return a Gizmo instance which has debug info output enabled or disabled}
+     * <p>
+     * By default, debug info is included.
      *
      * @param debugInfo {@code true} to include debug info, or {@code false} to exclude debug info
      */
@@ -40,10 +42,27 @@ public sealed interface Gizmo permits GizmoImpl {
      * This setting affects whether method parameter names are recorded in a {@code MethodParameters}
      * attribute, which is separate from debug info and appears when using runtime reflection.
      * Some frameworks require this attribute to be present.
+     * <p>
+     * By default, parameter name info is included.
      *
      * @param parameters {@code true} to include parameter name info, or {@code false} to exclude parameter name info
      */
     Gizmo withParameters(boolean parameters);
+
+    /**
+     * {@return a Gizmo instance which emits lambdas as anonymous classes if the parameter is {@code true}}
+     * When enabled, lambda bodies are not generated into synthetic methods on the generated class,
+     * but into additional anonymous classes. Further, lambda instances are not obtained through invokedynamic,
+     * but through regular instantiation of the additional anonymous classes.
+     * <p>
+     * This doesn't affect runtime semantics of generated code, but it does affect the number
+     * of generated classes and, as of this writing, also runtime memory consumption.
+     * <p>
+     * By default, lambdas are <em>not</em> generated as anonymous classes.
+     *
+     * @param lambdasAsAnonymousClasses whether lambdas should be generated as anonymous classes
+     */
+    Gizmo withLambdasAsAnonymousClasses(boolean lambdasAsAnonymousClasses);
 
     /**
      * {@return a Gizmo instance which uses the default modifiers configured by the given configurator}
@@ -53,7 +72,7 @@ public sealed interface Gizmo permits GizmoImpl {
     Gizmo withDefaultModifiers(Consumer<ModifierConfigurator> builder);
 
     /**
-     * {@return a Gizmo instance which uses the given {@link ClassHierarchyLocator }}
+     * {@return a Gizmo instance which uses the given {@link ClassHierarchyLocator}}
      *
      * @param classHierarchyLocator the class hierarchy locator (must not be {@code null})
      */

--- a/src/main/java/io/quarkus/gizmo2/impl/BlockCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/BlockCreatorImpl.java
@@ -711,6 +711,7 @@ public final class BlockCreatorImpl extends Item implements BlockCreator {
         List<MethodModel> methods = cm.methods();
         MethodModel ourCtor = methods.get(methods.size() - 1);
         owner.output().write(desc, bytes);
+        owner.addNestMember(desc);
         return new_(ConstructorDesc.of(desc, ourCtor.methodTypeSymbol()),
                 Stream.concat(args.stream(), captureExprs.stream()).toList());
     }

--- a/src/main/java/io/quarkus/gizmo2/impl/BlockCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/BlockCreatorImpl.java
@@ -595,6 +595,15 @@ public final class BlockCreatorImpl extends Item implements BlockCreator {
     }
 
     public Expr lambda(final MethodDesc sam, final ClassDesc samOwner, final Consumer<LambdaCreator> builder) {
+        if (owner.gizmo.lambdasAsAnonymousClasses()) {
+            return newAnonymousClass(samOwner, acc -> {
+                acc.method(sam, imc -> {
+                    builder.accept(new LambdaAsAnonClassCreatorImpl(
+                            (AnonymousClassCreatorImpl) acc, (InstanceMethodCreatorImpl) imc));
+                });
+            });
+        }
+
         // certain versions of GraalVM native image cannot handle our custom translation strategy of lambdas
         // see: https://github.com/quarkusio/quarkus/issues/49346
         // we'll need to handle it better, but for now, let's just use the "classic" translation strategy always

--- a/src/main/java/io/quarkus/gizmo2/impl/BlockCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/BlockCreatorImpl.java
@@ -78,7 +78,7 @@ public final class BlockCreatorImpl extends Item implements BlockCreator {
     private static final int ST_NESTED = 1;
     private static final int ST_DONE = 2;
 
-    private final TypeCreatorImpl owner;
+    final TypeCreatorImpl owner;
     /**
      * The outermost code builder.
      * This should only be used for creating new labels and other context-independent things.

--- a/src/main/java/io/quarkus/gizmo2/impl/ExecutableCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/ExecutableCreatorImpl.java
@@ -279,50 +279,58 @@ public sealed abstract class ExecutableCreatorImpl extends ModifiableCreatorImpl
                 this instanceof ConstructorCreator ? "new" : name());
         ArrayDeque<TypeAnnotation.TypePathComponent> pathStack = new ArrayDeque<>();
         if ((modifiers & ACC_STATIC) == 0) {
-            // reserve `this` for all instance methods
-            cb.localVariable(0, "this", typeCreator.type(), bc.startLabel(), bc.endLabel());
             GenericType.OfClass genericType = typeCreator.genericType();
-            if (!genericType.isRaw()) {
-                cb.localVariableType(0, "this", Util.signatureOf(genericType), bc.startLabel(), bc.endLabel());
+            if (typeCreator.gizmo.debugInfo()) {
+                // reserve `this` for all instance methods
+                cb.localVariable(0, "this", typeCreator.type(), bc.startLabel(), bc.endLabel());
+                if (!genericType.isRaw()) {
+                    cb.localVariableType(0, "this", Util.signatureOf(genericType), bc.startLabel(), bc.endLabel());
+                }
             }
             if (genericType.hasVisibleAnnotations()) {
-                Util.computeAnnotations(genericType, RetentionPolicy.RUNTIME, TypeAnnotation.TargetInfo.ofLocalVariable(
-                        List.of(TypeAnnotation.LocalVarTargetInfo.of(bc.startLabel(), bc.endLabel(), 0))),
-                        visible, pathStack);
-                assert pathStack.isEmpty();
+                if (typeCreator.gizmo.debugInfo()) {
+                    Util.computeAnnotations(genericType, RetentionPolicy.RUNTIME, TypeAnnotation.TargetInfo.ofLocalVariable(
+                            List.of(TypeAnnotation.LocalVarTargetInfo.of(bc.startLabel(), bc.endLabel(), 0))),
+                            visible, pathStack);
+                    assert pathStack.isEmpty();
+                }
                 Util.computeAnnotations(genericType, RetentionPolicy.RUNTIME, TypeAnnotation.TargetInfo.ofMethodReceiver(),
                         visible, pathStack);
                 assert pathStack.isEmpty();
             }
             if (genericType.hasInvisibleAnnotations()) {
-                Util.computeAnnotations(genericType, RetentionPolicy.CLASS, TypeAnnotation.TargetInfo.ofLocalVariable(
-                        List.of(TypeAnnotation.LocalVarTargetInfo.of(bc.startLabel(), bc.endLabel(), 0))),
-                        invisible, pathStack);
-                assert pathStack.isEmpty();
+                if (typeCreator.gizmo.debugInfo()) {
+                    Util.computeAnnotations(genericType, RetentionPolicy.CLASS, TypeAnnotation.TargetInfo.ofLocalVariable(
+                            List.of(TypeAnnotation.LocalVarTargetInfo.of(bc.startLabel(), bc.endLabel(), 0))),
+                            invisible, pathStack);
+                    assert pathStack.isEmpty();
+                }
                 Util.computeAnnotations(genericType, RetentionPolicy.CLASS, TypeAnnotation.TargetInfo.ofMethodReceiver(),
                         invisible, pathStack);
                 assert pathStack.isEmpty();
             }
         }
-        for (final ParamVarImpl param : params) {
-            if (param != null) {
-                cb.localVariable(param.slot(), param.name(), param.type(), bc.startLabel(), bc.endLabel());
-                GenericType genericType = param.genericType();
-                if (!genericType.isRaw()) {
-                    cb.localVariableType(param.slot(), param.name(), Util.signatureOf(genericType), bc.startLabel(),
-                            bc.endLabel());
-                }
-                if (genericType.hasVisibleAnnotations()) {
-                    Util.computeAnnotations(genericType, RetentionPolicy.RUNTIME, TypeAnnotation.TargetInfo.ofLocalVariable(
-                            List.of(TypeAnnotation.LocalVarTargetInfo.of(bc.startLabel(), bc.endLabel(), param.slot()))),
-                            visible, pathStack);
-                    assert pathStack.isEmpty();
-                }
-                if (genericType.hasInvisibleAnnotations()) {
-                    Util.computeAnnotations(genericType, RetentionPolicy.CLASS, TypeAnnotation.TargetInfo.ofLocalVariable(
-                            List.of(TypeAnnotation.LocalVarTargetInfo.of(bc.startLabel(), bc.endLabel(), param.slot()))),
-                            invisible, pathStack);
-                    assert pathStack.isEmpty();
+        if (typeCreator.gizmo.debugInfo()) {
+            for (final ParamVarImpl param : params) {
+                if (param != null) {
+                    cb.localVariable(param.slot(), param.name(), param.type(), bc.startLabel(), bc.endLabel());
+                    GenericType genericType = param.genericType();
+                    if (!genericType.isRaw()) {
+                        cb.localVariableType(param.slot(), param.name(), Util.signatureOf(genericType), bc.startLabel(),
+                                bc.endLabel());
+                    }
+                    if (genericType.hasVisibleAnnotations()) {
+                        Util.computeAnnotations(genericType, RetentionPolicy.RUNTIME, TypeAnnotation.TargetInfo.ofLocalVariable(
+                                List.of(TypeAnnotation.LocalVarTargetInfo.of(bc.startLabel(), bc.endLabel(), param.slot()))),
+                                visible, pathStack);
+                        assert pathStack.isEmpty();
+                    }
+                    if (genericType.hasInvisibleAnnotations()) {
+                        Util.computeAnnotations(genericType, RetentionPolicy.CLASS, TypeAnnotation.TargetInfo.ofLocalVariable(
+                                List.of(TypeAnnotation.LocalVarTargetInfo.of(bc.startLabel(), bc.endLabel(), param.slot()))),
+                                invisible, pathStack);
+                        assert pathStack.isEmpty();
+                    }
                 }
             }
         }

--- a/src/main/java/io/quarkus/gizmo2/impl/GizmoImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/GizmoImpl.java
@@ -104,6 +104,10 @@ public final class GizmoImpl implements Gizmo {
                 lambdasAsAnonymousClasses);
     }
 
+    boolean debugInfo() {
+        return debugInfo;
+    }
+
     boolean parameters() {
         return parameters;
     }

--- a/src/main/java/io/quarkus/gizmo2/impl/GizmoImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/GizmoImpl.java
@@ -25,19 +25,22 @@ public final class GizmoImpl implements Gizmo {
     private final ClassHierarchyLocator classHierarchyLocator;
     private final boolean debugInfo;
     private final boolean parameters;
+    private final boolean lambdasAsAnonymousClasses;
     private final ClassFile.Option[] options;
 
     public GizmoImpl(final ClassOutput outputHandler) {
-        this(outputHandler, DEFAULTS, null, true, true);
+        this(outputHandler, DEFAULTS, null, true, true, false);
     }
 
     private GizmoImpl(final ClassOutput outputHandler, final int[] modifiersByLocation,
-            final ClassHierarchyLocator classHierarchyLocator, final boolean debugInfo, final boolean parameters) {
+            final ClassHierarchyLocator classHierarchyLocator, final boolean debugInfo, final boolean parameters,
+            final boolean lambdasAsAnonymousClasses) {
         this.outputHandler = outputHandler;
         this.modifiersByLocation = modifiersByLocation;
         this.classHierarchyLocator = classHierarchyLocator;
         this.debugInfo = debugInfo;
         this.parameters = parameters;
+        this.lambdasAsAnonymousClasses = lambdasAsAnonymousClasses;
         ArrayList<ClassFile.Option> options = new ArrayList<>();
         options.add(ClassFile.StackMapsOption.GENERATE_STACK_MAPS);
         if (classHierarchyLocator != null) {
@@ -97,31 +100,46 @@ public final class GizmoImpl implements Gizmo {
             }
         };
         builder.accept(configurator);
-        return new GizmoImpl(outputHandler, flags.clone(), classHierarchyLocator, debugInfo, parameters);
+        return new GizmoImpl(outputHandler, flags.clone(), classHierarchyLocator, debugInfo, parameters,
+                lambdasAsAnonymousClasses);
     }
 
     boolean parameters() {
         return parameters;
     }
 
+    boolean lambdasAsAnonymousClasses() {
+        return lambdasAsAnonymousClasses;
+    }
+
     @Override
     public Gizmo withOutput(final ClassOutput outputHandler) {
-        return new GizmoImpl(outputHandler, modifiersByLocation, classHierarchyLocator, debugInfo, parameters);
+        return new GizmoImpl(outputHandler, modifiersByLocation, classHierarchyLocator, debugInfo, parameters,
+                lambdasAsAnonymousClasses);
     }
 
     @Override
     public Gizmo withClassHierarchyLocator(final ClassHierarchyLocator classHierarchyLocator) {
-        return new GizmoImpl(outputHandler, modifiersByLocation, classHierarchyLocator, debugInfo, parameters);
+        return new GizmoImpl(outputHandler, modifiersByLocation, classHierarchyLocator, debugInfo, parameters,
+                lambdasAsAnonymousClasses);
     }
 
     @Override
     public Gizmo withDebugInfo(final boolean debugInfo) {
-        return new GizmoImpl(outputHandler, modifiersByLocation, classHierarchyLocator, debugInfo, parameters);
+        return new GizmoImpl(outputHandler, modifiersByLocation, classHierarchyLocator, debugInfo, parameters,
+                lambdasAsAnonymousClasses);
     }
 
     @Override
     public Gizmo withParameters(final boolean parameters) {
-        return new GizmoImpl(outputHandler, modifiersByLocation, classHierarchyLocator, debugInfo, parameters);
+        return new GizmoImpl(outputHandler, modifiersByLocation, classHierarchyLocator, debugInfo, parameters,
+                lambdasAsAnonymousClasses);
+    }
+
+    @Override
+    public Gizmo withLambdasAsAnonymousClasses(boolean lambdasAsAnonymousClasses) {
+        return new GizmoImpl(outputHandler, modifiersByLocation, classHierarchyLocator, debugInfo, parameters,
+                lambdasAsAnonymousClasses);
     }
 
     public ClassDesc class_(final ClassDesc desc, final Consumer<ClassCreator> builder) {

--- a/src/main/java/io/quarkus/gizmo2/impl/LocalVarAllocator.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/LocalVarAllocator.java
@@ -22,18 +22,20 @@ final class LocalVarAllocator extends Item {
     public void writeCode(final CodeBuilder cb, final BlockCreatorImpl block) {
         int slot = cb.allocateLocal(Util.actualKindOf(localVar.typeKind()));
         // we reserve the slot for the full remainder of the block to avoid control-flow analysis
-        startScope = cb.newBoundLabel();
-        endScope = block.endLabel();
-        cb.localVariable(slot, localVar.name(), localVar.type(), startScope, endScope);
-        GenericType gt = localVar.genericType();
-        if (!gt.isRaw()) {
-            cb.localVariableType(slot, localVar.name(), Util.signatureOf(gt), startScope, endScope);
+        if (block.owner.gizmo.debugInfo()) {
+            startScope = cb.newBoundLabel();
+            endScope = block.endLabel();
+            cb.localVariable(slot, localVar.name(), localVar.type(), startScope, endScope);
+            GenericType gt = localVar.genericType();
+            if (!gt.isRaw()) {
+                cb.localVariableType(slot, localVar.name(), Util.signatureOf(gt), startScope, endScope);
+            }
         }
         localVar.slot = slot;
     }
 
     public void writeAnnotations(final RetentionPolicy retention, final ArrayList<TypeAnnotation> annotations) {
-        if (localVar.genericType().hasAnnotations(retention)) {
+        if (startScope != null && endScope != null && localVar.genericType().hasAnnotations(retention)) {
             Util.computeAnnotations(localVar.genericType(), retention, TypeAnnotation.TargetInfo.ofLocalVariable(
                     List.of(
                             TypeAnnotation.LocalVarTargetInfo.of(startScope, endScope, localVar.slot))),

--- a/src/main/java/io/quarkus/gizmo2/impl/TypeCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/TypeCreatorImpl.java
@@ -35,6 +35,7 @@ import io.github.dmlloyd.classfile.ClassBuilder;
 import io.github.dmlloyd.classfile.ClassSignature;
 import io.github.dmlloyd.classfile.Signature;
 import io.github.dmlloyd.classfile.TypeAnnotation;
+import io.github.dmlloyd.classfile.attribute.NestMembersAttribute;
 import io.github.dmlloyd.classfile.attribute.RuntimeVisibleTypeAnnotationsAttribute;
 import io.github.dmlloyd.classfile.attribute.SignatureAttribute;
 import io.github.dmlloyd.classfile.attribute.SourceFileAttribute;
@@ -108,6 +109,7 @@ public abstract sealed class TypeCreatorImpl extends ModifiableCreatorImpl imple
     private List<Consumer<BlockCreator>> staticInits = List.of();
     List<Consumer<BlockCreator>> preInits = List.of();
     List<Consumer<BlockCreator>> postInits = List.of();
+    private List<ClassDesc> nestMembers = new ArrayList<>();
     private int bootstraps;
 
     /**
@@ -152,6 +154,10 @@ public abstract sealed class TypeCreatorImpl extends ModifiableCreatorImpl imple
 
     ClassFileFormatVersion version() {
         return version;
+    }
+
+    void addNestMember(ClassDesc nestMember) {
+        nestMembers.add(nestMember);
     }
 
     public void sourceFile(final String name) {
@@ -298,6 +304,9 @@ public abstract sealed class TypeCreatorImpl extends ModifiableCreatorImpl imple
         }
         addVisible(zb);
         addInvisible(zb);
+        if (!nestMembers.isEmpty()) {
+            zb.with(NestMembersAttribute.ofSymbols(nestMembers));
+        }
         ArrayList<TypeAnnotation> visible = new ArrayList<>();
         ArrayList<TypeAnnotation> invisible = new ArrayList<>();
         ArrayDeque<TypeAnnotation.TypePathComponent> pathStack = new ArrayDeque<>();

--- a/src/test/java/io/quarkus/gizmo2/LambdaTest.java
+++ b/src/test/java/io/quarkus/gizmo2/LambdaTest.java
@@ -10,16 +10,27 @@ import java.util.function.IntSupplier;
 import java.util.function.Supplier;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.Parameter;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import io.quarkus.gizmo2.desc.InterfaceMethodDesc;
 import io.quarkus.gizmo2.desc.MethodDesc;
 
+@ParameterizedClass
+@ValueSource(booleans = { false, true })
 public class LambdaTest {
+    @Parameter
+    boolean lambdasAsAnonymousClasses;
+
+    private Gizmo gizmo(TestClassMaker tcm) {
+        return Gizmo.create(tcm).withLambdasAsAnonymousClasses(lambdasAsAnonymousClasses);
+    }
 
     @Test
     public void testSupplierLambda() {
         TestClassMaker tcm = new TestClassMaker();
-        Gizmo g = Gizmo.create(tcm);
+        Gizmo g = gizmo(tcm);
         g.class_("io.quarkus.gizmo2.SupplierLambda", cc -> {
             cc.staticMethod("runTest", smc -> {
                 // static Object runTest() {
@@ -43,7 +54,7 @@ public class LambdaTest {
     @Test
     public void testRunnableLambda() {
         TestClassMaker tcm = new TestClassMaker();
-        Gizmo g = Gizmo.create(tcm);
+        Gizmo g = gizmo(tcm);
         g.class_("io.quarkus.gizmo2.RunnableLambda", cc -> {
             cc.staticMethod("runTest", smc -> {
                 // static int runTest() {
@@ -74,7 +85,7 @@ public class LambdaTest {
     @Test
     public void testConsumerLambda() {
         TestClassMaker tcm = new TestClassMaker();
-        Gizmo g = Gizmo.create(tcm);
+        Gizmo g = gizmo(tcm);
         g.class_("io.quarkus.gizmo2.ConsumerLambda", cc -> {
             cc.staticMethod("runTest", smc -> {
                 // static int runTest() {
@@ -109,7 +120,7 @@ public class LambdaTest {
     @Test
     public void testBasicLambdas() {
         TestClassMaker tcm = new TestClassMaker();
-        Gizmo g = Gizmo.create(tcm);
+        Gizmo g = gizmo(tcm);
         g.class_("io.quarkus.gizmo2.Lambdas", cc -> {
             cc.staticMethod("test", mc -> {
                 // static int test() {
@@ -155,7 +166,7 @@ public class LambdaTest {
     @Test
     public void testLambdaCapturingThis() {
         TestClassMaker tcm = new TestClassMaker();
-        Gizmo g = Gizmo.create(tcm);
+        Gizmo g = gizmo(tcm);
         g.class_("io.quarkus.gizmo2.LambdaCapturingThis", cc -> {
             cc.defaultConstructor();
 
@@ -210,7 +221,7 @@ public class LambdaTest {
     @Test
     public void testLambdaWithManyParametersAndCaptures() {
         TestClassMaker tcm = new TestClassMaker();
-        Gizmo g = Gizmo.create(tcm);
+        Gizmo g = gizmo(tcm);
         ClassDesc lambdaType = g.interface_("io.quarkus.gizmo2.LambdaType", cc -> {
             cc.addAnnotation(FunctionalInterface.class);
             cc.method("get", mc -> {
@@ -293,7 +304,7 @@ public class LambdaTest {
     @Test
     public void testConsumerLambdaAssigningToItsParameter() {
         TestClassMaker tcm = new TestClassMaker();
-        Gizmo g = Gizmo.create(tcm);
+        Gizmo g = gizmo(tcm);
         g.class_("io.quarkus.gizmo2.ConsumerLambdaAssigningToItsParameter", cc -> {
             cc.staticMethod("runTest", smc -> {
                 // static int runTest() {


### PR DESCRIPTION
- add ability to emit lambdas as anonymous classes
- avoid declaring local variables when debug info is disabled
  - This one is particularly interesting. The previous solution (which I suggested) indeed avoids emitting the LVT, but it doesn't avoid emitting the (otherwise useless) entries in the constant pool. So I had to add what @dmlloyd already previously had.
- fix emitting nests