### PR TITLE
Release 2.0.0.Beta9

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,4 +1,4 @@
 release:
-  current-version: "2.0.0.Beta8"
+  current-version: "2.0.0.Beta9"
   next-version: "2.0.0-SNAPSHOT"
 


### PR DESCRIPTION
I know it's a bit early to do a release but I want to check if we can release with the new jboss-parent. We don't have to upgrade in Quarkus for now.