### PR TITLE
Compute generic types only when needed

### DIFF
--- a/src/main/java/io/quarkus/gizmo2/Expr.java
+++ b/src/main/java/io/quarkus/gizmo2/Expr.java
@@ -17,10 +17,15 @@ public sealed interface Expr extends SimpleTyped permits Const, Assignable, This
 
     /**
      * {@return the generic expression type (not {@code null})}
+     * If {@link #hasGenericType()} returns {@code false},
+     * the returned type will be a wrapper around {@link Typed#type() type()}.
      */
-    default GenericType genericType() {
-        return GenericType.of(type());
-    }
+    GenericType genericType();
+
+    /**
+     * {@return {@code true} if this value has a generic type, or {@code false} if it does not have one}
+     */
+    boolean hasGenericType();
 
     /**
      * {@return an assignable for an element of this array}
@@ -57,9 +62,7 @@ public sealed interface Expr extends SimpleTyped permits Const, Assignable, This
      *
      * @param desc the field descriptor (must not be {@code null})
      */
-    default InstanceFieldVar field(FieldDesc desc) {
-        return field(desc, GenericType.of(desc.type()));
-    }
+    InstanceFieldVar field(FieldDesc desc);
 
     /**
      * {@return an assignable for a field of this object}
@@ -97,7 +100,7 @@ public sealed interface Expr extends SimpleTyped permits Const, Assignable, This
      * @param desc the field descriptor (must not be {@code null})
      */
     static StaticFieldVar staticField(FieldDesc desc) {
-        return staticField(desc, GenericType.of(desc.type()));
+        return new StaticFieldVarImpl(desc, null);
     }
 
     /**

--- a/src/main/java/io/quarkus/gizmo2/GenericTyped.java
+++ b/src/main/java/io/quarkus/gizmo2/GenericTyped.java
@@ -12,4 +12,9 @@ public sealed interface GenericTyped extends SimpleTyped permits TypeParameter, 
      * {@return the generic type of this entity (not {@code null})}
      */
     GenericType genericType();
+
+    /**
+     * {@return {@code true} if this value has a generic type, or {@code false} if it does not have one}
+     */
+    boolean hasGenericType();
 }

--- a/src/main/java/io/quarkus/gizmo2/GenericTypes.java
+++ b/src/main/java/io/quarkus/gizmo2/GenericTypes.java
@@ -12,41 +12,41 @@ public final class GenericTypes {
     /**
      * The generic type for {@code boolean}.
      */
-    public static final GenericType GT_boolean = GenericType.of(CD_boolean);
+    public static final GenericType.OfPrimitive GT_boolean = (GenericType.OfPrimitive) GenericType.of(CD_boolean);
     /**
      * The generic type for {@code byte}.
      */
-    public static final GenericType GT_byte = GenericType.of(CD_byte);
+    public static final GenericType.OfPrimitive GT_byte = (GenericType.OfPrimitive) GenericType.of(CD_byte);
     /**
      * The generic type for {@code short}.
      */
-    public static final GenericType GT_short = GenericType.of(CD_short);
+    public static final GenericType.OfPrimitive GT_short = (GenericType.OfPrimitive) GenericType.of(CD_short);
     /**
      * The generic type for {@code char}.
      */
-    public static final GenericType GT_char = GenericType.of(CD_char);
+    public static final GenericType.OfPrimitive GT_char = (GenericType.OfPrimitive) GenericType.of(CD_char);
     /**
      * The generic type for {@code int}.
      */
-    public static final GenericType GT_int = GenericType.of(CD_int);
+    public static final GenericType.OfPrimitive GT_int = (GenericType.OfPrimitive) GenericType.of(CD_int);
     /**
      * The generic type for {@code long}.
      */
-    public static final GenericType GT_long = GenericType.of(CD_long);
+    public static final GenericType.OfPrimitive GT_long = (GenericType.OfPrimitive) GenericType.of(CD_long);
     /**
      * The generic type for {@code float}.
      */
-    public static final GenericType GT_float = GenericType.of(CD_float);
+    public static final GenericType.OfPrimitive GT_float = (GenericType.OfPrimitive) GenericType.of(CD_float);
     /**
      * The generic type for {@code double}.
      */
-    public static final GenericType GT_double = GenericType.of(CD_double);
+    public static final GenericType.OfPrimitive GT_double = (GenericType.OfPrimitive) GenericType.of(CD_double);
     /**
      * The generic type for {@code void}.
      */
-    public static final GenericType GT_void = GenericType.of(CD_void);
+    public static final GenericType.OfPrimitive GT_void = (GenericType.OfPrimitive) GenericType.of(CD_void);
     /**
      * The generic type for {@code java.lang.Object}.
      */
-    public static final GenericType GT_Object = GenericType.of(CD_Object);
+    public static final GenericType.OfClass GT_Object = (GenericType.OfClass) GenericType.of(CD_Object);
 }

--- a/src/main/java/io/quarkus/gizmo2/MethodTyped.java
+++ b/src/main/java/io/quarkus/gizmo2/MethodTyped.java
@@ -34,6 +34,11 @@ public sealed interface MethodTyped extends Typed permits MethodDesc, Constructo
     }
 
     /**
+     * {@return {@code true} if the method return type is generic, or {@code false} if it is not}
+     */
+    boolean hasGenericReturnType();
+
+    /**
      * {@return the type kind of the return type (not {@code null})}
      */
     default TypeKind returnTypeKind() {

--- a/src/main/java/io/quarkus/gizmo2/MethodTyped.java
+++ b/src/main/java/io/quarkus/gizmo2/MethodTyped.java
@@ -22,16 +22,12 @@ public sealed interface MethodTyped extends Typed permits MethodDesc, Constructo
     /**
      * {@return the return type}
      */
-    default ClassDesc returnType() {
-        return type().returnType();
-    }
+    ClassDesc returnType();
 
     /**
      * {@return the generic return type}
      */
-    default GenericType genericReturnType() {
-        return GenericType.of(returnType());
-    }
+    GenericType genericReturnType();
 
     /**
      * {@return {@code true} if the method return type is generic, or {@code false} if it is not}

--- a/src/main/java/io/quarkus/gizmo2/TypeParameter.java
+++ b/src/main/java/io/quarkus/gizmo2/TypeParameter.java
@@ -68,7 +68,15 @@ public sealed abstract class TypeParameter implements GenericTyped {
      * {@return the generic type corresponding to this type variable (not {@code null})}
      */
     public GenericType.OfTypeVariable genericType() {
-        return GenericType.ofTypeVariable(name(), type());
+        GenericType.OfTypeVariable genericType = this.genericType;
+        if (genericType != null) {
+            return genericType;
+        }
+        return this.genericType = GenericType.ofTypeVariable(name(), type());
+    }
+
+    public boolean hasGenericType() {
+        return true;
     }
 
     /**

--- a/src/main/java/io/quarkus/gizmo2/creator/BlockCreator.java
+++ b/src/main/java/io/quarkus/gizmo2/creator/BlockCreator.java
@@ -146,9 +146,7 @@ public sealed interface BlockCreator extends SimpleTyped permits BlockCreatorImp
      * @param value the variable initial value (must not be {@code null})
      * @return the local variable (not {@code null})
      */
-    default LocalVar localVar(String name, ClassDesc type, Expr value) {
-        return localVar(name, GenericType.of(type), value);
-    }
+    LocalVar localVar(String name, ClassDesc type, Expr value);
 
     /**
      * Declare a local variable with given {@code name} and {@code type}, which is initialized
@@ -162,7 +160,7 @@ public sealed interface BlockCreator extends SimpleTyped permits BlockCreatorImp
      * @return the local variable (not {@code null})
      */
     default LocalVar localVar(String name, Class<?> type, Expr value) {
-        return localVar(name, GenericType.of(type), value);
+        return localVar(name, Util.classDesc(type), value);
     }
 
     /**
@@ -176,7 +174,11 @@ public sealed interface BlockCreator extends SimpleTyped permits BlockCreatorImp
      * @return the local variable (not {@code null})
      */
     default LocalVar localVar(String name, Expr value) {
-        return localVar(name, value.genericType(), value);
+        if (value.hasGenericType()) {
+            return localVar(name, value.genericType(), value);
+        } else {
+            return localVar(name, value.type(), value);
+        }
     }
 
     /**
@@ -2427,9 +2429,7 @@ public sealed interface BlockCreator extends SimpleTyped permits BlockCreatorImp
      * @see #ifInstanceOf(Expr, ClassDesc, BiConsumer)
      * @see #ifInstanceOfElse(Expr, ClassDesc, BiConsumer, Consumer)
      */
-    default Expr cast(Expr a, ClassDesc toType) {
-        return cast(a, GenericType.of(toType));
-    }
+    Expr cast(Expr a, ClassDesc toType);
 
     /**
      * Cast a value to the given type.
@@ -2467,9 +2467,7 @@ public sealed interface BlockCreator extends SimpleTyped permits BlockCreatorImp
      * @return the cast value (not {@code null})
      * @see #cast(Expr, ClassDesc)
      */
-    default Expr uncheckedCast(Expr a, ClassDesc toType) {
-        return uncheckedCast(a, GenericType.of(toType));
-    }
+    Expr uncheckedCast(Expr a, ClassDesc toType);
 
     /**
      * Cast an object value to the given type without a type check.
@@ -2550,9 +2548,7 @@ public sealed interface BlockCreator extends SimpleTyped permits BlockCreatorImp
      * @param args the arguments to pass to the constructor (must not be {@code null})
      * @return the new object (not {@code null})
      */
-    default Expr new_(ConstructorDesc ctor, List<? extends Expr> args) {
-        return new_(GenericType.of(ctor.owner()), ctor, args);
-    }
+    Expr new_(ConstructorDesc ctor, List<? extends Expr> args);
 
     /**
      * Construct a new instance.

--- a/src/main/java/io/quarkus/gizmo2/creator/BlockCreator.java
+++ b/src/main/java/io/quarkus/gizmo2/creator/BlockCreator.java
@@ -2778,9 +2778,7 @@ public sealed interface BlockCreator extends SimpleTyped permits BlockCreatorImp
      * @param args the arguments to pass to the method (must not be {@code null})
      * @return the method call result (not {@code null})
      */
-    default Expr invokeStatic(MethodDesc method, List<? extends Expr> args) {
-        return invokeStatic(GenericType.of(method.returnType()), method, args);
-    }
+    Expr invokeStatic(MethodDesc method, List<? extends Expr> args);
 
     /**
      * Invoke a static method.
@@ -2845,9 +2843,7 @@ public sealed interface BlockCreator extends SimpleTyped permits BlockCreatorImp
      * @param args the arguments to pass to the method (must not be {@code null})
      * @return the method call result (not {@code null})
      */
-    default Expr invokeVirtual(MethodDesc method, Expr instance, List<? extends Expr> args) {
-        return invokeVirtual(GenericType.of(method.returnType()), method, instance, args);
-    }
+    Expr invokeVirtual(MethodDesc method, Expr instance, List<? extends Expr> args);
 
     /**
      * Invoke a virtual method.
@@ -2916,9 +2912,7 @@ public sealed interface BlockCreator extends SimpleTyped permits BlockCreatorImp
      * @param args the arguments to pass to the method (must not be {@code null})
      * @return the method call result (not {@code null})
      */
-    default Expr invokeSpecial(MethodDesc method, Expr instance, List<? extends Expr> args) {
-        return invokeSpecial(GenericType.of(method.returnType()), method, instance, args);
-    }
+    Expr invokeSpecial(MethodDesc method, Expr instance, List<? extends Expr> args);
 
     /**
      * Invoke a method using "special" semantics.

--- a/src/main/java/io/quarkus/gizmo2/impl/AnonymousClassCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/AnonymousClassCreatorImpl.java
@@ -48,7 +48,7 @@ public final class AnonymousClassCreatorImpl extends ClassCreatorImpl implements
                 superArgs.add(cc.parameter("p" + i, ctorType.parameterType(i)));
             }
         });
-        this_ = new ThisExpr(genericType());
+        this_ = new ThisExpr(type, null);
     }
 
     public ModifierLocation modifierLocation() {

--- a/src/main/java/io/quarkus/gizmo2/impl/ArrayDeref.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/ArrayDeref.java
@@ -3,7 +3,6 @@ package io.quarkus.gizmo2.impl;
 import static io.quarkus.gizmo2.impl.Conversions.convert;
 import static java.lang.constant.ConstantDescs.CD_int;
 
-import java.lang.constant.ClassDesc;
 import java.util.function.BiFunction;
 
 import io.github.dmlloyd.classfile.CodeBuilder;
@@ -13,13 +12,11 @@ import io.quarkus.gizmo2.MemoryOrder;
 
 public final class ArrayDeref extends AssignableImpl {
     private final Item item;
-    private final GenericType componentType;
     private final Item index;
     private boolean bound;
 
-    ArrayDeref(final Item item, final GenericType componentType, final Expr index) {
+    ArrayDeref(final Item item, final Expr index) {
         this.item = item;
-        this.componentType = componentType;
         this.index = convert(index, CD_int);
     }
 
@@ -52,12 +49,11 @@ public final class ArrayDeref extends AssignableImpl {
         };
     }
 
-    public ClassDesc type() {
-        return componentType.desc();
-    }
-
-    public GenericType genericType() {
-        return componentType;
+    protected void computeType() {
+        initType(item.type().componentType());
+        if (item.hasGenericType()) {
+            initGenericType(((GenericType.OfArray) item.genericType()).componentType());
+        }
     }
 
     protected void bind() {

--- a/src/main/java/io/quarkus/gizmo2/impl/ArrayLength.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/ArrayLength.java
@@ -1,7 +1,7 @@
 package io.quarkus.gizmo2.impl;
 
-import java.lang.constant.ClassDesc;
-import java.lang.constant.ConstantDescs;
+import static java.lang.constant.ConstantDescs.*;
+
 import java.util.function.BiFunction;
 
 import io.github.dmlloyd.classfile.CodeBuilder;
@@ -14,9 +14,8 @@ final class ArrayLength extends Item {
         this.item = item;
     }
 
-    @Override
-    public ClassDesc type() {
-        return ConstantDescs.CD_int;
+    protected void computeType() {
+        initType(CD_int);
     }
 
     protected void bind() {

--- a/src/main/java/io/quarkus/gizmo2/impl/ArrayLoadViaHandle.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/ArrayLoadViaHandle.java
@@ -1,14 +1,12 @@
 package io.quarkus.gizmo2.impl;
 
-import static io.smallrye.common.constraint.Assert.impossibleSwitchCase;
+import static io.smallrye.common.constraint.Assert.*;
 import static java.lang.constant.ConstantDescs.*;
 
-import java.lang.constant.ClassDesc;
 import java.lang.constant.MethodTypeDesc;
 import java.util.function.BiFunction;
 
 import io.github.dmlloyd.classfile.CodeBuilder;
-import io.quarkus.gizmo2.GenericType;
 import io.quarkus.gizmo2.MemoryOrder;
 import io.quarkus.gizmo2.impl.constant.ConstImpl;
 
@@ -26,12 +24,11 @@ final class ArrayLoadViaHandle extends Item {
                 .process(arrayDeref.array().process(arrayDeref.index().process(node.prev(), op), op), op);
     }
 
-    public ClassDesc type() {
-        return arrayDeref.type();
-    }
-
-    public GenericType genericType() {
-        return arrayDeref.genericType();
+    protected void computeType() {
+        initType(arrayDeref.type());
+        if (arrayDeref.hasGenericType()) {
+            initGenericType(arrayDeref.genericType());
+        }
     }
 
     public void writeCode(final CodeBuilder cb, final BlockCreatorImpl block) {

--- a/src/main/java/io/quarkus/gizmo2/impl/AssignableImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/AssignableImpl.java
@@ -1,11 +1,26 @@
 package io.quarkus.gizmo2.impl;
 
+import java.lang.constant.ClassDesc;
+
 import io.quarkus.gizmo2.Assignable;
 import io.quarkus.gizmo2.Const;
+import io.quarkus.gizmo2.GenericType;
 import io.quarkus.gizmo2.MemoryOrder;
 
 public non-sealed abstract class AssignableImpl extends Item implements Assignable {
     AssignableImpl() {
+    }
+
+    AssignableImpl(final ClassDesc type) {
+        super(type);
+    }
+
+    AssignableImpl(final GenericType genericType) {
+        super(genericType);
+    }
+
+    AssignableImpl(final ClassDesc type, final GenericType genericType) {
+        super(type, genericType);
     }
 
     abstract Item emitGet(final BlockCreatorImpl block, final MemoryOrder mode);

--- a/src/main/java/io/quarkus/gizmo2/impl/BinOp.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/BinOp.java
@@ -57,8 +57,11 @@ final class BinOp extends Item {
         return a.process(b.process(node.prev(), op), op);
     }
 
-    public ClassDesc type() {
-        return a.type();
+    protected void computeType() {
+        initType(a.type());
+        if (a.hasGenericType()) {
+            initGenericType(a.genericType());
+        }
     }
 
     public void writeCode(final CodeBuilder cb, final BlockCreatorImpl block) {

--- a/src/main/java/io/quarkus/gizmo2/impl/BlockCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/BlockCreatorImpl.java
@@ -50,6 +50,7 @@ import io.quarkus.gizmo2.Assignable;
 import io.quarkus.gizmo2.Const;
 import io.quarkus.gizmo2.Expr;
 import io.quarkus.gizmo2.GenericType;
+import io.quarkus.gizmo2.GenericTypes;
 import io.quarkus.gizmo2.InvokeKind;
 import io.quarkus.gizmo2.LocalVar;
 import io.quarkus.gizmo2.MemoryOrder;
@@ -839,6 +840,10 @@ public final class BlockCreatorImpl extends Item implements BlockCreator {
         return addItem(new Invoke(Opcode.INVOKESTATIC, method, null, args, genericReturnType));
     }
 
+    public Expr invokeStatic(final MethodDesc method, final List<? extends Expr> args) {
+        return addItem(new Invoke(Opcode.INVOKESTATIC, method, null, args, null));
+    }
+
     public Expr invokeVirtual(final GenericType genericReturnType, final MethodDesc method, final Expr instance,
             final List<? extends Expr> args) {
         if (!method.returnType().equals(genericReturnType.desc())) {
@@ -846,6 +851,10 @@ public final class BlockCreatorImpl extends Item implements BlockCreator {
                     "Generic type %s does not match method return type %s".formatted(genericReturnType, method.returnType()));
         }
         return addItem(new Invoke(Opcode.INVOKEVIRTUAL, method, instance, args, genericReturnType));
+    }
+
+    public Expr invokeVirtual(final MethodDesc method, final Expr instance, final List<? extends Expr> args) {
+        return addItem(new Invoke(Opcode.INVOKEVIRTUAL, method, instance, args, null));
     }
 
     public Expr invokeSpecial(final GenericType genericReturnType, final MethodDesc method, final Expr instance,
@@ -857,8 +866,12 @@ public final class BlockCreatorImpl extends Item implements BlockCreator {
         return addItem(new Invoke(Opcode.INVOKESPECIAL, method, instance, args, genericReturnType));
     }
 
+    public Expr invokeSpecial(final MethodDesc method, final Expr instance, final List<? extends Expr> args) {
+        return addItem(new Invoke(Opcode.INVOKESPECIAL, method, instance, args, null));
+    }
+
     public Expr invokeSpecial(final ConstructorDesc ctor, final Expr instance, final List<? extends Expr> args) {
-        Invoke invoke = new Invoke(ctor, instance, args, GenericType.of(void.class));
+        Invoke invoke = new Invoke(ctor, instance, args, GenericTypes.GT_void);
         addItem(invoke);
         if (instance instanceof ThisExpr) {
             // self-init

--- a/src/main/java/io/quarkus/gizmo2/impl/BlockCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/BlockCreatorImpl.java
@@ -201,8 +201,8 @@ public final class BlockCreatorImpl extends Item implements BlockCreator {
         return returnType;
     }
 
-    public ClassDesc type() {
-        return outputType;
+    protected void computeType() {
+        initType(outputType);
     }
 
     public boolean active() {
@@ -250,8 +250,15 @@ public final class BlockCreatorImpl extends Item implements BlockCreator {
         return this == other || parent != null && parent.isContainedBy(other);
     }
 
+    public LocalVar localVar(final String name, final ClassDesc type, final Expr value) {
+        return localVar0(new LocalVarImpl(this, name, type, null), value);
+    }
+
     public LocalVar localVar(final String name, final GenericType type, final Expr value) {
-        LocalVarImpl lv = new LocalVarImpl(this, name, type);
+        return localVar0(new LocalVarImpl(this, name, null, type), value);
+    }
+
+    private LocalVar localVar0(LocalVarImpl lv, Expr value) {
         addItem(lv.allocator());
         set(lv, value);
         return lv;
@@ -720,7 +727,7 @@ public final class BlockCreatorImpl extends Item implements BlockCreator {
         ClassDesc toType = toGenType.desc();
         if (a.type().isPrimitive()) {
             if (toType.isPrimitive()) {
-                return addItem(new PrimitiveCast(a, toGenType));
+                return addItem(new PrimitiveCast(a, toGenType.desc()));
             } else if (toType.equals(boxingConversion(a.type()).orElse(null))) {
                 return box(a);
             } else {
@@ -734,9 +741,41 @@ public final class BlockCreatorImpl extends Item implements BlockCreator {
                 throw new IllegalArgumentException("Cannot cast object value of type '" + a.type().displayName()
                         + "' to primitive type '" + toType.displayName() + "'");
             } else {
-                return addItem(new CheckCast(a, toGenType));
+                return addItem(new CheckCast(a, null, toGenType));
             }
         }
+    }
+
+    public Expr cast(final Expr a, final ClassDesc toType) {
+        if (a.type().isPrimitive()) {
+            if (toType.isPrimitive()) {
+                return addItem(new PrimitiveCast(a, toType));
+            } else if (toType.equals(boxingConversion(a.type()).orElse(null))) {
+                return box(a);
+            } else {
+                throw new IllegalArgumentException("Cannot cast primitive value of type '" + a.type().displayName()
+                        + "' to object type '" + toType.displayName() + "'");
+            }
+        } else {
+            if (toType.equals(unboxingConversion(a.type()).orElse(null))) {
+                return unbox(a);
+            } else if (toType.isPrimitive()) {
+                throw new IllegalArgumentException("Cannot cast object value of type '" + a.type().displayName()
+                        + "' to primitive type '" + toType.displayName() + "'");
+            } else {
+                return addItem(new CheckCast(a, toType, null));
+            }
+        }
+    }
+
+    public Expr uncheckedCast(final Expr a, final ClassDesc toType) {
+        if (a.type().isPrimitive()) {
+            throw new IllegalArgumentException("Cannot apply unchecked cast to primitive value: " + a.type().displayName());
+        }
+        if (toType.isPrimitive()) {
+            throw new IllegalArgumentException("Cannot apply unchecked cast to primitive type: " + toType.displayName());
+        }
+        return addItem(new UncheckedCast(a, toType, null));
     }
 
     public Expr uncheckedCast(final Expr a, final GenericType toType) {
@@ -746,7 +785,7 @@ public final class BlockCreatorImpl extends Item implements BlockCreator {
         if (toType.desc().isPrimitive()) {
             throw new IllegalArgumentException("Cannot apply unchecked cast to primitive type: " + toType.desc().displayName());
         }
-        return addItem(new UncheckedCast(a, toType));
+        return addItem(new UncheckedCast(a, null, toType));
     }
 
     public Expr instanceOf(final Expr obj, final GenericType type) {
@@ -755,12 +794,25 @@ public final class BlockCreatorImpl extends Item implements BlockCreator {
     }
 
     public Expr new_(final GenericType genericType, final ConstructorDesc ctor, final List<? extends Expr> args) {
+        Assert.checkNotNullParam("genericType", genericType);
+        Assert.checkNotNullParam("ctor", ctor);
+        Assert.checkNotNullParam("args", args);
         checkActive();
         if (!ctor.owner().equals(genericType.desc())) {
             throw new IllegalArgumentException(
                     "Generic type %s does not match constructor type %s".formatted(genericType, ctor.owner()));
         }
-        New new_ = new New(genericType);
+        return new0(genericType, ctor, args);
+    }
+
+    public Expr new_(final ConstructorDesc ctor, final List<? extends Expr> args) {
+        Assert.checkNotNullParam("ctor", ctor);
+        Assert.checkNotNullParam("args", args);
+        return new0(null, ctor, args);
+    }
+
+    private NewResult new0(final GenericType genericType, final ConstructorDesc ctor, final List<? extends Expr> args) {
+        New new_ = new New(ctor.owner(), genericType);
         Dup dup_ = new Dup(new_);
         Node node = tail.prev();
         // insert New & Dup *before* the arguments

--- a/src/main/java/io/quarkus/gizmo2/impl/BlockExpr.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/BlockExpr.java
@@ -5,14 +5,8 @@ import java.lang.constant.ClassDesc;
 import io.github.dmlloyd.classfile.CodeBuilder;
 
 final class BlockExpr extends Item {
-    private final ClassDesc type;
-
     BlockExpr(final ClassDesc type) {
-        this.type = type;
-    }
-
-    public ClassDesc type() {
-        return type;
+        super(type);
     }
 
     public void writeCode(final CodeBuilder cb, final BlockCreatorImpl block) {

--- a/src/main/java/io/quarkus/gizmo2/impl/BootstrappedMethodHandleImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/BootstrappedMethodHandleImpl.java
@@ -27,14 +27,11 @@ public final class BootstrappedMethodHandleImpl extends Item {
 
     public BootstrappedMethodHandleImpl(final ClassDesc owner, final MethodDesc bootstrapMethodDesc,
             final MethodTypeDesc methodHandleType, final List<Const> bootstrapArguments) {
+        super(ConstantDescs.CD_MethodHandle);
         this.owner = owner;
         this.bootstrapMethodDesc = bootstrapMethodDesc;
         this.methodHandleType = methodHandleType;
         this.bootstrapArguments = bootstrapArguments;
-    }
-
-    public ClassDesc type() {
-        return ConstantDescs.CD_MethodHandle;
     }
 
     public void writeCode(final CodeBuilder cb, final BlockCreatorImpl block) {

--- a/src/main/java/io/quarkus/gizmo2/impl/BoundItem.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/BoundItem.java
@@ -1,6 +1,5 @@
 package io.quarkus.gizmo2.impl;
 
-import java.lang.constant.ClassDesc;
 import java.util.function.BiFunction;
 
 import io.github.dmlloyd.classfile.CodeBuilder;
@@ -16,8 +15,11 @@ final class BoundItem extends Item {
         return item;
     }
 
-    public ClassDesc type() {
-        return item.type();
+    protected void computeType() {
+        initType(item.type());
+        if (item.hasGenericType()) {
+            initGenericType(item.genericType());
+        }
     }
 
     protected Node forEachDependency(final Node node, final BiFunction<Item, Node, Node> op) {

--- a/src/main/java/io/quarkus/gizmo2/impl/Box.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/Box.java
@@ -8,7 +8,6 @@ import java.lang.constant.MethodTypeDesc;
 import io.github.dmlloyd.classfile.CodeBuilder;
 import io.github.dmlloyd.classfile.Opcode;
 import io.quarkus.gizmo2.Expr;
-import io.quarkus.gizmo2.GenericType;
 
 final class Box extends Cast {
     private static ClassDesc boxing(ClassDesc unboxType) {
@@ -25,7 +24,7 @@ final class Box extends Cast {
     }
 
     Box(Expr a, ClassDesc toType) {
-        super(a, GenericType.of(toType));
+        super(a, toType, null);
     }
 
     @Override

--- a/src/main/java/io/quarkus/gizmo2/impl/Cast.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/Cast.java
@@ -8,13 +8,12 @@ import io.quarkus.gizmo2.GenericType;
 
 abstract class Cast extends Item {
     final Item a;
-    final GenericType toType;
 
     private boolean bound;
 
-    public Cast(final Expr a, final GenericType toType) {
+    public Cast(final Expr a, final ClassDesc toType, final GenericType toGenericType) {
+        super(toType, toGenericType);
         this.a = (Item) a;
-        this.toType = toType;
     }
 
     @Override
@@ -29,13 +28,5 @@ abstract class Cast extends Item {
 
     protected Node forEachDependency(final Node node, final BiFunction<Item, Node, Node> op) {
         return a.process(node.prev(), op);
-    }
-
-    public GenericType genericType() {
-        return toType;
-    }
-
-    public ClassDesc type() {
-        return toType.desc();
     }
 }

--- a/src/main/java/io/quarkus/gizmo2/impl/CheckCast.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/CheckCast.java
@@ -1,6 +1,7 @@
 package io.quarkus.gizmo2.impl;
 
 import java.lang.annotation.RetentionPolicy;
+import java.lang.constant.ClassDesc;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 
@@ -13,18 +14,18 @@ import io.quarkus.gizmo2.GenericType;
 final class CheckCast extends Cast {
     private Label label;
 
-    CheckCast(final Expr a, final GenericType toType) {
-        super(a, toType);
+    CheckCast(final Expr a, final ClassDesc toType, final GenericType toGenericType) {
+        super(a, toType, toGenericType);
     }
 
     public void writeCode(final CodeBuilder cb, final BlockCreatorImpl block) {
         label = cb.newBoundLabel();
-        cb.checkcast(toType.desc());
+        cb.checkcast(type());
     }
 
     public void writeAnnotations(final RetentionPolicy retention, final ArrayList<TypeAnnotation> annotations) {
-        if (toType.hasAnnotations(retention)) {
-            Util.computeAnnotations(toType, retention, TypeAnnotation.TargetInfo.ofCastExpr(label, 0), annotations,
+        if (hasGenericType() && genericType().hasAnnotations(retention)) {
+            Util.computeAnnotations(genericType(), retention, TypeAnnotation.TargetInfo.ofCastExpr(label, 0), annotations,
                     new ArrayDeque<>());
         }
     }

--- a/src/main/java/io/quarkus/gizmo2/impl/Cmp.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/Cmp.java
@@ -28,6 +28,7 @@ final class Cmp extends Item {
     private final Kind kind;
 
     Cmp(final Expr a, final Expr b, final Kind kind) {
+        super(CD_int);
         Optional<ClassDesc> promotedType = numericPromotion(a.type(), b.type());
         if (promotedType.isPresent()) {
             this.a = convert(a, promotedType.get());
@@ -45,10 +46,6 @@ final class Cmp extends Item {
 
     protected Node forEachDependency(final Node node, final BiFunction<Item, Node, Node> op) {
         return a.process(b.process(node.prev(), op), op);
-    }
-
-    public ClassDesc type() {
-        return CD_int;
     }
 
     public void writeCode(final CodeBuilder cb, final BlockCreatorImpl block) {

--- a/src/main/java/io/quarkus/gizmo2/impl/ConstructorDescImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/ConstructorDescImpl.java
@@ -33,6 +33,10 @@ public final class ConstructorDescImpl implements ConstructorDesc {
         return type;
     }
 
+    public boolean hasGenericReturnType() {
+        return false;
+    }
+
     public boolean equals(final Object obj) {
         return obj instanceof ConstructorDescImpl other && equals(other);
     }

--- a/src/main/java/io/quarkus/gizmo2/impl/ConstructorDescImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/ConstructorDescImpl.java
@@ -1,10 +1,13 @@
 package io.quarkus.gizmo2.impl;
 
+import static io.quarkus.gizmo2.GenericTypes.*;
+import static java.lang.constant.ConstantDescs.*;
+
 import java.lang.constant.ClassDesc;
-import java.lang.constant.ConstantDescs;
 import java.lang.constant.MethodTypeDesc;
 import java.util.Objects;
 
+import io.quarkus.gizmo2.GenericType;
 import io.quarkus.gizmo2.desc.ConstructorDesc;
 
 public final class ConstructorDescImpl implements ConstructorDesc {
@@ -13,7 +16,7 @@ public final class ConstructorDescImpl implements ConstructorDesc {
     private final int hashCode;
 
     public ConstructorDescImpl(final ClassDesc owner, final MethodTypeDesc type) {
-        if (!ConstantDescs.CD_void.equals(type.returnType())) {
+        if (!CD_void.equals(type.returnType())) {
             throw new IllegalArgumentException("Constructor descriptor must have a return type of void");
         }
         this.owner = owner;
@@ -31,6 +34,14 @@ public final class ConstructorDescImpl implements ConstructorDesc {
 
     public MethodTypeDesc type() {
         return type;
+    }
+
+    public ClassDesc returnType() {
+        return CD_void;
+    }
+
+    public GenericType genericReturnType() {
+        return GT_void;
     }
 
     public boolean hasGenericReturnType() {

--- a/src/main/java/io/quarkus/gizmo2/impl/Conversions.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/Conversions.java
@@ -12,8 +12,6 @@ import java.util.Optional;
 import java.util.Set;
 
 import io.quarkus.gizmo2.Expr;
-import io.quarkus.gizmo2.GenericType;
-import io.quarkus.gizmo2.GenericTypes;
 import io.quarkus.gizmo2.TypeKind;
 
 final class Conversions {
@@ -165,7 +163,7 @@ final class Conversions {
             // primitive widening + boxing
             ClassDesc widerType = unboxTypes.get(toDesc);
             if (primitiveWideningConversions.get(fromDesc).contains(widerType.descriptorString())) {
-                return new Box(new PrimitiveCast(item, GenericType.of(widerType)));
+                return new Box(new PrimitiveCast(item, widerType));
             }
         } else if (toType.equals(unboxTypes.get(fromDesc))) {
             // unboxing
@@ -173,18 +171,18 @@ final class Conversions {
         } else if (toType.isPrimitive() && unboxTypes.containsKey(fromDesc)
                 && primitiveWideningConversions.get(unboxTypes.get(fromDesc).descriptorString()).contains(toDesc)) {
             // unboxing + primitive widening
-            return new PrimitiveCast(new Unbox(item), GenericType.of(toType));
+            return new PrimitiveCast(new Unbox(item), toType);
         } else if (fromType.isPrimitive() && toType.isPrimitive()
                 && primitiveWideningConversions.get(fromDesc).contains(toDesc)) {
             // primitive widening
-            return new PrimitiveCast(item, GenericType.of(toType));
+            return new PrimitiveCast(item, toType);
         } else if (!fromType.isPrimitive() && DS_Object.equals(toDesc)) {
-            return new UncheckedCast(item, GenericTypes.GT_Object);
+            return new UncheckedCast(item, CD_Object, null);
         } else if (DS_Object.equals(fromDesc)) {
             if (toType.isPrimitive()) {
-                return new Unbox(new CheckCast(item, GenericType.of(boxTypes.get(toDesc))));
+                return new Unbox(new CheckCast(item, boxTypes.get(toDesc), null));
             } else {
-                return new CheckCast(item, GenericType.of(toType));
+                return new CheckCast(item, toType, null);
             }
         }
 

--- a/src/main/java/io/quarkus/gizmo2/impl/Dup.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/Dup.java
@@ -2,11 +2,9 @@ package io.quarkus.gizmo2.impl;
 
 import static io.smallrye.common.constraint.Assert.impossibleSwitchCase;
 
-import java.lang.constant.ClassDesc;
 import java.util.function.BiFunction;
 
 import io.github.dmlloyd.classfile.CodeBuilder;
-import io.quarkus.gizmo2.GenericType;
 
 final class Dup extends Item {
     private final Item input;
@@ -15,12 +13,11 @@ final class Dup extends Item {
         this.input = input;
     }
 
-    public ClassDesc type() {
-        return input.type();
-    }
-
-    public GenericType genericType() {
-        return input.genericType();
+    protected void computeType() {
+        initType(input.type());
+        if (input.hasGenericType()) {
+            initGenericType(input.genericType());
+        }
     }
 
     public Node pop(final Node node) {

--- a/src/main/java/io/quarkus/gizmo2/impl/ExecutableCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/ExecutableCreatorImpl.java
@@ -206,15 +206,17 @@ public sealed abstract class ExecutableCreatorImpl extends ModifiableCreatorImpl
                     parametersInvisibleAnnotations.add(i, currentParam.invisible);
                     hasInvisibleAnnotations = hasInvisibleAnnotations || !currentParam.invisible.isEmpty();
 
-                    GenericType genericType = currentParam.genericType();
-                    Util.computeAnnotations(genericType, RetentionPolicy.RUNTIME,
-                            TypeAnnotation.TargetInfo.ofMethodFormalParameter(i),
-                            visible, pathStack);
-                    assert pathStack.isEmpty();
-                    Util.computeAnnotations(genericType, RetentionPolicy.CLASS,
-                            TypeAnnotation.TargetInfo.ofMethodFormalParameter(i),
-                            invisible, pathStack);
-                    assert pathStack.isEmpty();
+                    if (currentParam.hasGenericType()) {
+                        GenericType genericType = currentParam.genericType();
+                        Util.computeAnnotations(genericType, RetentionPolicy.RUNTIME,
+                                TypeAnnotation.TargetInfo.ofMethodFormalParameter(i),
+                                visible, pathStack);
+                        assert pathStack.isEmpty();
+                        Util.computeAnnotations(genericType, RetentionPolicy.CLASS,
+                                TypeAnnotation.TargetInfo.ofMethodFormalParameter(i),
+                                invisible, pathStack);
+                        assert pathStack.isEmpty();
+                    }
                 } else {
                     parameters.add(i, EMPTY_PI);
                     parametersVisibleAnnotations.add(i, List.of());
@@ -263,7 +265,8 @@ public sealed abstract class ExecutableCreatorImpl extends ModifiableCreatorImpl
     boolean signatureNeeded() {
         return !typeParameters.isEmpty() || throws_.stream().anyMatch(GenericType::signatureNeeded)
                 || genericReturnType().signatureNeeded()
-                || params.stream().map(ParamVarImpl::genericType).anyMatch(GenericType::signatureNeeded);
+                || params.stream().filter(ParamVarImpl::hasGenericType).map(ParamVarImpl::genericType)
+                        .anyMatch(GenericType::signatureNeeded);
     }
 
     MethodSignature computeSignature() {

--- a/src/main/java/io/quarkus/gizmo2/impl/ExecutableCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/ExecutableCreatorImpl.java
@@ -5,6 +5,7 @@ import static io.smallrye.common.constraint.Assert.*;
 
 import java.lang.annotation.RetentionPolicy;
 import java.lang.constant.ClassDesc;
+import java.lang.constant.ConstantDescs;
 import java.lang.constant.MethodTypeDesc;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
@@ -57,6 +58,7 @@ public sealed abstract class ExecutableCreatorImpl extends ModifiableCreatorImpl
 
     private List<TypeParameter> typeParameters = List.of();
 
+    ClassDesc returnType;
     GenericType genericReturnType;
     boolean typeEstablished;
     MethodTypeDesc type = null;
@@ -92,10 +94,11 @@ public sealed abstract class ExecutableCreatorImpl extends ModifiableCreatorImpl
                 return;
             }
             // validate existing information
-            GenericType returnType = this.genericReturnType;
-            if (returnType != null && !desc.returnType().equals(returnType.desc())) {
+            GenericType genericReturnType = this.genericReturnType;
+            ClassDesc returnType = this.returnType;
+            if ((genericReturnType != null || returnType != null) && !Util.equals(returnType(), desc.returnType())) {
                 throw new IllegalArgumentException(
-                        "Type " + desc + " has a return type that does not match established return type " + returnType);
+                        "Type " + desc + " has a return type that does not match established return type " + returnType());
             }
             int paramCnt = params.size();
             int descParamCnt = desc.parameterCount();
@@ -113,7 +116,6 @@ public sealed abstract class ExecutableCreatorImpl extends ModifiableCreatorImpl
             }
             clearType();
             type = desc;
-            this.genericReturnType = GenericType.of(desc.returnType());
             if (params.size() != descParamCnt) {
                 if (params instanceof ArrayList<ParamVarImpl> al) {
                     al.ensureCapacity(descParamCnt);
@@ -134,15 +136,39 @@ public sealed abstract class ExecutableCreatorImpl extends ModifiableCreatorImpl
     }
 
     public GenericType genericReturnType() {
-        GenericType returnType = this.genericReturnType;
-        if (returnType == null) {
-            return GenericTypes.GT_void;
+        GenericType genericReturnType = this.genericReturnType;
+        if (genericReturnType != null) {
+            return genericReturnType;
         }
-        return returnType;
+        ClassDesc returnType = this.returnType;
+        if (returnType != null) {
+            return this.genericReturnType = GenericType.of(returnType);
+        }
+        MethodTypeDesc type = this.type;
+        if (type != null) {
+            return this.genericReturnType = GenericType.of(type.returnType());
+        }
+        return GenericTypes.GT_void;
+    }
+
+    public boolean hasGenericReturnType() {
+        return genericReturnType != null;
     }
 
     public ClassDesc returnType() {
-        return genericReturnType().desc();
+        ClassDesc returnType = this.returnType;
+        if (returnType != null) {
+            return returnType;
+        }
+        MethodTypeDesc type = this.type;
+        if (type != null) {
+            return this.returnType = type.returnType();
+        }
+        GenericType genericReturnType = this.genericReturnType;
+        if (genericReturnType != null) {
+            return this.returnType = genericReturnType.desc();
+        }
+        return ConstantDescs.CD_void;
     }
 
     void returning(final GenericType type) {
@@ -150,17 +176,39 @@ public sealed abstract class ExecutableCreatorImpl extends ModifiableCreatorImpl
         if (state >= ST_BODY) {
             throw new IllegalStateException("Return type may no longer be changed");
         }
-        GenericType returnType = this.genericReturnType;
-        if (returnType == null) {
-            assert !typeEstablished;
+        GenericType genericReturnType = this.genericReturnType;
+        if (genericReturnType != null && !genericReturnType.equals(type)) {
+            throw new IllegalArgumentException(
+                    "Generic return type " + type + " does not match previously set generic return type " + genericReturnType);
+        }
+        if (typeEstablished) {
+            if (!type.desc().equals(this.type.returnType())) {
+                throw new IllegalArgumentException(
+                        "Return type " + type + " does not match established return type " + this.type.returnType());
+            }
+        } else {
             this.genericReturnType = type;
-        } else if (!returnType.equals(type)) {
-            throw new IllegalArgumentException("Return type " + type + " does not match established return type " + returnType);
         }
     }
 
     void returning(final ClassDesc type) {
-        returning(GenericType.of(type));
+        checkNotNullParam("type", type);
+        if (state >= ST_BODY) {
+            throw new IllegalStateException("Return type may no longer be changed");
+        }
+        GenericType genericReturnType = this.genericReturnType;
+        ClassDesc returnType = this.returnType;
+        if (returnType == null && genericReturnType != null) {
+            assert !typeEstablished;
+            if (!Util.equals(type, genericReturnType.desc())) {
+                throw new IllegalArgumentException(
+                        "Return type " + type + " does not match established return type " + genericReturnType);
+            }
+        } else if (returnType != null && !returnType.equals(type)
+                || genericReturnType != null && !genericReturnType.desc().equals(type)) {
+            throw new IllegalArgumentException("Return type " + type + " does not match established return type " + returnType);
+        }
+        this.returnType = type;
     }
 
     void doBody(final Consumer<BlockCreator> builder, MethodBuilder mb) {
@@ -233,10 +281,12 @@ public sealed abstract class ExecutableCreatorImpl extends ModifiableCreatorImpl
                 mb.with(RuntimeInvisibleParameterAnnotationsAttribute.of(parametersInvisibleAnnotations));
             }
         }
-        Util.computeAnnotations(genericReturnType(), RetentionPolicy.RUNTIME, TypeAnnotation.TargetInfo.ofMethodReturn(),
-                visible, pathStack);
-        Util.computeAnnotations(genericReturnType(), RetentionPolicy.CLASS, TypeAnnotation.TargetInfo.ofMethodReturn(),
-                invisible, pathStack);
+        if (hasGenericReturnType()) {
+            Util.computeAnnotations(genericReturnType(), RetentionPolicy.RUNTIME, TypeAnnotation.TargetInfo.ofMethodReturn(),
+                    visible, pathStack);
+            Util.computeAnnotations(genericReturnType(), RetentionPolicy.CLASS, TypeAnnotation.TargetInfo.ofMethodReturn(),
+                    invisible, pathStack);
+        }
         // todo: `this` type annotations and generic type
         for (int i = 0; i < typeParameters.size(); i++) {
             final TypeParameter tv = typeParameters.get(i);

--- a/src/main/java/io/quarkus/gizmo2/impl/FieldDeref.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/FieldDeref.java
@@ -1,6 +1,5 @@
 package io.quarkus.gizmo2.impl;
 
-import java.lang.constant.ClassDesc;
 import java.util.function.BiFunction;
 
 import io.github.dmlloyd.classfile.CodeBuilder;
@@ -39,13 +38,11 @@ public final class FieldDeref extends AssignableImpl implements InstanceFieldVar
         return desc;
     }
 
-    @Override
-    public ClassDesc type() {
-        return desc.type();
-    }
-
-    public GenericType genericType() {
-        return genericType;
+    protected void computeType() {
+        initType(desc.type());
+        if (genericType != null) {
+            initGenericType(genericType);
+        }
     }
 
     public String itemName() {

--- a/src/main/java/io/quarkus/gizmo2/impl/FieldGetViaHandle.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/FieldGetViaHandle.java
@@ -3,7 +3,6 @@ package io.quarkus.gizmo2.impl;
 import static io.smallrye.common.constraint.Assert.impossibleSwitchCase;
 import static java.lang.constant.ConstantDescs.*;
 
-import java.lang.constant.ClassDesc;
 import java.lang.constant.MethodTypeDesc;
 import java.util.function.BiFunction;
 
@@ -20,8 +19,11 @@ final class FieldGetViaHandle extends Item {
         this.mode = mode;
     }
 
-    public ClassDesc type() {
-        return fieldDeref.type();
+    protected void computeType() {
+        initType(fieldDeref.type());
+        if (fieldDeref.hasGenericType()) {
+            initGenericType(fieldDeref.genericType());
+        }
     }
 
     protected Node forEachDependency(final Node node, final BiFunction<Item, Node, Node> op) {

--- a/src/main/java/io/quarkus/gizmo2/impl/If.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/If.java
@@ -11,20 +11,15 @@ import io.github.dmlloyd.classfile.CodeBuilder;
 import io.github.dmlloyd.classfile.Label;
 
 abstract class If extends Item {
-    private final ClassDesc type;
     final Kind kind;
     final BlockCreatorImpl whenTrue;
     final BlockCreatorImpl whenFalse;
 
     If(final ClassDesc type, final Kind kind, final BlockCreatorImpl whenTrue, final BlockCreatorImpl whenFalse) {
-        this.type = type;
+        super(type);
         this.kind = kind;
         this.whenTrue = whenTrue;
         this.whenFalse = whenFalse;
-    }
-
-    public ClassDesc type() {
-        return type;
     }
 
     private static void comparable_acmp(CodeBuilder cb, Label label) {

--- a/src/main/java/io/quarkus/gizmo2/impl/InstanceFieldCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/InstanceFieldCreatorImpl.java
@@ -55,7 +55,7 @@ public final class InstanceFieldCreatorImpl extends FieldCreatorImpl implements 
         }
         tc.zb.withField(name(), desc().type(), fb -> {
             fb.withFlags(modifiers);
-            if (!genericType.isRaw() || genericType.hasAnnotations()) {
+            if (genericType != null && !genericType.isRaw()) {
                 fb.with(SignatureAttribute.of(Util.signatureOf(genericType())));
             }
             addVisible(fb);

--- a/src/main/java/io/quarkus/gizmo2/impl/InstanceOf.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/InstanceOf.java
@@ -1,7 +1,6 @@
 package io.quarkus.gizmo2.impl;
 
 import java.lang.annotation.RetentionPolicy;
-import java.lang.constant.ClassDesc;
 import java.lang.constant.ConstantDescs;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
@@ -19,12 +18,9 @@ final class InstanceOf extends Item {
     private Label label;
 
     InstanceOf(final Expr input, final GenericType type) {
+        super(ConstantDescs.CD_boolean);
         this.input = (Item) input;
         this.type = type;
-    }
-
-    public ClassDesc type() {
-        return ConstantDescs.CD_boolean;
     }
 
     protected Node forEachDependency(final Node node, final BiFunction<Item, Node, Node> op) {

--- a/src/main/java/io/quarkus/gizmo2/impl/Invoke.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/Invoke.java
@@ -20,7 +20,6 @@ final class Invoke extends Item {
     private final ClassDesc owner;
     private final String name;
     private final MethodTypeDesc type;
-    private final GenericType genericType;
     private final Item instance;
     private final List<Item> args;
     private final Opcode opcode;
@@ -39,7 +38,7 @@ final class Invoke extends Item {
 
     private Invoke(final ClassDesc owner, final String name, final MethodTypeDesc type, final Opcode opcode,
             final boolean isInterface, Item instance, final List<Item> args, final GenericType genericType) {
-        this.genericType = genericType;
+        super(type.returnType(), genericType);
         if (type.parameterCount() != args.size()) {
             String paramsStr = type.parameterCount() == 1 ? "1 parameter" : type.parameterCount() + " parameters";
             String argsStr = args.size() == 1 ? "1 argument was" : args.size() + " arguments were";
@@ -72,14 +71,6 @@ final class Invoke extends Item {
     @Override
     public String itemName() {
         return "Invoke:" + owner.displayName() + "." + name;
-    }
-
-    public ClassDesc type() {
-        return type.returnType();
-    }
-
-    public GenericType genericType() {
-        return genericType;
     }
 
     protected Node forEachDependency(Node node, final BiFunction<Item, Node, Node> op) {

--- a/src/main/java/io/quarkus/gizmo2/impl/InvokeDynamic.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/InvokeDynamic.java
@@ -1,6 +1,5 @@
 package io.quarkus.gizmo2.impl;
 
-import java.lang.constant.ClassDesc;
 import java.lang.constant.DynamicCallSiteDesc;
 import java.util.List;
 import java.util.function.BiFunction;
@@ -13,6 +12,7 @@ final class InvokeDynamic extends Item {
     private final DynamicCallSiteDesc callSiteDesc;
 
     InvokeDynamic(final List<? extends Expr> args, final DynamicCallSiteDesc callSiteDesc) {
+        super(callSiteDesc.invocationType().returnType());
         this.args = args;
         this.callSiteDesc = callSiteDesc;
     }
@@ -24,10 +24,6 @@ final class InvokeDynamic extends Item {
             node = arg.process(node, op);
         }
         return node;
-    }
-
-    public ClassDesc type() {
-        return callSiteDesc.invocationType().returnType();
     }
 
     public void writeCode(final CodeBuilder cb, final BlockCreatorImpl block) {

--- a/src/main/java/io/quarkus/gizmo2/impl/LambdaAsMethodCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/LambdaAsMethodCreatorImpl.java
@@ -45,6 +45,10 @@ public final class LambdaAsMethodCreatorImpl implements LambdaCreator {
             throw new IllegalStateException("All captures must be defined before parameters are defined");
         }
         captures.add(value);
-        return samCreator.parameter(name, value.genericType());
+        if (value.hasGenericType()) {
+            return samCreator.parameter(name, value.genericType());
+        } else {
+            return samCreator.parameter(name, value.type());
+        }
     }
 }

--- a/src/main/java/io/quarkus/gizmo2/impl/LocalVarAllocator.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/LocalVarAllocator.java
@@ -27,15 +27,17 @@ final class LocalVarAllocator extends Item {
         startScope = cb.newBoundLabel();
         endScope = block.endLabel();
         cb.with(LocalVariable.of(slot, localVar.name(), localVar.type(), startScope, endScope));
-        GenericType gt = localVar.genericType();
-        if (!gt.isRaw()) {
-            cb.with(LocalVariableType.of(slot, localVar.name(), Util.signatureOf(gt), startScope, endScope));
+        if (localVar.hasGenericType()) {
+            GenericType gt = localVar.genericType();
+            if (!gt.isRaw()) {
+                cb.with(LocalVariableType.of(slot, localVar.name(), Util.signatureOf(gt), startScope, endScope));
+            }
         }
         localVar.slot = slot;
     }
 
     public void writeAnnotations(final RetentionPolicy retention, final ArrayList<TypeAnnotation> annotations) {
-        if (localVar.genericType().hasAnnotations(retention)) {
+        if (localVar.hasGenericType() && localVar.genericType().hasAnnotations(retention)) {
             Util.computeAnnotations(localVar.genericType(), retention, TypeAnnotation.TargetInfo.ofLocalVariable(
                     List.of(
                             TypeAnnotation.LocalVarTargetInfo.of(startScope, endScope, localVar.slot))),

--- a/src/main/java/io/quarkus/gizmo2/impl/LocalVarImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/LocalVarImpl.java
@@ -12,13 +12,12 @@ import io.quarkus.gizmo2.creator.BlockCreator;
 
 public final class LocalVarImpl extends AssignableImpl implements LocalVar {
     private final String name;
-    private final GenericType type;
     private final BlockCreatorImpl owner;
     int slot = -1;
 
-    LocalVarImpl(final BlockCreatorImpl owner, final String name, final GenericType type) {
+    LocalVarImpl(final BlockCreatorImpl owner, final String name, final ClassDesc type, final GenericType genericType) {
+        super(type, genericType);
         this.name = name;
-        this.type = type;
         this.owner = owner;
     }
 
@@ -32,14 +31,6 @@ public final class LocalVarImpl extends AssignableImpl implements LocalVar {
 
     public String name() {
         return name;
-    }
-
-    public ClassDesc type() {
-        return type.desc();
-    }
-
-    public GenericType genericType() {
-        return type;
     }
 
     public boolean bound() {

--- a/src/main/java/io/quarkus/gizmo2/impl/MethodDescImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/MethodDescImpl.java
@@ -4,6 +4,7 @@ import java.lang.constant.ClassDesc;
 import java.lang.constant.MethodTypeDesc;
 import java.util.Objects;
 
+import io.quarkus.gizmo2.GenericType;
 import io.quarkus.gizmo2.desc.MethodDesc;
 
 public sealed abstract class MethodDescImpl implements MethodDesc permits ClassMethodDescImpl, InterfaceMethodDescImpl {
@@ -29,6 +30,14 @@ public sealed abstract class MethodDescImpl implements MethodDesc permits ClassM
 
     public MethodTypeDesc type() {
         return type;
+    }
+
+    public ClassDesc returnType() {
+        return type.returnType();
+    }
+
+    public GenericType genericReturnType() {
+        return GenericType.of(type().returnType());
     }
 
     public boolean hasGenericReturnType() {

--- a/src/main/java/io/quarkus/gizmo2/impl/MethodDescImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/MethodDescImpl.java
@@ -31,6 +31,10 @@ public sealed abstract class MethodDescImpl implements MethodDesc permits ClassM
         return type;
     }
 
+    public boolean hasGenericReturnType() {
+        return false;
+    }
+
     public boolean equals(final Object obj) {
         return obj instanceof MethodDescImpl other && equals(other);
     }

--- a/src/main/java/io/quarkus/gizmo2/impl/Neg.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/Neg.java
@@ -4,7 +4,6 @@ import static io.quarkus.gizmo2.impl.Conversions.convert;
 import static io.quarkus.gizmo2.impl.Conversions.unboxingConversion;
 import static io.smallrye.common.constraint.Assert.impossibleSwitchCase;
 
-import java.lang.constant.ClassDesc;
 import java.util.function.BiFunction;
 
 import io.github.dmlloyd.classfile.CodeBuilder;
@@ -17,6 +16,7 @@ final class Neg extends Item {
     Neg(Expr a) {
         a = convert(a, unboxingConversion(a.type()).orElse(a.type()));
         this.a = (Item) a;
+        initType(a.type());
         TypeKind typeKind = a.typeKind();
         if (typeKind == TypeKind.REFERENCE || typeKind == TypeKind.BOOLEAN || typeKind == TypeKind.VOID) {
             throw new IllegalArgumentException("Cannot negate non-numeric expression: " + a);
@@ -25,10 +25,6 @@ final class Neg extends Item {
 
     protected Node forEachDependency(final Node node, final BiFunction<Item, Node, Node> op) {
         return a.process(node.prev(), op);
-    }
-
-    public ClassDesc type() {
-        return a.type();
     }
 
     public void writeCode(final CodeBuilder cb, final BlockCreatorImpl block) {

--- a/src/main/java/io/quarkus/gizmo2/impl/New.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/New.java
@@ -11,11 +11,10 @@ import io.github.dmlloyd.classfile.TypeAnnotation;
 import io.quarkus.gizmo2.GenericType;
 
 final class New extends Item {
-    private final GenericType type;
     private Label label;
 
-    New(final GenericType type) {
-        this.type = type;
+    New(final ClassDesc type, final GenericType genericType) {
+        super(type, genericType);
     }
 
     @Override
@@ -23,22 +22,14 @@ final class New extends Item {
         return "New:" + type().displayName();
     }
 
-    public GenericType genericType() {
-        return type;
-    }
-
-    public ClassDesc type() {
-        return type.desc();
-    }
-
     public void writeCode(final CodeBuilder cb, final BlockCreatorImpl block) {
         label = cb.newBoundLabel();
-        cb.new_(type.desc());
+        cb.new_(type());
     }
 
     public void writeAnnotations(final RetentionPolicy retention, final ArrayList<TypeAnnotation> annotations) {
-        if (type.hasAnnotations(retention)) {
-            Util.computeAnnotations(type, retention, TypeAnnotation.TargetInfo.ofNewExpr(label), annotations,
+        if (hasGenericType() && genericType().hasAnnotations(retention)) {
+            Util.computeAnnotations(genericType(), retention, TypeAnnotation.TargetInfo.ofNewExpr(label), annotations,
                     new ArrayDeque<>());
         }
     }

--- a/src/main/java/io/quarkus/gizmo2/impl/NewArrayResult.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/NewArrayResult.java
@@ -1,6 +1,5 @@
 package io.quarkus.gizmo2.impl;
 
-import java.lang.constant.ClassDesc;
 import java.util.List;
 import java.util.function.BiFunction;
 
@@ -11,6 +10,7 @@ public class NewArrayResult extends Item {
     private final List<ArrayStore> elements;
 
     NewArrayResult(NewEmptyArray newEmptyArray, List<ArrayStore> elements) {
+        super(newEmptyArray.type());
         this.newEmptyArray = newEmptyArray;
         this.elements = elements;
     }
@@ -18,11 +18,6 @@ public class NewArrayResult extends Item {
     @Override
     public String itemName() {
         return "NewArrayResult:" + newEmptyArray.type().displayName();
-    }
-
-    @Override
-    public ClassDesc type() {
-        return newEmptyArray.type();
     }
 
     @Override

--- a/src/main/java/io/quarkus/gizmo2/impl/NewEmptyArray.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/NewEmptyArray.java
@@ -12,25 +12,20 @@ import io.quarkus.gizmo2.Expr;
 import io.quarkus.gizmo2.impl.constant.IntConst;
 
 final class NewEmptyArray extends Item {
-    private final ClassDesc arrayType;
     private final Item size;
 
     NewEmptyArray(final ClassDesc componentType, final Item size) {
-        arrayType = componentType.arrayType();
+        super(componentType.arrayType());
         this.size = convert(size, CD_int);
     }
 
     @Override
     public String itemName() {
-        return "NewEmptyArray:" + arrayType.displayName();
+        return "NewEmptyArray:" + type().displayName();
     }
 
     protected Node forEachDependency(final Node node, final BiFunction<Item, Node, Node> op) {
         return size.process(node.prev(), op);
-    }
-
-    public ClassDesc type() {
-        return arrayType;
     }
 
     public Expr length() {

--- a/src/main/java/io/quarkus/gizmo2/impl/NewResult.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/NewResult.java
@@ -1,6 +1,5 @@
 package io.quarkus.gizmo2.impl;
 
-import java.lang.constant.ClassDesc;
 import java.util.function.BiFunction;
 
 import io.github.dmlloyd.classfile.CodeBuilder;
@@ -10,6 +9,7 @@ public class NewResult extends Item {
     private final Invoke invoke;
 
     NewResult(New new_, Invoke invoke) {
+        super(new_.type(), new_.hasGenericType() ? new_.genericType() : null);
         this.new_ = new_;
         this.invoke = invoke;
     }
@@ -17,11 +17,6 @@ public class NewResult extends Item {
     @Override
     public String itemName() {
         return "NewResult:" + new_.type().displayName();
-    }
-
-    @Override
-    public ClassDesc type() {
-        return new_.type();
     }
 
     @Override

--- a/src/main/java/io/quarkus/gizmo2/impl/ParamCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/ParamCreatorImpl.java
@@ -71,6 +71,10 @@ public final class ParamCreatorImpl extends ModifiableCreatorImpl implements Par
         return genericType;
     }
 
+    public boolean hasGenericType() {
+        return genericType != null;
+    }
+
     public ElementType annotationTargetType() {
         return ElementType.PARAMETER;
     }

--- a/src/main/java/io/quarkus/gizmo2/impl/ParamCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/ParamCreatorImpl.java
@@ -14,6 +14,7 @@ import io.quarkus.gizmo2.creator.ParamCreator;
 
 public final class ParamCreatorImpl extends ModifiableCreatorImpl implements ParamCreator {
     boolean typeEstablished;
+    ClassDesc type;
     GenericType genericType;
 
     public ParamCreatorImpl(final GizmoImpl gizmo) {
@@ -32,33 +33,38 @@ public final class ParamCreatorImpl extends ModifiableCreatorImpl implements Par
 
     ParamVarImpl apply(final Consumer<ParamCreator> builder, final String name, final int index, final int slot) {
         builder.accept(this);
-        if (genericType == null) {
+        if (type == null && genericType == null) {
             throw new IllegalStateException("Parameter type was not set");
         }
         typeEstablished = true;
-        return new ParamVarImpl(genericType, name, index, slot, modifiers, List.copyOf(invisible.values()),
+        return new ParamVarImpl(type, genericType, name, index, slot, modifiers, List.copyOf(invisible.values()),
                 List.copyOf(visible.values()));
     }
 
     public void setType(final GenericType genericType) {
         checkNotNullParam("type", genericType);
-        if (genericType.desc().equals(ConstantDescs.CD_void)) {
-            throw new IllegalArgumentException("Bad genericType for parameter: " + genericType);
-        }
         if (typeEstablished && !genericType.equals(this.genericType)) {
             throw new IllegalArgumentException(
                     "Given type " + genericType + " differs from established type " + this.genericType);
         }
+        setType(genericType.desc());
         this.genericType = genericType;
     }
 
     public void setType(final ClassDesc type) {
         checkNotNullParam("type", type);
-        setType(GenericType.of(type));
+        if (type.equals(ConstantDescs.CD_void)) {
+            throw new IllegalArgumentException("Bad type for parameter: " + type);
+        }
+        if (typeEstablished && !type.equals(this.type)) {
+            throw new IllegalArgumentException(
+                    "Given type " + type + " differs from established type " + this.type);
+        }
+        this.type = type;
     }
 
     public ClassDesc type() {
-        return genericType.desc();
+        return type;
     }
 
     public GenericType genericType() {

--- a/src/main/java/io/quarkus/gizmo2/impl/ParamVarImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/ParamVarImpl.java
@@ -10,7 +10,6 @@ import io.quarkus.gizmo2.MemoryOrder;
 import io.quarkus.gizmo2.ParamVar;
 
 public final class ParamVarImpl extends AssignableImpl implements ParamVar {
-    private final GenericType type;
     private final String name;
     private final int index;
     private final int slot;
@@ -18,9 +17,9 @@ public final class ParamVarImpl extends AssignableImpl implements ParamVar {
     final List<Annotation> visible;
     private final int flags;
 
-    public ParamVarImpl(final GenericType type, final String name, final int index, final int slot, final int flags,
-            final List<Annotation> invisible, final List<Annotation> visible) {
-        this.type = type;
+    ParamVarImpl(final ClassDesc type, final GenericType genericType, final String name, final int index,
+            final int slot, final int flags, final List<Annotation> invisible, final List<Annotation> visible) {
+        super(type, genericType);
         this.name = name;
         this.index = index;
         this.slot = slot;
@@ -52,14 +51,6 @@ public final class ParamVarImpl extends AssignableImpl implements ParamVar {
 
     Item emitSet(final BlockCreatorImpl block, final Item value, final MemoryOrder mode) {
         return new ParamSet(this, value);
-    }
-
-    public ClassDesc type() {
-        return type.desc();
-    }
-
-    public GenericType genericType() {
-        return type;
     }
 
     public boolean bound() {

--- a/src/main/java/io/quarkus/gizmo2/impl/PrimitiveCast.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/PrimitiveCast.java
@@ -1,17 +1,18 @@
 package io.quarkus.gizmo2.impl;
 
+import java.lang.constant.ClassDesc;
+
 import io.github.dmlloyd.classfile.CodeBuilder;
 import io.github.dmlloyd.classfile.TypeKind;
 import io.quarkus.gizmo2.Expr;
-import io.quarkus.gizmo2.GenericType;
 
 final class PrimitiveCast extends Cast {
 
-    PrimitiveCast(final Expr a, final GenericType toType) {
-        super(a, toType);
+    PrimitiveCast(final Expr a, final ClassDesc toType) {
+        super(a, toType, null);
     }
 
     public void writeCode(final CodeBuilder cb, final BlockCreatorImpl block) {
-        cb.conversion(Util.actualKindOf(a.typeKind()), TypeKind.from(toType.desc()));
+        cb.conversion(Util.actualKindOf(a.typeKind()), TypeKind.from(type()));
     }
 }

--- a/src/main/java/io/quarkus/gizmo2/impl/Rel.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/Rel.java
@@ -4,7 +4,6 @@ import static io.quarkus.gizmo2.impl.Preconditions.requireSameTypeKind;
 import static io.smallrye.common.constraint.Assert.impossibleSwitchCase;
 import static java.lang.constant.ConstantDescs.CD_boolean;
 
-import java.lang.constant.ClassDesc;
 import java.util.function.BiFunction;
 
 import io.github.dmlloyd.classfile.CodeBuilder;
@@ -18,6 +17,7 @@ final class Rel extends Item {
     private final If.Kind kind;
 
     Rel(final Expr a, final Expr b, final If.Kind kind) {
+        super(CD_boolean);
         this.kind = kind;
         requireSameTypeKind(a, b);
         this.a = (Item) a;
@@ -41,10 +41,6 @@ final class Rel extends Item {
 
     Item right() {
         return b;
-    }
-
-    public ClassDesc type() {
-        return CD_boolean;
     }
 
     If.Kind kind() {

--- a/src/main/java/io/quarkus/gizmo2/impl/RelZero.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/RelZero.java
@@ -3,7 +3,6 @@ package io.quarkus.gizmo2.impl;
 import static io.smallrye.common.constraint.Assert.impossibleSwitchCase;
 import static java.lang.constant.ConstantDescs.CD_boolean;
 
-import java.lang.constant.ClassDesc;
 import java.util.function.BiFunction;
 
 import io.github.dmlloyd.classfile.CodeBuilder;
@@ -16,6 +15,7 @@ final class RelZero extends Item {
     private final If.Kind kind;
 
     RelZero(final Expr a, final If.Kind kind) {
+        super(CD_boolean);
         this.kind = kind;
         this.a = (Item) a;
         if (a.typeKind() == TypeKind.REFERENCE) {
@@ -31,10 +31,6 @@ final class RelZero extends Item {
 
     protected Node forEachDependency(final Node node, final BiFunction<Item, Node, Node> op) {
         return a.process(node.prev(), op);
-    }
-
-    public ClassDesc type() {
-        return CD_boolean;
     }
 
     If.Kind kind() {

--- a/src/main/java/io/quarkus/gizmo2/impl/StaticFieldCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/StaticFieldCreatorImpl.java
@@ -55,7 +55,7 @@ public sealed abstract class StaticFieldCreatorImpl extends FieldCreatorImpl imp
         }
         tc.zb.withField(name(), desc().type(), fb -> {
             fb.withFlags(modifiers);
-            if (!genericType.isRaw() || genericType.hasAnnotations()) {
+            if (genericType != null && !genericType.isRaw()) {
                 fb.with(SignatureAttribute.of(Util.signatureOf(genericType())));
             }
             addVisible(fb);

--- a/src/main/java/io/quarkus/gizmo2/impl/StaticFieldGetViaHandle.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/StaticFieldGetViaHandle.java
@@ -3,7 +3,6 @@ package io.quarkus.gizmo2.impl;
 import static io.smallrye.common.constraint.Assert.impossibleSwitchCase;
 import static java.lang.constant.ConstantDescs.*;
 
-import java.lang.constant.ClassDesc;
 import java.lang.constant.MethodTypeDesc;
 import java.util.function.BiFunction;
 
@@ -16,12 +15,9 @@ final class StaticFieldGetViaHandle extends Item {
     private final MemoryOrder mode;
 
     StaticFieldGetViaHandle(final StaticFieldVarImpl staticFieldVar, final MemoryOrder mode) {
+        super(staticFieldVar.type(), staticFieldVar.hasGenericType() ? staticFieldVar.genericType() : null);
         this.staticFieldVar = staticFieldVar;
         this.mode = mode;
-    }
-
-    public ClassDesc type() {
-        return staticFieldVar.type();
     }
 
     protected Node forEachDependency(final Node node, final BiFunction<Item, Node, Node> op) {

--- a/src/main/java/io/quarkus/gizmo2/impl/StaticFieldVarImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/StaticFieldVarImpl.java
@@ -1,7 +1,5 @@
 package io.quarkus.gizmo2.impl;
 
-import java.lang.constant.ClassDesc;
-
 import io.github.dmlloyd.classfile.CodeBuilder;
 import io.quarkus.gizmo2.GenericType;
 import io.quarkus.gizmo2.MemoryOrder;
@@ -10,23 +8,14 @@ import io.quarkus.gizmo2.desc.FieldDesc;
 
 public final class StaticFieldVarImpl extends AssignableImpl implements StaticFieldVar {
     private final FieldDesc desc;
-    private final GenericType genericType;
 
     public StaticFieldVarImpl(FieldDesc desc, final GenericType genericType) {
+        super(desc.type(), genericType);
         this.desc = desc;
-        this.genericType = genericType;
     }
 
     public FieldDesc desc() {
         return desc;
-    }
-
-    public ClassDesc type() {
-        return desc.type();
-    }
-
-    public GenericType genericType() {
-        return genericType;
     }
 
     public boolean bound() {

--- a/src/main/java/io/quarkus/gizmo2/impl/SwitchCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/SwitchCreatorImpl.java
@@ -61,6 +61,7 @@ public sealed abstract class SwitchCreatorImpl<C extends ConstImpl> extends Item
 
     SwitchCreatorImpl(final BlockCreatorImpl enclosing, final Expr switchVal, final ClassDesc type,
             final Class<C> constantType) {
+        super(type);
         this.enclosing = enclosing;
         this.switchVal = (Item) switchVal;
         this.type = type;
@@ -87,10 +88,6 @@ public sealed abstract class SwitchCreatorImpl<C extends ConstImpl> extends Item
 
     public boolean mayFallThrough() {
         return fallThrough;
-    }
-
-    public final ClassDesc type() {
-        return type;
     }
 
     abstract int staticHash(C val);

--- a/src/main/java/io/quarkus/gizmo2/impl/ThisExpr.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/ThisExpr.java
@@ -7,22 +7,12 @@ import io.quarkus.gizmo2.GenericType;
 import io.quarkus.gizmo2.This;
 
 public final class ThisExpr extends Item implements This {
-    private final GenericType type;
-
-    public ThisExpr(final GenericType type) {
-        this.type = type;
+    public ThisExpr(final ClassDesc type, final GenericType genericType) {
+        super(type, genericType);
     }
 
     public boolean bound() {
         return false;
-    }
-
-    public ClassDesc type() {
-        return type.desc();
-    }
-
-    public GenericType genericType() {
-        return type;
     }
 
     public void writeCode(final CodeBuilder cb, final BlockCreatorImpl block) {

--- a/src/main/java/io/quarkus/gizmo2/impl/TypeCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/TypeCreatorImpl.java
@@ -45,6 +45,7 @@ import io.quarkus.gizmo2.ClassVersion;
 import io.quarkus.gizmo2.Const;
 import io.quarkus.gizmo2.Expr;
 import io.quarkus.gizmo2.GenericType;
+import io.quarkus.gizmo2.GenericTypes;
 import io.quarkus.gizmo2.LocalVar;
 import io.quarkus.gizmo2.ParamVar;
 import io.quarkus.gizmo2.StaticFieldVar;
@@ -102,7 +103,7 @@ public abstract sealed class TypeCreatorImpl extends ModifiableCreatorImpl imple
     private final ClassOutput output;
     private ThisExpr this_;
     private ClassDesc superType = ConstantDescs.CD_Object;
-    private GenericType.OfClass superSig = GenericType.ofClass(Object.class);
+    private GenericType.OfClass superSig = GenericTypes.GT_Object;
     private List<GenericType.OfClass> interfaceSigs = List.of();
     private List<TypeParameter> typeParameters = List.of();
     final ClassBuilder zb;
@@ -197,6 +198,10 @@ public abstract sealed class TypeCreatorImpl extends ModifiableCreatorImpl imple
             this.genericType = genericType;
         }
         return genericType;
+    }
+
+    public boolean hasGenericType() {
+        return genericType != null;
     }
 
     boolean signatureNeeded() {

--- a/src/main/java/io/quarkus/gizmo2/impl/TypeCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/TypeCreatorImpl.java
@@ -286,7 +286,7 @@ public abstract sealed class TypeCreatorImpl extends ModifiableCreatorImpl imple
     public This this_() {
         ThisExpr this_ = this.this_;
         if (this_ == null) {
-            this_ = this.this_ = new ThisExpr(genericType());
+            this_ = this.this_ = new ThisExpr(type(), genericType());
         }
         return this_;
     }

--- a/src/main/java/io/quarkus/gizmo2/impl/TypeCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/TypeCreatorImpl.java
@@ -291,7 +291,7 @@ public abstract sealed class TypeCreatorImpl extends ModifiableCreatorImpl imple
     public This this_() {
         ThisExpr this_ = this.this_;
         if (this_ == null) {
-            this_ = this.this_ = new ThisExpr(type(), genericType());
+            this_ = this.this_ = new ThisExpr(type(), hasGenericType() ? genericType() : null);
         }
         return this_;
     }

--- a/src/main/java/io/quarkus/gizmo2/impl/Unbox.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/Unbox.java
@@ -9,7 +9,6 @@ import java.lang.constant.MethodTypeDesc;
 import io.github.dmlloyd.classfile.CodeBuilder;
 import io.github.dmlloyd.classfile.Opcode;
 import io.quarkus.gizmo2.Expr;
-import io.quarkus.gizmo2.GenericType;
 import io.quarkus.gizmo2.TypeKind;
 
 final class Unbox extends Cast {
@@ -23,12 +22,12 @@ final class Unbox extends Cast {
     }
 
     Unbox(Expr a) {
-        super(a, GenericType.of(unboxing(a.type())));
+        super(a, unboxing(a.type()), null);
     }
 
     @Override
     public void writeCode(CodeBuilder cb, BlockCreatorImpl block) {
-        cb.invoke(Opcode.INVOKEVIRTUAL, a.type(), switch (TypeKind.from(toType.desc())) {
+        cb.invoke(Opcode.INVOKEVIRTUAL, a.type(), switch (TypeKind.from(type())) {
             case BOOLEAN -> "booleanValue";
             case BYTE -> "byteValue";
             case CHAR -> "charValue";
@@ -37,7 +36,7 @@ final class Unbox extends Cast {
             case LONG -> "longValue";
             case FLOAT -> "floatValue";
             case DOUBLE -> "doubleValue";
-            default -> throw impossibleSwitchCase(TypeKind.from(toType.desc()));
-        }, MethodTypeDesc.of(toType.desc()), false);
+            default -> throw impossibleSwitchCase(TypeKind.from(type()));
+        }, MethodTypeDesc.of(type()), false);
     }
 }

--- a/src/main/java/io/quarkus/gizmo2/impl/UncheckedCast.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/UncheckedCast.java
@@ -1,13 +1,15 @@
 package io.quarkus.gizmo2.impl;
 
+import java.lang.constant.ClassDesc;
+
 import io.github.dmlloyd.classfile.CodeBuilder;
 import io.quarkus.gizmo2.Expr;
 import io.quarkus.gizmo2.GenericType;
 
 final class UncheckedCast extends Cast {
 
-    UncheckedCast(final Expr a, final GenericType toType) {
-        super(a, toType);
+    UncheckedCast(final Expr a, final ClassDesc toType, final GenericType toGenericType) {
+        super(a, toType, toGenericType);
     }
 
     public void writeCode(final CodeBuilder cb, final BlockCreatorImpl block) {

--- a/src/main/java/io/quarkus/gizmo2/impl/Util.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/Util.java
@@ -66,6 +66,10 @@ public final class Util {
         return constantCache.get(clazz);
     }
 
+    public static boolean equals(ClassDesc a, ClassDesc b) {
+        return a == b || a != null && b != null && a.descriptorString().equals(b.descriptorString());
+    }
+
     private static final MethodHandle actualKind;
     private static final MethodHandle GenericType_computeAnnotations;
     private static final MethodHandle TypeParameter_computeAnnotations;

--- a/src/main/java/io/quarkus/gizmo2/impl/constant/ConstImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/constant/ConstImpl.java
@@ -24,10 +24,8 @@ import io.quarkus.gizmo2.impl.Item;
 import io.quarkus.gizmo2.impl.Util;
 
 public abstract non-sealed class ConstImpl extends Item implements Const {
-    private final ClassDesc type;
-
     ConstImpl(final ClassDesc type) {
-        this.type = type;
+        super(type);
     }
 
     public static StringConst of(final String value) {
@@ -326,10 +324,6 @@ public abstract non-sealed class ConstImpl extends Item implements Const {
 
     public static MethodTypeConst of(MethodTypeDesc desc) {
         return new MethodTypeConst(desc);
-    }
-
-    public ClassDesc type() {
-        return type;
     }
 
     public boolean bound() {


### PR DESCRIPTION
Reduce `GenericType` usage to only cases where they are required. Fixes #490.

This only ended up taking me an hour or so, so I guess I was worried over nothing.