### PR TITLE
fix `try`/`catch`/`finally` code generation when the `try` block is empty

### DIFF
--- a/src/main/java/io/quarkus/gizmo2/impl/BlockCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/BlockCreatorImpl.java
@@ -1011,6 +1011,15 @@ public final class BlockCreatorImpl extends Item implements BlockCreator {
         finish();
     }
 
+    public void accept(final Consumer<? super BlockCreator> handler, final Runnable ifEmpty) {
+        checkActive();
+        handler.accept(this);
+        if (items.size() == 1 && items.get(0) instanceof BlockHeader) {
+            ifEmpty.run();
+        }
+        finish();
+    }
+
     private void finish() {
         if (!done()) {
             addItem(Yield.YIELD_VOID);

--- a/src/main/java/io/quarkus/gizmo2/impl/StaticFieldCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/StaticFieldCreatorImpl.java
@@ -3,6 +3,7 @@ package io.quarkus.gizmo2.impl;
 import static java.lang.constant.ConstantDescs.*;
 
 import java.lang.constant.ClassDesc;
+import java.util.Set;
 import java.util.function.Consumer;
 
 import io.quarkus.gizmo2.Const;
@@ -15,6 +16,16 @@ import io.smallrye.common.constraint.Assert;
 
 public sealed abstract class StaticFieldCreatorImpl extends FieldCreatorImpl implements StaticFieldCreator
         permits ClassStaticFieldCreatorImpl, InterfaceStaticFieldCreatorImpl {
+
+    // it is only possible to emit a `ConstantValue` for these types
+    // see `ConstantValueAttribute.of()`
+    private static final Set<String> CONSTANT_TYPE_DESCS = Set.of(
+            CD_int.descriptorString(),
+            CD_long.descriptorString(),
+            CD_float.descriptorString(),
+            CD_double.descriptorString(),
+            CD_String.descriptorString());
+
     private Const initial;
     private Consumer<BlockCreator> initializer;
 
@@ -26,7 +37,7 @@ public sealed abstract class StaticFieldCreatorImpl extends FieldCreatorImpl imp
         Assert.checkNotNullParam("initial", initial);
         checkOneInit();
         setType(initial.type());
-        if (initial.type().isPrimitive() || Util.equals(initial.type(), CD_String)) {
+        if (CONSTANT_TYPE_DESCS.contains(initial.type().descriptorString())) {
             this.initial = initial;
         } else {
             initializer = bc -> bc.setStaticField(desc(), initial);

--- a/src/main/java/io/quarkus/gizmo2/impl/TryCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/TryCreatorImpl.java
@@ -38,7 +38,10 @@ public final class TryCreatorImpl implements TryCreator {
     public void body(final Consumer<BlockCreator> builder) {
         advanceToState(ST_BODY);
         body.parent().nesting(() -> {
-            body.accept(builder);
+            body.accept(builder, () -> {
+                // `body` is empty, but an exception handler must guard at least one instruction
+                body.addItem(Nop.EMITTING);
+            });
         });
         advanceToState(ST_CATCH);
     }

--- a/src/test/java/io/quarkus/gizmo2/TryTest.java
+++ b/src/test/java/io/quarkus/gizmo2/TryTest.java
@@ -357,6 +357,111 @@ public final class TryTest {
         assertTrue(tcm.staticMethod(tests, "test1", BooleanSupplier.class).getAsBoolean());
     }
 
+    @Test
+    public void testEmptyTryOnlyCatch() {
+        TestClassMaker tcm = TestClassMaker.create();
+        Gizmo g = tcm.gizmo();
+        ClassDesc catchTests = g.class_("io.quarkus.gizmo2.EmptyTryOnlyCatch", cc -> {
+            StaticFieldVar caught = cc.staticField("caught", Const.of(false));
+
+            cc.staticMethod("test", mc -> {
+                mc.body(b0 -> {
+                    b0.try_(try0 -> {
+                        try0.body(b1 -> {
+                        });
+                        try0.catch_(Exception.class, "e", (b1, e) -> {
+                            b1.set(caught, Const.of(true));
+                        });
+                    });
+                    b0.return_();
+                });
+            });
+
+            cc.staticMethod("caught", mc -> {
+                mc.returning(boolean.class);
+                mc.body(bc -> {
+                    bc.return_(caught);
+                });
+            });
+        });
+        assertDoesNotThrow(() -> tcm.staticMethod(catchTests, "test", Runnable.class).run());
+        assertFalse(tcm.staticMethod(catchTests, "caught", BooleanSupplier.class).getAsBoolean());
+    }
+
+    @Test
+    public void testEmptyTryOnlyFinally() {
+        TestClassMaker tcm = TestClassMaker.create();
+        Gizmo g = tcm.gizmo();
+        ClassDesc catchTests = g.class_("io.quarkus.gizmo2.EmptyTryOnlyFinally", cc -> {
+            StaticFieldVar always = cc.staticField("always", Const.of(false));
+
+            cc.staticMethod("test", mc -> {
+                mc.body(b0 -> {
+                    b0.try_(try0 -> {
+                        try0.body(b1 -> {
+                        });
+                        try0.finally_(b1 -> {
+                            b1.set(always, Const.of(true));
+                        });
+                    });
+                    b0.return_();
+                });
+            });
+
+            cc.staticMethod("always", mc -> {
+                mc.returning(boolean.class);
+                mc.body(bc -> {
+                    bc.return_(always);
+                });
+            });
+        });
+        assertDoesNotThrow(() -> tcm.staticMethod(catchTests, "test", Runnable.class).run());
+        assertTrue(tcm.staticMethod(catchTests, "always", BooleanSupplier.class).getAsBoolean());
+    }
+
+    @Test
+    public void testEmptyTryCatchAndFinally() {
+        TestClassMaker tcm = TestClassMaker.create();
+        Gizmo g = tcm.gizmo();
+        ClassDesc catchTests = g.class_("io.quarkus.gizmo2.EmptyTryCatchAndFinally", cc -> {
+            StaticFieldVar caught = cc.staticField("caught", Const.of(false));
+            StaticFieldVar always = cc.staticField("always", Const.of(false));
+
+            cc.staticMethod("test", mc -> {
+                mc.body(b0 -> {
+                    b0.try_(try0 -> {
+                        try0.body(b1 -> {
+                        });
+                        try0.catch_(Exception.class, "e", (b1, e) -> {
+                            b1.set(caught, Const.of(true));
+                        });
+                        try0.finally_(b1 -> {
+                            b1.set(always, Const.of(true));
+                        });
+                    });
+                    b0.return_();
+                });
+            });
+
+            cc.staticMethod("caught", mc -> {
+                mc.returning(boolean.class);
+                mc.body(bc -> {
+                    bc.return_(caught);
+                });
+            });
+
+            cc.staticMethod("always", mc -> {
+                mc.returning(boolean.class);
+                mc.body(bc -> {
+                    bc.return_(always);
+                });
+            });
+        });
+        assertDoesNotThrow(() -> tcm.staticMethod(catchTests, "test", Runnable.class).run());
+        assertFalse(tcm.staticMethod(catchTests, "caught", BooleanSupplier.class).getAsBoolean());
+        assertTrue(tcm.staticMethod(catchTests, "always", BooleanSupplier.class).getAsBoolean());
+    }
+
     @FunctionalInterface
     public interface CrashIt {
         String crashIt(String foo, String bar);


### PR DESCRIPTION
An exception handler must guard at least one instruction, so if the generated `try` block is empty, we generate a single `nop` instruction into it. The rest is unaffected.

This commit also fixes generation of constant values for `static` fields. Not all primitive types result in a valid constant value; only `int`, `long`, `float` and `double` do (and `String`, but that's not a primitive type). An initial value of the other primitive types is now generated as an assignment in a static initializer block, like initial values of other types.