### PR TITLE
Provide a way to set the version at the Gizmo level

### DIFF
--- a/src/main/java/io/quarkus/gizmo2/Gizmo.java
+++ b/src/main/java/io/quarkus/gizmo2/Gizmo.java
@@ -92,6 +92,18 @@ public sealed interface Gizmo permits GizmoImpl {
     Gizmo withDefaultModifiers(Consumer<ModifierConfigurator> builder);
 
     /**
+     * {@return a Gizmo instance which generates classes with the given class file version}
+     * When set, all classes and interfaces created by the returned instance will
+     * use the specified version by default, unless overridden per-class via
+     * {@link io.quarkus.gizmo2.creator.TypeCreator#setVersion(ClassVersion)}.
+     * <p>
+     * If not called, generated classes default to Java 17.
+     *
+     * @param version the class file version (must not be {@code null})
+     */
+    Gizmo withVersion(ClassVersion version);
+
+    /**
      * Add a new class.
      *
      * @param name the fully qualified (dot-separated) binary class name (must not be {@code null})

--- a/src/main/java/io/quarkus/gizmo2/creator/TypeCreator.java
+++ b/src/main/java/io/quarkus/gizmo2/creator/TypeCreator.java
@@ -25,7 +25,8 @@ public sealed interface TypeCreator extends ModifiableCreator, GenericTyped
         permits ClassCreator, InterfaceCreator, TypeCreatorImpl {
     /**
      * Set the class file version to correspond with a run time version.
-     * If not called, the generated class has the version of Java 17.
+     * If not called, the generated class uses the version set on the {@link io.quarkus.gizmo2.Gizmo}
+     * instance via {@link io.quarkus.gizmo2.Gizmo#withVersion(ClassVersion)}, or Java 17 if none was set.
      *
      * @param version the run time version (must not be {@code null})
      */
@@ -33,7 +34,8 @@ public sealed interface TypeCreator extends ModifiableCreator, GenericTyped
 
     /**
      * Set the class file version.
-     * If not called, the generated class has the version of Java 17.
+     * If not called, the generated class uses the version set on the {@link io.quarkus.gizmo2.Gizmo}
+     * instance via {@link io.quarkus.gizmo2.Gizmo#withVersion(ClassVersion)}, or Java 17 if none was set.
      *
      * @param version the class file version (must not be {@code null})
      */

--- a/src/main/java/io/quarkus/gizmo2/impl/GizmoImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/GizmoImpl.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import java.util.function.Consumer;
 
 import io.quarkus.gizmo2.ClassOutput;
+import io.quarkus.gizmo2.ClassVersion;
 import io.quarkus.gizmo2.Gizmo;
 import io.quarkus.gizmo2.LambdaStrategy;
 import io.quarkus.gizmo2.ModifierConfigurator;
@@ -24,20 +25,22 @@ public final class GizmoImpl implements Gizmo {
     private final boolean debugInfo;
     private final boolean parameters;
     private final LambdaStrategy lambdaStrategy;
+    private final ClassVersion classVersion;
     private final ClassFile.Option[] options;
 
     public GizmoImpl(final ClassOutput outputHandler) {
-        this(outputHandler, DEFAULTS, true, true, LambdaStrategy.OPTIMIZED);
+        this(outputHandler, DEFAULTS, true, true, LambdaStrategy.OPTIMIZED, ClassVersion.V17);
     }
 
     private GizmoImpl(final ClassOutput outputHandler, final int[] modifiersByLocation,
             final boolean debugInfo, final boolean parameters,
-            final LambdaStrategy lambdaStrategy) {
+            final LambdaStrategy lambdaStrategy, final ClassVersion classVersion) {
         this.outputHandler = outputHandler;
         this.modifiersByLocation = modifiersByLocation;
         this.debugInfo = debugInfo;
         this.parameters = parameters;
         this.lambdaStrategy = lambdaStrategy;
+        this.classVersion = classVersion;
         ArrayList<ClassFile.Option> options = new ArrayList<>();
         options.add(ClassFile.StackMapsOption.DROP_STACK_MAPS);
         if (!debugInfo) {
@@ -92,7 +95,7 @@ public final class GizmoImpl implements Gizmo {
         };
         builder.accept(configurator);
         return new GizmoImpl(outputHandler, flags.clone(), debugInfo, parameters,
-                lambdaStrategy);
+                lambdaStrategy, classVersion);
     }
 
     boolean parameters() {
@@ -103,28 +106,38 @@ public final class GizmoImpl implements Gizmo {
         return lambdaStrategy;
     }
 
+    ClassVersion classVersion() {
+        return classVersion;
+    }
+
     @Override
     public Gizmo withOutput(final ClassOutput outputHandler) {
         return new GizmoImpl(outputHandler, modifiersByLocation, debugInfo, parameters,
-                lambdaStrategy);
+                lambdaStrategy, classVersion);
     }
 
     @Override
     public Gizmo withDebugInfo(final boolean debugInfo) {
         return new GizmoImpl(outputHandler, modifiersByLocation, debugInfo, parameters,
-                lambdaStrategy);
+                lambdaStrategy, classVersion);
     }
 
     @Override
     public Gizmo withParameters(final boolean parameters) {
         return new GizmoImpl(outputHandler, modifiersByLocation, debugInfo, parameters,
-                lambdaStrategy);
+                lambdaStrategy, classVersion);
     }
 
     @Override
     public Gizmo withLambdaStrategy(final LambdaStrategy lambdaStrategy) {
         return new GizmoImpl(outputHandler, modifiersByLocation, debugInfo, parameters,
-                lambdaStrategy);
+                lambdaStrategy, classVersion);
+    }
+
+    @Override
+    public Gizmo withVersion(final ClassVersion classVersion) {
+        return new GizmoImpl(outputHandler, modifiersByLocation, debugInfo, parameters,
+                lambdaStrategy, classVersion);
     }
 
     public ClassDesc class_(final ClassDesc desc, final Consumer<ClassCreator> builder) {

--- a/src/main/java/io/quarkus/gizmo2/impl/TypeCreatorImpl.java
+++ b/src/main/java/io/quarkus/gizmo2/impl/TypeCreatorImpl.java
@@ -75,7 +75,7 @@ public abstract sealed class TypeCreatorImpl extends ModifiableCreatorImpl imple
             "invoke", ConstantDescs.CD_Object);
 
     final GizmoImpl gizmo;
-    private ClassFileFormatVersion version = ClassFileFormatVersion.RELEASE_17;
+    private ClassFileFormatVersion version;
     private final ClassDesc type;
     private GenericType.OfClass genericType;
     private final ClassOutput output;
@@ -119,6 +119,7 @@ public abstract sealed class TypeCreatorImpl extends ModifiableCreatorImpl imple
         this.output = output;
         this.zb = zb;
         this.enclosingType = enclosingType;
+        setVersion(gizmo.classVersion());
     }
 
     public ClassOutput output() {
@@ -402,10 +403,10 @@ public abstract sealed class TypeCreatorImpl extends ModifiableCreatorImpl imple
     }
 
     void preAccept() {
-        zb.withVersion(version.major(), 0);
     }
 
     void postAccept() {
+        zb.withVersion(version.major(), 0);
         zb.withSuperclass(superSig.desc());
         zb.withInterfaces(interfaceSigs.stream().map(d -> zb.constantPool().classEntry(d.desc())).toList());
         zb.withFlags(modifiers & ~ACC_STATIC);

--- a/src/test/java/io/quarkus/gizmo2/ClassVersionTest.java
+++ b/src/test/java/io/quarkus/gizmo2/ClassVersionTest.java
@@ -1,0 +1,70 @@
+package io.quarkus.gizmo2;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.lang.constant.ClassDesc;
+import java.nio.ByteBuffer;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.gizmo2.testing.TestClassMaker;
+
+public final class ClassVersionTest {
+
+    private static final int JAVA_17_MAJOR = 61;
+    private static final int JAVA_21_MAJOR = 65;
+
+    @Test
+    public void defaultVersionIsJava17() {
+        TestClassMaker tcm = TestClassMaker.create();
+        Gizmo g = tcm.gizmo();
+        ClassDesc desc = ClassDesc.of("io.quarkus.gizmo2.TestDefaultVersion");
+        g.class_(desc, cc -> {
+        });
+        int major = readMajorVersion(tcm, desc);
+        assertEquals(JAVA_17_MAJOR, major);
+    }
+
+    @Test
+    public void withVersionSetsGlobalDefault() {
+        TestClassMaker tcm = TestClassMaker.create(Gizmo.create().withVersion(ClassVersion.V21));
+        Gizmo g = tcm.gizmo();
+        ClassDesc desc = ClassDesc.of("io.quarkus.gizmo2.TestGlobalV21");
+        g.class_(desc, cc -> {
+        });
+        int major = readMajorVersion(tcm, desc);
+        assertEquals(JAVA_21_MAJOR, major);
+    }
+
+    @Test
+    public void perClassSetVersionOverridesGlobal() {
+        TestClassMaker tcm = TestClassMaker.create(Gizmo.create().withVersion(ClassVersion.V21));
+        Gizmo g = tcm.gizmo();
+        ClassDesc desc = ClassDesc.of("io.quarkus.gizmo2.TestPerClassOverride");
+        g.class_(desc, cc -> {
+            cc.setVersion(ClassVersion.V17);
+        });
+        int major = readMajorVersion(tcm, desc);
+        assertEquals(JAVA_17_MAJOR, major);
+    }
+
+    @Test
+    public void interfaceVersionFromGizmo() {
+        TestClassMaker tcm = TestClassMaker.create(Gizmo.create().withVersion(ClassVersion.V21));
+        Gizmo g = tcm.gizmo();
+        ClassDesc desc = ClassDesc.of("io.quarkus.gizmo2.TestInterfaceV21");
+        g.interface_(desc, ic -> {
+        });
+        int major = readMajorVersion(tcm, desc);
+        assertEquals(JAVA_21_MAJOR, major);
+    }
+
+    private static int readMajorVersion(TestClassMaker tcm, ClassDesc desc) {
+        return tcm.readClass(desc, bytes -> {
+            ByteBuffer buf = ByteBuffer.wrap(bytes);
+            buf.getInt(); // magic
+            buf.getShort(); // minor
+            return buf.getShort() & 0xFFFF; // major
+        });
+    }
+}


### PR DESCRIPTION
We plan to set the minimum for Quarkus to Java 21, but I think it makes sense to keep the default for Gizmo to Java 17 for now - except if at some point we have a strong reason to move to 21.

This PR introduces a more practical way to set the bytecode version right at the Gizmo instance level.