### PR TITLE
Revert jboss-parent to 49

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jboss</groupId>
         <artifactId>jboss-parent</artifactId>
-        <version>50</version>
+        <version>49</version>
     </parent>
 
     <groupId>io.quarkus.gizmo</groupId>


### PR DESCRIPTION
Our infrastructure is not ready yet for jboss-parent 50, which introduces several breaking changes.